### PR TITLE
Improve Notes Block Editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # testing
 /coverage
+.playwright-mcp
 
 # next.js
 /.next/

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -1,4 +1,3 @@
-import { PageHeader } from "@/components/ui/page-header";
 import { requireServerSession } from "@/lib/auth-session";
 import { listUserClassEvents } from "@/lib/classes/queries";
 import { CalendarClient, type CalendarEvent } from "./calendar-client";
@@ -13,14 +12,10 @@ export default async function CalendarPage() {
   }));
 
   return (
-    <div className="space-y-6">
-      <PageHeader
-        eyebrow="Calendar"
-        title="Calendar"
-        description="A month view for parsed syllabus dates, selected-day focus, and upcoming class work."
-      />
-
-      <CalendarClient events={calendarEvents} initialDate={initialDate} />
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <CalendarClient events={calendarEvents} initialDate={initialDate} />
+      </div>
     </div>
   );
 }

--- a/app/(app)/classes/[runId]/page.tsx
+++ b/app/(app)/classes/[runId]/page.tsx
@@ -5,7 +5,6 @@ import { Badge } from "@/components/ui/badge";
 import { getButtonClassName } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
-import { PageHeader } from "@/components/ui/page-header";
 import { requireServerSession } from "@/lib/auth-session";
 import { db } from "@/lib/db";
 import { note } from "@/lib/db/schema";
@@ -113,22 +112,19 @@ export default async function ClassDetailPage(props: {
       : "bg-surface-muted text-muted-foreground hover:text-foreground";
 
   return (
-    <div className="space-y-6">
-      <PageHeader
-        eyebrow="Class detail"
-        title={preview.course.title}
-        description={preview.course.studentSummary}
-        actions={
-          <>
-            <Link href={`/notes?classId=${preview.course.id}&new=1`} className={getButtonClassName("primary")}>
-              New note in this class
-            </Link>
-            <Link href={`/notes?classId=${preview.course.id}`} className={getButtonClassName("outline")}>
-              Manage notes
-            </Link>
-          </>
-        }
-      />
+    <div className="flex h-full flex-col gap-4">
+      <div className="shrink-0 space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{preview.course.title}</h1>
+        <div className="flex flex-wrap gap-2">
+          <Link href={`/notes?classId=${preview.course.id}&new=1`} className={getButtonClassName("primary")}>
+            New note in this class
+          </Link>
+          <Link href={`/notes?classId=${preview.course.id}`} className={getButtonClassName("outline")}>
+            Manage notes
+          </Link>
+        </div>
+      </div>
 
       <div className="flex flex-wrap gap-2">
         {preview.course.courseCode ? <Badge variant="accent">{preview.course.courseCode}</Badge> : null}
@@ -149,7 +145,9 @@ export default async function ClassDetailPage(props: {
           </Link>
         ))}
       </div>
+      </div>
 
+      <div className="min-h-0 flex-1 overflow-y-auto">
       {currentTab === "overview" ? (
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_360px]">
           <Card>
@@ -390,6 +388,7 @@ export default async function ClassDetailPage(props: {
           />
         )
       ) : null}
+      </div>
     </div>
   );
 }

--- a/app/(app)/classes/page.tsx
+++ b/app/(app)/classes/page.tsx
@@ -3,7 +3,6 @@ import { getButtonClassName } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
-import { PageHeader } from "@/components/ui/page-header";
 import { requireServerSession } from "@/lib/auth-session";
 import { listUserClasses } from "@/lib/classes/queries";
 
@@ -19,61 +18,59 @@ export default async function ClassesPage() {
   const classes = await listUserClasses(session.user.id);
 
   return (
-    <div className="space-y-6">
-      <PageHeader
-        eyebrow="Classes"
-        title="Your parsed classes"
-        description="Every syllabus upload becomes a real class page that can hold notes, contacts, grading, and schedule context."
-        actions={
-          <Link href="/parse-test" className={getButtonClassName("primary")}>
-            Upload syllabus
-          </Link>
-        }
-      />
+    <div className="flex h-full flex-col gap-4">
+      <div className="shrink-0 flex items-center justify-between">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">Classes</h1>
+        <Link href="/parse-test" className={getButtonClassName("primary")}>
+          Upload syllabus
+        </Link>
+      </div>
 
-      {classes.length === 0 ? (
-        <EmptyState
-          eyebrow="No classes yet"
-          title="Upload your first syllabus"
-          description="Once a syllabus is parsed, it will show up here as a real class card and immediately become available inside the notes workspace."
-          action={
-            <Link href="/parse-test" className={getButtonClassName("primary")}>
-              Open syllabus upload
-            </Link>
-          }
-        />
-      ) : (
-        <div className="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
-          {classes.map((item) => (
-            <Link key={item.courseId} href={`/classes/${item.runId}`}>
-              <Card className="h-full transition hover:border-border-strong hover:bg-surface-muted">
-                <CardHeader>
-                  <div className="flex flex-wrap items-center gap-2">
-                    {item.courseCode ? <Badge variant="accent">{item.courseCode}</Badge> : null}
-                    {item.courseSection ? <Badge variant="outline">Section {item.courseSection}</Badge> : null}
-                    <Badge variant="outline">{item.noteCount} note{item.noteCount === 1 ? "" : "s"}</Badge>
-                  </div>
-                  <CardTitle>{item.title}</CardTitle>
-                  <CardDescription>
-                    {item.instructorName ? `${item.instructorName} · ` : ""}
-                    {item.meetingDays || item.meetingTime
-                      ? `${item.meetingDays ?? "Schedule TBD"} ${item.meetingTime ?? ""}`.trim()
-                      : "Schedule pending from syllabus"}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <div className="text-sm text-muted-foreground">
-                    {item.meetingLocation ?? "Location not extracted yet"}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    Updated {formatTimestamp(item.updatedAt)}
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
-        </div>
-      )}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {classes.length === 0 ? (
+          <EmptyState
+            eyebrow="No classes yet"
+            title="Upload your first syllabus"
+            description="Once a syllabus is parsed, it will show up here as a real class card and immediately become available inside the notes workspace."
+            action={
+              <Link href="/parse-test" className={getButtonClassName("primary")}>
+                Open syllabus upload
+              </Link>
+            }
+          />
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
+            {classes.map((item) => (
+              <Link key={item.courseId} href={`/classes/${item.runId}`}>
+                <Card className="h-full transition hover:border-border-strong hover:bg-surface-muted">
+                  <CardHeader>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {item.courseCode ? <Badge variant="accent">{item.courseCode}</Badge> : null}
+                      {item.courseSection ? <Badge variant="outline">Section {item.courseSection}</Badge> : null}
+                      <Badge variant="outline">{item.noteCount} note{item.noteCount === 1 ? "" : "s"}</Badge>
+                    </div>
+                    <CardTitle>{item.title}</CardTitle>
+                    <CardDescription>
+                      {item.instructorName ? `${item.instructorName} · ` : ""}
+                      {item.meetingDays || item.meetingTime
+                        ? `${item.meetingDays ?? "Schedule TBD"} ${item.meetingTime ?? ""}`.trim()
+                        : "Schedule pending from syllabus"}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <div className="text-sm text-muted-foreground">
+                      {item.meetingLocation ?? "Location not extracted yet"}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Updated {formatTimestamp(item.updatedAt)}
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/(app)/notes/page.tsx
+++ b/app/(app)/notes/page.tsx
@@ -22,6 +22,7 @@ export default async function NotesPage(props: { searchParams?: SearchParams }) 
       title: note.title,
       classId: note.classId,
       content: note.content,
+      markdown: note.markdown,
       sourceType: note.sourceType,
       fileName: note.fileName,
       mimeType: note.mimeType,

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,141 +1,384 @@
+import type { ReactNode } from "react";
 import Link from "next/link";
-import { desc, eq } from "drizzle-orm";
-import { Badge } from "@/components/ui/badge";
+import { and, asc, desc, eq, gte, lt } from "drizzle-orm";
 import { getButtonClassName } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { EmptyState } from "@/components/ui/empty-state";
-import { PageHeader } from "@/components/ui/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { requireServerSession } from "@/lib/auth-session";
 import { listUserClasses } from "@/lib/classes/queries";
 import { db } from "@/lib/db";
-import { note } from "@/lib/db/schema";
+import { note, parseTestCourse, parseTestEvent, parseTestRun } from "@/lib/db/schema";
+import { LiveClock } from "@/components/dashboard/live-clock";
+import { TodayEventsList, type DashboardEvent } from "@/components/dashboard/event-countdown";
+import { cx } from "@/lib/utils";
 
-function formatTimestamp(value: Date) {
-  return new Intl.DateTimeFormat("en-US", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(value);
+function relativeTime(date: Date): string {
+  const diff = Date.now() - date.getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "Just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  if (hours < 48) return "Yesterday";
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function CourseIcon({ courseCode }: { courseCode: string | null }) {
+  const code = (courseCode ?? "").toUpperCase();
+  let icon: ReactNode;
+
+  if (/^(CS|CE|CSCE|CSCI|ECE|EE)/.test(code)) {
+    icon = (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    );
+  } else if (/^(MATH|STAT|CALC)/.test(code)) {
+    icon = (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+        <line x1="18" y1="20" x2="18" y2="10" />
+        <line x1="12" y1="20" x2="12" y2="4" />
+        <line x1="6" y1="20" x2="6" y2="14" />
+      </svg>
+    );
+  } else if (/^(PHYS|CHEM|BIO|SCI)/.test(code)) {
+    icon = (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+        <path d="M9 3h6M9 3v7l-4 9h14L15 10V3" />
+      </svg>
+    );
+  } else {
+    icon = (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+      </svg>
+    );
+  }
+
+  return (
+    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-surface-elevated text-muted-foreground">
+      {icon}
+    </span>
+  );
+}
+
+function NoteIcon() {
+  return (
+    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-surface-elevated text-muted-foreground">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5" aria-hidden>
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <path d="M14 2v6h6M16 13H8M16 17H8" />
+      </svg>
+    </span>
+  );
+}
+
+function ChevronRight() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5 shrink-0" aria-hidden>
+      <path d="M9 6l6 6-6 6" />
+    </svg>
+  );
+}
+
+function SectionHeader({ icon, title, action }: { icon: ReactNode; title: string; action?: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <span className="text-muted-foreground">{icon}</span>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </div>
+      {action}
+    </div>
+  );
 }
 
 export default async function DashboardPage() {
   const session = await requireServerSession("/");
-  const classes = await listUserClasses(session.user.id);
-  const recentNotes = await db
+  const userId = session.user.id;
+
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const todayEnd = new Date();
+  todayEnd.setHours(23, 59, 59, 999);
+
+  const [classes, recentNotes, todayEventRows] = await Promise.all([
+    listUserClasses(userId),
+    db
+      .select({ id: note.id, title: note.title, classId: note.classId, updatedAt: note.updatedAt })
+      .from(note)
+      .where(eq(note.userId, userId))
+      .orderBy(desc(note.updatedAt))
+      .limit(10),
+    db
+      .select({
+        id: parseTestEvent.id,
+        title: parseTestEvent.title,
+        category: parseTestEvent.category,
+        courseTitle: parseTestCourse.title,
+        courseCode: parseTestCourse.courseCode,
+        dueAt: parseTestEvent.dueAt,
+        timeText: parseTestEvent.timeText,
+        courseId: parseTestEvent.courseId,
+      })
+      .from(parseTestEvent)
+      .innerJoin(parseTestCourse, eq(parseTestCourse.id, parseTestEvent.courseId))
+      .innerJoin(parseTestRun, eq(parseTestRun.id, parseTestCourse.runId))
+      .where(
+        and(
+          eq(parseTestRun.userId, userId),
+          gte(parseTestEvent.dueAt, todayStart),
+          lt(parseTestEvent.dueAt, todayEnd),
+        ),
+      )
+      .orderBy(asc(parseTestEvent.dueAt))
+      .limit(20),
+  ]);
+
+  const upcomingEventRows = await db
     .select({
-      id: note.id,
-      title: note.title,
-      classId: note.classId,
-      updatedAt: note.updatedAt,
+      id: parseTestEvent.id,
+      title: parseTestEvent.title,
+      category: parseTestEvent.category,
+      dueAt: parseTestEvent.dueAt,
+      courseId: parseTestEvent.courseId,
     })
-    .from(note)
-    .where(eq(note.userId, session.user.id))
-    .orderBy(desc(note.updatedAt))
-    .limit(3);
-  const classNameById = new Map(
-    classes.map((item) => [item.courseId, item.title]),
-  );
+    .from(parseTestEvent)
+    .innerJoin(parseTestCourse, eq(parseTestCourse.id, parseTestEvent.courseId))
+    .innerJoin(parseTestRun, eq(parseTestRun.id, parseTestCourse.runId))
+    .where(and(eq(parseTestRun.userId, userId), gte(parseTestEvent.dueAt, new Date())))
+    .orderBy(asc(parseTestEvent.dueAt));
+
+  const nextEventByCourse = new Map<string, { title: string; category: string; dueAt: Date }>();
+  for (const ev of upcomingEventRows) {
+    if (!nextEventByCourse.has(ev.courseId) && ev.dueAt) {
+      nextEventByCourse.set(ev.courseId, { title: ev.title, category: ev.category, dueAt: ev.dueAt });
+    }
+  }
+
+  const classNameById = new Map(classes.map((c) => [c.courseId, c.title]));
+
+  const todayEvents: DashboardEvent[] = todayEventRows.map((ev) => ({
+    id: ev.id,
+    title: ev.title,
+    category: ev.category,
+    courseTitle: ev.courseTitle,
+    courseCode: ev.courseCode,
+    dueAt: ev.dueAt?.toISOString() ?? null,
+    timeText: ev.timeText,
+  }));
+
   const firstName = (session.user.name ?? "").trim().split(" ")[0] ?? "";
-  const greeting = firstName ? `Welcome back, ${firstName}` : "Welcome back";
-  const noteCount = recentNotes.length;
+  const greeting = firstName ? `Welcome back, ${firstName} 👋` : "Welcome back 👋";
+
+  function formatNextEventDate(dueAt: Date): string {
+    const now = new Date();
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (dueAt.toDateString() === now.toDateString()) return "Today";
+    if (dueAt.toDateString() === tomorrow.toDateString()) return "Tomorrow";
+    return dueAt.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+  }
+
+  const linkClass = "text-xs font-medium text-accent transition hover:text-accent/80";
+  const iconSm = "h-3.5 w-3.5";
 
   return (
-    <div className="space-y-6">
-      <PageHeader
-        eyebrow="Dashboard"
-        title={greeting}
-        description={
-          classes.length === 0 && noteCount === 0
-            ? "Upload a syllabus to create your first class, then start taking notes against it."
-            : "Jump back into your classes and recent notes, or kick off something new."
-        }
-        actions={
-          <>
-            <Link href="/notes?new=1" className={getButtonClassName("primary")}>
-              New note
-            </Link>
-            <Link href="/parse-test" className={getButtonClassName("outline")}>
-              Upload syllabus
-            </Link>
-          </>
-        }
-      />
+    <div className="flex h-full flex-col gap-5">
+      {/* Header — fixed height */}
+      <div className="flex shrink-0 flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Dashboard</p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">{greeting}</h1>
+          <p className="mt-1 text-sm leading-7 text-muted-foreground">
+            Here's what's happening with your classes and notes.
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-3">
+          <Link href="/notes?new=1" className={getButtonClassName("primary")}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconSm} aria-hidden>
+              <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            New note
+          </Link>
+          <Link href="/parse-test" className={getButtonClassName("outline")}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconSm} aria-hidden>
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="17 8 12 3 7 8" /><line x1="12" y1="3" x2="12" y2="15" />
+            </svg>
+            Upload syllabus
+          </Link>
+        </div>
+      </div>
 
-      <div className="grid gap-4 xl:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardTitle>Your notes</CardTitle>
-            <CardDescription>{recentNotes.length} recent note{recentNotes.length === 1 ? "" : "s"}</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {recentNotes.length > 0 ? (
-              recentNotes.map((item) => (
-                <Link key={item.id} href="/notes" className="block rounded-[var(--radius-lg)] border border-border bg-surface-muted px-4 py-3 transition hover:border-border-strong hover:bg-surface">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-sm font-medium text-foreground">{item.title}</p>
-                    {item.classId ? <Badge variant="accent">{classNameById.get(item.classId) ?? "Linked class"}</Badge> : null}
+      {/* Main grid — fills remaining height */}
+      <div className="grid min-h-0 flex-1 gap-5 xl:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+
+        {/* Left column */}
+        <div className="flex min-h-0 flex-col gap-5">
+
+          {/* Clock — fixed height */}
+          <Card className="shrink-0">
+            <CardHeader className="pb-3">
+              <SectionHeader
+                title="Current time"
+                icon={
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconSm} aria-hidden>
+                    <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+                  </svg>
+                }
+              />
+            </CardHeader>
+            <CardContent className="pt-0">
+              <LiveClock />
+            </CardContent>
+          </Card>
+
+          {/* Today's events — flex-1 with internal scroll */}
+          <Card className="flex min-h-0 flex-1 flex-col">
+            <CardHeader className="shrink-0 pb-2">
+              <SectionHeader
+                title="Today's class events"
+                icon={
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconSm} aria-hidden>
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+                  </svg>
+                }
+                action={
+                  <Link href="/calendar" className={linkClass}>View calendar</Link>
+                }
+              />
+            </CardHeader>
+            <CardContent className="min-h-0 flex-1 overflow-y-auto pt-1">
+              <TodayEventsList events={todayEvents} />
+            </CardContent>
+          </Card>
+
+          {/* Recent notes — flex-1 with internal scroll */}
+          <Card className="flex min-h-0 flex-1 flex-col">
+            <CardHeader className="shrink-0 pb-2">
+              <SectionHeader
+                title="Recently viewed notes"
+                icon={
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconSm} aria-hidden>
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" />
+                  </svg>
+                }
+                action={
+                  <Link href="/notes" className={linkClass}>View all notes</Link>
+                }
+              />
+            </CardHeader>
+            <CardContent className="min-h-0 flex-1 overflow-y-auto pt-1">
+              {recentNotes.length === 0 ? (
+                <div className="flex h-full items-center justify-center">
+                  <div className="text-center">
+                    <p className="text-sm font-medium text-muted-foreground">No notes yet</p>
+                    <p className="mt-1 text-xs text-muted-foreground">Notes you create will appear here.</p>
+                    <Link href="/notes?new=1" className={cx(getButtonClassName("primary", "sm"), "mt-4 inline-flex")}>
+                      Create a note
+                    </Link>
                   </div>
-                  <p className="mt-1 text-xs text-muted-foreground">Updated {formatTimestamp(item.updatedAt)}</p>
-                </Link>
-              ))
-            ) : (
-              <p className="text-sm text-muted-foreground">No notes yet.</p>
-            )}
-          </CardContent>
-        </Card>
+                </div>
+              ) : (
+                <div className="-mx-1 space-y-0.5">
+                  {recentNotes.map((item) => (
+                    <Link
+                      key={item.id}
+                      href="/notes"
+                      className="flex items-center gap-3 rounded-lg px-3 py-2.5 transition hover:bg-surface-muted"
+                    >
+                      <NoteIcon />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {item.classId ? (classNameById.get(item.classId) ?? "Linked class") : "Unfiled"}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2 text-muted-foreground">
+                        <span className="text-xs">{relativeTime(item.updatedAt)}</span>
+                        <ChevronRight />
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Your classes</CardTitle>
-            <CardDescription>{classes.length} parsed class{classes.length === 1 ? "" : "es"}</CardDescription>
+        {/* Right column — courses fills full height with internal scroll */}
+        <Card className="flex min-h-0 flex-col">
+          <CardHeader className="shrink-0 pb-2">
+            <SectionHeader
+              title="Your courses"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconSm} aria-hidden>
+                  <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" /><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+                </svg>
+              }
+              action={
+                <Link href="/classes" className={linkClass}>All courses</Link>
+              }
+            />
           </CardHeader>
-          <CardContent className="space-y-3">
-            {classes.length > 0 ? (
-              classes.slice(0, 3).map((item) => (
-                <Link key={item.courseId} href={`/classes/${item.runId}`} className="block rounded-[var(--radius-lg)] border border-border bg-surface-muted px-4 py-3 transition hover:border-border-strong hover:bg-surface">
-                  <div className="flex flex-wrap items-center gap-2">
-                    {item.courseCode ? <Badge variant="accent">{item.courseCode}</Badge> : null}
-                    <p className="text-sm font-medium text-foreground">{item.title}</p>
-                  </div>
-                  <p className="mt-1 text-xs text-muted-foreground">{item.noteCount} linked note{item.noteCount === 1 ? "" : "s"}</p>
-                </Link>
-              ))
+          <CardContent className="min-h-0 flex-1 overflow-y-auto pt-1">
+            {classes.length === 0 ? (
+              <div className="flex h-full items-center justify-center">
+                <div className="text-center">
+                  <p className="text-sm font-medium text-muted-foreground">No courses yet</p>
+                  <p className="mt-1 text-xs text-muted-foreground">Upload a syllabus to create your first course.</p>
+                  <Link href="/parse-test" className={cx(getButtonClassName("primary", "sm"), "mt-4 inline-flex")}>
+                    Upload syllabus
+                  </Link>
+                </div>
+              </div>
             ) : (
-              <p className="text-sm text-muted-foreground">No classes yet.</p>
+              <div className="-mx-1 divide-y divide-border">
+                {classes.map((item) => {
+                  const next = nextEventByCourse.get(item.courseId);
+                  return (
+                    <Link
+                      key={item.courseId}
+                      href={`/classes/${item.runId}`}
+                      className="flex items-center gap-3 px-3 py-3 transition hover:bg-surface-muted first:rounded-t-lg last:rounded-b-lg"
+                    >
+                      <CourseIcon courseCode={item.courseCode} />
+                      <div className="min-w-0 flex-1">
+                        {item.courseCode ? (
+                          <p className="text-[0.7rem] font-medium uppercase tracking-wide text-muted-foreground">
+                            {item.courseCode}
+                          </p>
+                        ) : null}
+                        <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {item.noteCount} linked note{item.noteCount === 1 ? "" : "s"}
+                          {item.instructorName ? ` · ${item.instructorName}` : ""}
+                        </p>
+                      </div>
+                      {next ? (
+                        <div className="shrink-0 text-right">
+                          <p className="text-[0.7rem] font-medium text-muted-foreground">Next: {next.category}</p>
+                          <p className="text-xs font-semibold text-foreground">
+                            {formatNextEventDate(next.dueAt)},{" "}
+                            {next.dueAt.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })}
+                          </p>
+                        </div>
+                      ) : (
+                        <div className="shrink-0 text-right">
+                          <p className="text-xs text-muted-foreground">No upcoming</p>
+                          <p className="text-xs text-muted-foreground">events</p>
+                        </div>
+                      )}
+                      <ChevronRight />
+                    </Link>
+                  );
+                })}
+              </div>
             )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Jump back in</CardTitle>
-            <CardDescription>Fast links to the working parts of the product.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <Link href="/classes" className={getButtonClassName("outline", "md", "w-full justify-center")}>
-              Browse classes
-            </Link>
-            <Link href="/notes" className={getButtonClassName("outline", "md", "w-full justify-center")}>
-              Open notes workspace
-            </Link>
-            <Link href="/parse-test" className={getButtonClassName("outline", "md", "w-full justify-center")}>
-              Parse another syllabus
-            </Link>
           </CardContent>
         </Card>
       </div>
-
-      {classes.length === 0 && recentNotes.length === 0 ? (
-        <EmptyState
-          eyebrow="Start here"
-          title="Build your first class workspace"
-          description="Upload a syllabus first, then start taking notes inside the resulting class."
-          action={
-            <Link href="/parse-test" className={getButtonClassName("primary")}>
-              Upload syllabus
-            </Link>
-          }
-        />
-      ) : null}
     </div>
   );
 }

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -192,7 +192,7 @@ export default async function DashboardPage() {
           <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Dashboard</p>
           <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">{greeting}</h1>
           <p className="mt-1 text-sm leading-7 text-muted-foreground">
-            Here's what's happening with your classes and notes.
+            Here&apos;s what&apos;s happening with your classes and notes.
           </p>
         </div>
         <div className="flex shrink-0 flex-wrap items-center gap-3">

--- a/app/(app)/parse-test/page.tsx
+++ b/app/(app)/parse-test/page.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
 import { Button, getButtonClassName } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
 import { requireServerSession } from "@/lib/auth-session";
 import { isParseTestEnabled } from "@/lib/parse-test/feature";
 import { getParseTestRunSummaries, getParseTestViewModelForRun } from "@/lib/parse-test/service";
@@ -47,23 +46,16 @@ export default async function ParseTestPage(props: {
       : null;
 
   return (
-    <div className="space-y-6">
-      <PageHeader
-        eyebrow="Syllabus parsing"
-        title="Classes start here"
-        description="Upload a syllabus, let ParseTest structure it, and use the resulting class as the anchor for notes and future study tools."
-        actions={
-          <>
-            <Link href="/classes" className={getButtonClassName("outline")}>
-              View classes
-            </Link>
-            <Button type="button" disabled>
-              AI pipeline live
-            </Button>
-          </>
-        }
-      />
+    <div className="flex h-full flex-col gap-4">
+      <div className="shrink-0 flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">Upload syllabus</h1>
+        <div className="flex gap-2">
+          <Link href="/classes" className={getButtonClassName("outline")}>View classes</Link>
+          <Button type="button" disabled>AI pipeline live</Button>
+        </div>
+      </div>
 
+      <div className="min-h-0 flex-1 overflow-y-auto">
       <div className="grid items-start gap-6 xl:grid-cols-[360px_minmax(0,1fr)]">
         <ParseTestClient
           hasPreview={Boolean(preview)}
@@ -93,6 +85,7 @@ export default async function ParseTestPage(props: {
         uploadStatusParam={uploadStatusParam}
         displayName={session.user.name || session.user.email}
       />
+      </div>
     </div>
   );
 }

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,22 +1,17 @@
 import { ProfileSettingsForm } from "@/components/auth/profile-settings-form";
-import { PageHeader } from "@/components/ui/page-header";
 import { requireServerSession } from "@/lib/auth-session";
 
 export default async function SettingsPage() {
   const session = await requireServerSession("/settings");
 
   return (
-    <div className="space-y-6">
-      <PageHeader
-        eyebrow="Settings"
-        title="Account settings"
-        description="Manage your profile, workspace appearance, and active session."
-      />
-
-      <ProfileSettingsForm
-        name={session.user.name || ""}
-        email={session.user.email}
-      />
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <ProfileSettingsForm
+          name={session.user.name || ""}
+          email={session.user.email}
+        />
+      </div>
     </div>
   );
 }

--- a/app/(app)/study/page.tsx
+++ b/app/(app)/study/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { PageHeader } from "@/components/ui/page-header";
 
 const studyPages = [
   { href: "/study/pomodoro", title: "Pomodoro", description: "A real local timer you can use today.", live: true },
@@ -14,28 +13,24 @@ const studyPages = [
 
 export default function StudyPage() {
   return (
-    <div className="space-y-6">
-      <PageHeader
-        eyebrow="Study"
-        title="Study techniques"
-        description="This section scaffolds the study-method pages around one real Pomodoro timer and a set of polished informational pages."
-      />
-
-      <div className="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
-        {studyPages.map((item) => (
-          <Link key={item.href} href={item.href}>
-            <Card className="h-full transition hover:border-border-strong hover:bg-surface-muted">
-              <CardHeader>
-                <div className="flex items-center gap-2">
-                  <Badge variant={item.live ? "accent" : "outline"}>{item.live ? "Live" : "Scaffolded"}</Badge>
-                </div>
-                <CardTitle>{item.title}</CardTitle>
-                <CardDescription>{item.description}</CardDescription>
-              </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">Open page</CardContent>
-            </Card>
-          </Link>
-        ))}
+    <div className="flex h-full flex-col gap-4">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
+          {studyPages.map((item) => (
+            <Link key={item.href} href={item.href}>
+              <Card className="h-full transition hover:border-border-strong hover:bg-surface-muted">
+                <CardHeader>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={item.live ? "accent" : "outline"}>{item.live ? "Live" : "Scaffolded"}</Badge>
+                  </div>
+                  <CardTitle>{item.title}</CardTitle>
+                  <CardDescription>{item.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="text-sm text-muted-foreground">Open page</CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/app/api/notes/[id]/route.ts
+++ b/app/api/notes/[id]/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { note } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
 import { assertClassBelongsToUser } from "@/lib/classes/queries";
+import { normalizeNoteWriteContent } from "@/lib/notes/persistence";
 
 export const runtime = "nodejs";
 
@@ -61,7 +62,18 @@ export async function PATCH(req: Request, ctx: RouteContext) {
 
   const updates: Record<string, unknown> = {};
   if (typeof body.title === "string") updates.title = body.title.trim() || "Untitled";
-  if (body.content !== undefined) updates.content = body.content;
+  if (body.content !== undefined) {
+    try {
+      const content = normalizeNoteWriteContent(body.content);
+      updates.content = content.document;
+      updates.markdown = content.markdown;
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid note content" },
+        { status: 400 },
+      );
+    }
+  }
   if (body.classId !== undefined) {
     if (body.classId !== null && typeof body.classId !== "string") {
       return NextResponse.json({ error: "Invalid class selection" }, { status: 400 });

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { note } from "@/lib/db/schema";
 import { and, desc, eq } from "drizzle-orm";
 import { assertClassBelongsToUser } from "@/lib/classes/queries";
+import { normalizeNoteWriteContent } from "@/lib/notes/persistence";
 
 export const runtime = "nodejs";
 
@@ -30,6 +31,7 @@ export async function GET(req: Request) {
       title: note.title,
       classId: note.classId,
       content: note.content,
+      markdown: note.markdown,
       sourceType: note.sourceType,
       fileName: note.fileName,
       mimeType: note.mimeType,
@@ -80,8 +82,15 @@ export async function POST(req: Request) {
     }
   }
 
-  // content is the Editor.js output JSON; we store it as-is.
-  const content = body.content ?? null;
+  let content: ReturnType<typeof normalizeNoteWriteContent>;
+  try {
+    content = normalizeNoteWriteContent(body.content);
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid note content" },
+      { status: 400 },
+    );
+  }
 
   const [created] = await db
     .insert(note)
@@ -89,7 +98,8 @@ export async function POST(req: Request) {
       userId: session.user.id,
       title,
       classId,
-      content,
+      content: content.document,
+      markdown: content.markdown,
       sourceType: "manual",
     })
     .returning();

--- a/app/api/notes/upload/route.ts
+++ b/app/api/notes/upload/route.ts
@@ -121,6 +121,7 @@ export async function POST(req: Request) {
         mimeType: file.type,
         fileSize: file.size,
         embedding: topic.embedding,
+        markdown: topic.markdown,
         content: {
           ...markdownToNoteDocument(topic.markdown),
           noteGeneration: {

--- a/app/flashcards/flashcards-client.tsx
+++ b/app/flashcards/flashcards-client.tsx
@@ -1,16 +1,29 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Brain, ChevronLeft, ChevronRight, Layers3, Loader2, Play, RotateCcw } from "lucide-react";
+import {
+  Brain,
+  ChevronLeft,
+  ChevronRight,
+  Layers3,
+  Loader2,
+  Play,
+  RotateCcw,
+} from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { PageHeader } from "@/components/ui/page-header";
 import { cx } from "@/lib/utils";
 import type { FlashcardDeck } from "@/lib/flashcards/types";
 
@@ -26,7 +39,9 @@ type FlashcardsClientProps = {
 };
 
 async function readJsonResponse<T>(response: Response): Promise<T> {
-  const payload = (await response.json().catch(() => null)) as T & { error?: string };
+  const payload = (await response.json().catch(() => null)) as T & {
+    error?: string;
+  };
   if (!response.ok) {
     throw new Error(payload?.error || "Request failed");
   }
@@ -34,7 +49,13 @@ async function readJsonResponse<T>(response: Response): Promise<T> {
   return payload;
 }
 
-function MarkdownText({ markdown, className }: { markdown: string; className?: string }) {
+function MarkdownText({
+  markdown,
+  className,
+}: {
+  markdown: string;
+  className?: string;
+}) {
   return (
     <div className={cx("min-w-0 space-y-2 text-foreground", className)}>
       <ReactMarkdown
@@ -42,8 +63,12 @@ function MarkdownText({ markdown, className }: { markdown: string; className?: s
         remarkPlugins={[remarkGfm, remarkMath]}
         components={{
           p: ({ children }) => <p>{children}</p>,
-          ul: ({ children }) => <ul className="ml-5 list-disc space-y-1">{children}</ul>,
-          ol: ({ children }) => <ol className="ml-5 list-decimal space-y-1">{children}</ol>,
+          ul: ({ children }) => (
+            <ul className="ml-5 list-disc space-y-1">{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="ml-5 list-decimal space-y-1">{children}</ol>
+          ),
           code: ({ children }) => (
             <code className="rounded bg-surface-elevated px-1 py-0.5 font-mono text-[0.92em]">
               {children}
@@ -57,8 +82,14 @@ function MarkdownText({ markdown, className }: { markdown: string; className?: s
   );
 }
 
-export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps) {
-  const embeddedNotes = useMemo(() => notes.filter((note) => note.hasEmbedding), [notes]);
+export function FlashcardsClient({
+  notes,
+  initialDecks,
+}: FlashcardsClientProps) {
+  const embeddedNotes = useMemo(
+    () => notes.filter((note) => note.hasEmbedding),
+    [notes],
+  );
   const [selectedNoteIds, setSelectedNoteIds] = useState<string[]>([]);
   const [cardCount, setCardCount] = useState(16);
   const [decks, setDecks] = useState<FlashcardDeck[]>(initialDecks);
@@ -70,7 +101,8 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
 
   const activeDeck = decks.find((deck) => deck.id === activeDeckId) ?? decks[0];
   const activeCard = activeDeck?.cards[activeCardIndex];
-  const canGenerate = selectedNoteIds.length > 0 && embeddedNotes.length > 0 && !isGenerating;
+  const canGenerate =
+    selectedNoteIds.length > 0 && embeddedNotes.length > 0 && !isGenerating;
 
   function toggleNote(noteId: string) {
     setSelectedNoteIds((current) =>
@@ -91,7 +123,9 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
       return;
     }
 
-    setActiveCardIndex(Math.min(Math.max(index, 0), activeDeck.cards.length - 1));
+    setActiveCardIndex(
+      Math.min(Math.max(index, 0), activeDeck.cards.length - 1),
+    );
     setShowBack(false);
   }
 
@@ -115,37 +149,40 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
       setActiveCardIndex(0);
       setShowBack(false);
     } catch (generationError) {
-      setError(generationError instanceof Error ? generationError.message : "Flashcard generation failed");
+      setError(
+        generationError instanceof Error
+          ? generationError.message
+          : "Flashcard generation failed",
+      );
     } finally {
       setIsGenerating(false);
     }
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
-      <PageHeader
-        eyebrow="Flashcards"
-        title="Flashcards"
-        description="Generate persistent flashcard decks from selected notes using stored embeddings and note content."
-      />
-
+    <main className="flex h-full flex-col gap-4">
       {error ? (
-        <div className="rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
+        <div className="shrink-0 rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
           {error}
         </div>
       ) : null}
 
-      <div className="grid gap-6 lg:grid-cols-[380px_minmax(0,1fr)]">
-        <Card>
+      <div className="grid min-h-0 flex-1 gap-6 lg:grid-cols-[380px_minmax(0,1fr)]">
+        <Card className="flex min-h-0 flex-col overflow-hidden">
           <CardHeader>
             <CardTitle>Create deck</CardTitle>
-            <CardDescription>Select notes with embeddings and choose how many cards to generate.</CardDescription>
+            <CardDescription>
+              Select notes with embeddings and choose how many cards to
+              generate.
+            </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-6">
+          <CardContent className="min-h-0 flex-1 space-y-6 overflow-y-auto">
             <section className="space-y-3">
               <div className="flex items-center justify-between gap-3">
                 <h2 className="text-sm font-medium text-foreground">Notes</h2>
-                <Badge variant="outline">{selectedNoteIds.length} selected</Badge>
+                <Badge variant="outline">
+                  {selectedNoteIds.length} selected
+                </Badge>
               </div>
               <div className="max-h-72 space-y-2 overflow-auto pr-1">
                 {notes.length === 0 ? (
@@ -171,9 +208,13 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
                         onChange={() => toggleNote(note.id)}
                       />
                       <span className="min-w-0 flex-1">
-                        <span className="block truncate font-medium text-foreground">{note.title}</span>
+                        <span className="block truncate font-medium text-foreground">
+                          {note.title}
+                        </span>
                         <span className="text-xs text-muted-foreground">
-                          {note.hasEmbedding ? "Embedding ready" : "No embedding stored"}
+                          {note.hasEmbedding
+                            ? "Embedding ready"
+                            : "No embedding stored"}
                         </span>
                       </span>
                     </label>
@@ -198,14 +239,22 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
               type="button"
               className="w-full"
               disabled={!canGenerate}
-              leadingIcon={isGenerating ? <Loader2 className="size-4 animate-spin" /> : <Play className="size-4" />}
+              leadingIcon={
+                isGenerating ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Play className="size-4" />
+                )
+              }
               onClick={createDeck}
             >
               Generate deck
             </Button>
 
             <section className="space-y-3">
-              <h2 className="text-sm font-medium text-foreground">Saved decks</h2>
+              <h2 className="text-sm font-medium text-foreground">
+                Saved decks
+              </h2>
               <div className="space-y-2">
                 {decks.length === 0 ? (
                   <p className="rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm text-muted-foreground">
@@ -225,8 +274,12 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
                       onClick={() => selectDeck(deck.id)}
                     >
                       <span className="min-w-0">
-                        <span className="block truncate font-medium">{deck.title}</span>
-                        <span className="text-xs text-muted-foreground">{deck.cardCount} cards</span>
+                        <span className="block truncate font-medium">
+                          {deck.title}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {deck.cardCount} cards
+                        </span>
                       </span>
                       <Layers3 className="size-4 shrink-0" />
                     </button>
@@ -242,10 +295,14 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
             <div className="space-y-2">
               <CardTitle>{activeDeck?.title ?? "Deck workspace"}</CardTitle>
               <CardDescription>
-                {activeDeck ? `${activeCardIndex + 1}/${activeDeck.cards.length} cards` : "Generate a deck to begin."}
+                {activeDeck
+                  ? `${activeCardIndex + 1}/${activeDeck.cards.length} cards`
+                  : "Generate a deck to begin."}
               </CardDescription>
             </div>
-            {activeDeck ? <Badge variant="outline">{activeDeck.cardCount} cards</Badge> : null}
+            {activeDeck ? (
+              <Badge variant="outline">{activeDeck.cardCount} cards</Badge>
+            ) : null}
           </CardHeader>
           <CardContent>
             {isGenerating && !activeDeck ? (
@@ -261,7 +318,9 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
                   onClick={() => setShowBack((value) => !value)}
                 >
                   <div className="flex items-center justify-between gap-3">
-                    <Badge variant="accent">{showBack ? "Back" : "Front"}</Badge>
+                    <Badge variant="accent">
+                      {showBack ? "Back" : "Front"}
+                    </Badge>
                     <Badge variant="outline">Tap to flip</Badge>
                   </div>
                   <div className="mx-auto flex w-full max-w-3xl flex-1 items-center justify-center py-8">
@@ -299,7 +358,10 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
                   </Button>
                   <Button
                     type="button"
-                    disabled={!activeDeck || activeCardIndex >= activeDeck.cards.length - 1}
+                    disabled={
+                      !activeDeck ||
+                      activeCardIndex >= activeDeck.cards.length - 1
+                    }
                     leadingIcon={<ChevronRight className="size-4" />}
                     onClick={() => goToCard(activeCardIndex + 1)}
                   >
@@ -311,9 +373,12 @@ export function FlashcardsClient({ notes, initialDecks }: FlashcardsClientProps)
               <div className="flex min-h-96 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-surface-muted px-6 text-center">
                 <Brain className="size-10 text-muted-foreground" />
                 <div className="space-y-1">
-                  <h2 className="text-base font-semibold text-foreground">No deck selected</h2>
+                  <h2 className="text-base font-semibold text-foreground">
+                    No deck selected
+                  </h2>
                   <p className="max-w-md text-sm leading-6 text-muted-foreground">
-                    Select notes with embeddings and generate a deck to review front/back flashcards.
+                    Select notes with embeddings and generate a deck to review
+                    front/back flashcards.
                   </p>
                 </div>
               </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -996,3 +996,34 @@ html.dark body {
   background: var(--note-code-bg);
   color: var(--note-code-fg);
 }
+
+/* ---- Code block: language label ---- */
+.note-code-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.35rem var(--note-code-block-padding-x) 0;
+}
+
+.note-code-block__lang {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  color: var(--note-muted-foreground);
+  opacity: 0.7;
+  user-select: none;
+  pointer-events: none;
+}
+
+/* ---- Inline math spans ---- */
+.note-inline-math {
+  display: inline;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.9em;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  border-radius: 3px;
+  padding: 0.05em 0.3em;
+  white-space: nowrap;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -582,9 +582,13 @@ html.dark body {
 }
 
 .note-editor .ce-block:hover .ce-block__content::before,
-.note-editor .ce-block--focused .ce-block__content::before,
-.note-editor .ce-block--selected .ce-block__content::before {
+.note-editor .ce-block--focused .ce-block__content::before {
   background: var(--note-border-strong);
+}
+
+.note-editor .ce-block--selected .ce-block__content {
+  background: transparent !important;
+  box-shadow: none !important;
 }
 
 .note-editor:has(.ce-block [contenteditable="true"]:focus)
@@ -733,12 +737,13 @@ html.dark body {
 }
 
 .note-editor__slash-menu button:hover,
-.note-editor__slash-menu button:focus-visible {
+.note-editor__slash-menu button:focus-visible,
+.note-editor__slash-menu-active {
   background: var(--note-toolbar-hover);
   outline: none;
 }
 
-.note-editor__slash-menu button:first-child {
+.note-editor__slash-menu-active {
   background: color-mix(in srgb, var(--accent) 14%, transparent);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,10 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+html {
+  font-size: 20px;
+}
+
 :root {
   --background: #ffffff;
   --foreground: #18181b;

--- a/app/globals.css
+++ b/app/globals.css
@@ -121,6 +121,7 @@ html.dark body {
 .note-editor .ce-toolbar__content {
   max-width: 100%;
   border-radius: 0.75rem;
+  position: relative;
   transition:
     background-color 140ms ease,
     box-shadow 140ms ease,
@@ -205,6 +206,8 @@ html.dark body {
 }
 
 .note-editor .ce-paragraph {
+  position: relative;
+  min-height: 1.85em;
   font-size: 1.05rem;
   line-height: 1.85;
 }
@@ -242,7 +245,10 @@ html.dark body {
   .codex-editor__redactor
   [contenteditable="true"][data-placeholder]:empty::before,
 .note-editor .cdx-input[data-placeholder]::before {
+  position: absolute;
+  inset: 0 auto auto 0;
   color: var(--note-muted-foreground);
+  pointer-events: none;
 }
 
 .note-editor
@@ -252,9 +258,9 @@ html.dark body {
   .ce-block:first-child
   .codex-editor__redactor
   [contenteditable="true"][data-placeholder]:empty::before {
-  font-size: clamp(2.25rem, 4vw, 3rem);
-  font-weight: 700;
-  line-height: 1.1;
+  font-size: 1.05rem;
+  font-weight: 400;
+  line-height: 1.85;
   color: color-mix(in srgb, var(--foreground) 28%, transparent);
 }
 
@@ -262,8 +268,124 @@ html.dark body {
   padding-top: 0.25rem;
 }
 
+.note-editor .ce-block {
+  position: relative;
+  transition: transform 120ms ease;
+  will-change: transform;
+}
+
+.note-editor__canvas {
+  position: relative;
+  min-height: calc(100dvh - 12rem);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.note-editor,
+.note-editor .codex-editor,
 .note-editor .codex-editor__redactor {
-  padding-bottom: 12rem;
+  min-height: 100%;
+}
+
+.note-editor .codex-editor__redactor {
+  padding-bottom: 0 !important;
+}
+
+.note-editor .ce-block,
+.note-editor .ce-block__content,
+.note-editor .ce-toolbar__content {
+  max-width: none;
+}
+
+.note-editor .ce-block__content {
+  border: 0;
+  box-shadow: none;
+}
+
+.note-editor__block-selected::after {
+  position: absolute;
+  inset: 0.1rem 0;
+  z-index: 2;
+  border: 1px solid color-mix(in srgb, var(--accent) 48%, transparent);
+  border-left-width: 3px;
+  border-radius: 0.45rem;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  content: "";
+  pointer-events: none;
+}
+
+.note-editor__block-selected .ce-block__content {
+  padding-left: 0.95rem;
+  background: transparent;
+  border-radius: 0 !important;
+  box-shadow: none;
+}
+
+.note-editor__block-dragging {
+  opacity: 0.24;
+}
+
+.note-editor__drop-placeholder {
+  position: absolute;
+  right: 1.5rem;
+  left: 1.5rem;
+  z-index: 30;
+  min-height: 2.5rem;
+  border: 1px dashed color-mix(in srgb, var(--accent) 54%, transparent);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+  pointer-events: none;
+}
+
+.note-editor__drop-placeholder::before {
+  position: absolute;
+  top: -2px;
+  right: 0;
+  left: 0;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent);
+  content: "";
+}
+
+.note-editor__drag-preview {
+  position: fixed;
+  z-index: 9998;
+  max-height: min(70vh, 42rem);
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, transparent);
+  border-radius: 0.6rem;
+  background: var(--background);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.18),
+    0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+  opacity: 0.96;
+  pointer-events: none;
+  will-change: top, left;
+}
+
+.note-editor__drag-preview-block {
+  background: var(--background);
+}
+
+.note-editor__drag-preview-block .ce-block__content {
+  max-width: none;
+  background: transparent;
+}
+
+.note-editor__selection-box {
+  position: fixed;
+  z-index: 9999;
+  border: 1px solid color-mix(in srgb, var(--accent) 68%, white 12%);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+  pointer-events: none;
+}
+
+.note-editor .ce-toolbar__actions {
+  display: none !important;
 }
 
 .note-editor .ce-inline-toolbar,
@@ -310,6 +432,14 @@ html.dark body {
   background: transparent;
   border-color: var(--note-border);
   border-radius: 0.75rem;
+}
+
+.note-editor .ce-toolbar__settings-btn {
+  cursor: grab;
+}
+
+.note-editor .ce-toolbar__settings-btn:active {
+  cursor: grabbing;
 }
 
 .note-editor .ce-toolbar__plus:hover,
@@ -430,20 +560,57 @@ html.dark body {
   background: var(--note-border);
 }
 
-.note-editor .ce-block--selected,
-.note-editor .ce-block--selected .ce-block__content {
-  background: color-mix(in srgb, var(--note-selection) 55%, transparent);
-  border-radius: 0 !important;
-  box-shadow: inset 0 0 0 1px var(--note-selection-strong);
-}
-
 .note-editor .ce-block__content:hover {
   background: color-mix(in srgb, var(--note-toolbar-hover) 65%, transparent);
 }
 
-.note-editor .ce-block--selected:hover,
-.note-editor .ce-block--selected .ce-block__content:hover {
-  background: color-mix(in srgb, var(--note-selection) 75%, transparent);
+.note-editor:has(.ce-block [contenteditable="true"]:focus) .ce-block__content:hover,
+.note-editor:has(.ce-block textarea:focus) .ce-block__content:hover,
+.note-editor:has(.ce-block math-field:focus) .ce-block__content:hover {
+  background: transparent;
+}
+
+.note-editor .ce-block__content::before {
+  position: absolute;
+  inset-block: 0.35rem;
+  inset-inline-start: -0.55rem;
+  width: 2px;
+  border-radius: 999px;
+  background: transparent;
+  content: "";
+  transition: background-color 140ms ease;
+}
+
+.note-editor .ce-block:hover .ce-block__content::before,
+.note-editor .ce-block--focused .ce-block__content::before,
+.note-editor .ce-block--selected .ce-block__content::before {
+  background: var(--note-border-strong);
+}
+
+.note-editor:has(.ce-block [contenteditable="true"]:focus)
+  .ce-block:hover
+  .ce-block__content::before,
+.note-editor:has(.ce-block textarea:focus) .ce-block:hover .ce-block__content::before,
+.note-editor:has(.ce-block math-field:focus) .ce-block:hover .ce-block__content::before,
+.note-editor:has(.ce-block [contenteditable="true"]:focus)
+  .ce-block--focused
+  .ce-block__content::before,
+.note-editor:has(.ce-block textarea:focus)
+  .ce-block--focused
+  .ce-block__content::before,
+.note-editor:has(.ce-block math-field:focus)
+  .ce-block--focused
+  .ce-block__content::before {
+  background: transparent;
+}
+
+.note-editor__block-selected .ce-block__content::before {
+  background: transparent;
+}
+
+.note-editor__block-selected:hover .ce-block__content,
+.note-editor__block-selected .ce-block__content:hover {
+  background: transparent;
   border-radius: 0 !important;
 }
 
@@ -451,23 +618,159 @@ html.dark body {
   background: var(--note-selection-strong);
 }
 
+.note-editor__context-menu {
+  position: fixed;
+  z-index: 10000;
+  width: 13.5rem;
+  max-width: calc(100vw - 1rem);
+  padding: 0.35rem;
+  border: 1px solid var(--note-border);
+  border-radius: 0.65rem;
+  background: var(--note-toolbar);
+  color: var(--foreground);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.22),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.note-editor__context-menu button,
+.note-editor__context-menu-item {
+  display: flex;
+  min-height: 1.9rem;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 0;
+  border-radius: 0.45rem;
+  background: transparent;
+  padding: 0.35rem 0.5rem;
+  color: var(--foreground);
+  font-size: 0.82rem;
+  line-height: 1.2;
+  text-align: left;
+}
+
+.note-editor__context-menu button:hover,
+.note-editor__context-menu-item:hover {
+  background: var(--note-toolbar-hover);
+}
+
+.note-editor__context-menu-item--submenu {
+  position: relative;
+}
+
+.note-editor__context-submenu {
+  position: absolute;
+  top: -0.35rem;
+  left: calc(100% + 0.3rem);
+  display: none;
+  width: 13.5rem;
+  padding: 0.35rem;
+  border: 1px solid var(--note-border);
+  border-radius: 0.65rem;
+  background: var(--note-toolbar);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.22),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.note-editor__context-menu-item--submenu:hover .note-editor__context-submenu,
+.note-editor__context-menu-item--submenu:focus-within .note-editor__context-submenu {
+  display: block;
+}
+
+.note-editor__context-menu-separator {
+  height: 1px;
+  margin: 0.3rem 0.25rem;
+  background: var(--note-border);
+}
+
+.note-editor__context-menu-danger {
+  color: var(--danger) !important;
+}
+
+.note-editor__context-menu-danger:hover {
+  background: var(--danger-soft) !important;
+}
+
+.note-editor__context-menu-meta {
+  padding: 0.3rem 0.5rem 0.15rem;
+  color: var(--note-muted-foreground);
+  font-size: 0.68rem;
+  text-transform: capitalize;
+}
+
+.note-editor__slash-menu {
+  position: fixed;
+  z-index: 10000;
+  width: 18rem;
+  max-width: calc(100vw - 1rem);
+  max-height: min(22rem, calc(100vh - 2rem));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.35rem;
+  border: 1px solid var(--note-border);
+  border-radius: 0.65rem;
+  background: var(--note-toolbar);
+  color: var(--foreground);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.22),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.note-editor__slash-menu button {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.1rem;
+  border: 0;
+  border-radius: 0.45rem;
+  background: transparent;
+  padding: 0.45rem 0.55rem;
+  color: var(--foreground);
+  text-align: left;
+}
+
+.note-editor__slash-menu button:hover,
+.note-editor__slash-menu button:focus-visible {
+  background: var(--note-toolbar-hover);
+  outline: none;
+}
+
+.note-editor__slash-menu button:first-child {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.note-editor__slash-menu button span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.84rem;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.note-editor__slash-menu button span:last-child,
+.note-editor__slash-menu-empty {
+  color: var(--note-muted-foreground);
+  font-size: 0.72rem;
+  line-height: 1.25;
+}
+
+.note-editor__slash-menu-empty {
+  padding: 0.5rem 0.55rem;
+}
+
 .note-surface {
+  height: 100%;
+  min-height: 100%;
   width: 100%;
 }
 
-.note-surface[role="button"] {
-  cursor: text;
-  border-radius: 0.75rem;
-  transition:
-    background-color 140ms ease,
-    box-shadow 140ms ease,
-    color 140ms ease;
-}
-
-.note-surface[role="button"]:hover,
-.note-surface[role="button"]:focus-visible {
-  background: color-mix(in srgb, var(--note-toolbar-hover) 28%, transparent);
-  outline: none;
+.note-surface--editing {
+  height: 100%;
+  min-height: 100%;
 }
 
 .note-surface__content {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Script from "next/script";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 import "mathlive/fonts.css";
 import "mathlive/static.css";
@@ -55,6 +56,18 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: themeInitScript }}
         />
         {children}
+        <Toaster
+          position="bottom-right"
+          toastOptions={{
+            style: {
+              background: "var(--surface-elevated)",
+              color: "var(--foreground)",
+              border: "1px solid var(--border)",
+              borderRadius: "0.5rem",
+              fontSize: "0.875rem",
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/app/notes/notes-workspace.tsx
+++ b/app/notes/notes-workspace.tsx
@@ -78,7 +78,19 @@ function getClassLabel(item: WorkspaceClass) {
  */
 function getClassShortLabel(item: WorkspaceClass) {
   if (item.courseCode) return item.courseCode;
-  const skip = new Set(["a", "an", "the", "of", "in", "to", "for", "and", "or", "at", "by"]);
+  const skip = new Set([
+    "a",
+    "an",
+    "the",
+    "of",
+    "in",
+    "to",
+    "for",
+    "and",
+    "or",
+    "at",
+    "by",
+  ]);
   const words = item.title.split(/\s+/).filter(Boolean);
   const acronym = words
     .filter((w) => !skip.has(w.toLowerCase()))
@@ -90,7 +102,10 @@ function getClassShortLabel(item: WorkspaceClass) {
 
 const isTempNote = (id: string) => id.startsWith("temp-");
 
-function createTempNote(classId: string | null, overrides?: Partial<WorkspaceNote>): WorkspaceNote {
+function createTempNote(
+  classId: string | null,
+  overrides?: Partial<WorkspaceNote>,
+): WorkspaceNote {
   const now = new Date().toISOString();
   return {
     id: `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -154,7 +169,9 @@ function UploadModal({ onClose, onUploadMd, onGenerate }: UploadModalProps) {
               <FileText className="h-4 w-4" aria-hidden="true" />
             </span>
             <span className="min-w-0">
-              <span className="block text-sm font-medium text-foreground">Upload .md file</span>
+              <span className="block text-sm font-medium text-foreground">
+                Upload .md file
+              </span>
               <span className="mt-0.5 block text-xs text-muted-foreground">
                 Import a Markdown document directly
               </span>
@@ -170,7 +187,9 @@ function UploadModal({ onClose, onUploadMd, onGenerate }: UploadModalProps) {
               <Sparkles className="h-4 w-4" aria-hidden="true" />
             </span>
             <span className="min-w-0">
-              <span className="block text-sm font-medium text-foreground">Generate from study material</span>
+              <span className="block text-sm font-medium text-foreground">
+                Generate from study material
+              </span>
               <span className="mt-0.5 block text-xs text-muted-foreground">
                 Upload slides, PDFs, or images — AI writes the notes
               </span>
@@ -196,7 +215,9 @@ export function NotesWorkspace({
   const router = useRouter();
   const [notes, setNotes] = useState(() => sortWorkspaceNotes(initialNotes));
   const initialSelectedNote = initialClassId
-    ? (initialNotes.find((note) => note.classId === initialClassId) ?? initialNotes[0] ?? null)
+    ? (initialNotes.find((note) => note.classId === initialClassId) ??
+      initialNotes[0] ??
+      null)
     : (initialNotes[0] ?? null);
 
   const [selectedId, setSelectedId] = useState<string | null>(
@@ -206,7 +227,9 @@ export function NotesWorkspace({
     noteId: initialSelectedNote?.id ?? null,
     value: initialSelectedNote?.title ?? "Untitled",
   }));
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [isPending, startTransition] = useTransition();
 
   // Sidebar drag-and-drop state
@@ -214,8 +237,12 @@ export function NotesWorkspace({
   const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null);
 
   // Sidebar multi-select state
-  const [sidebarSelectedIds, setSidebarSelectedIds] = useState<Set<string>>(() => new Set());
-  const [lastSidebarSelectedId, setLastSidebarSelectedId] = useState<string | null>(null);
+  const [sidebarSelectedIds, setSidebarSelectedIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [lastSidebarSelectedId, setLastSidebarSelectedId] = useState<
+    string | null
+  >(null);
   const [isBulkMoveOpen, setIsBulkMoveOpen] = useState(false);
 
   // Sidebar note context menu
@@ -241,7 +268,10 @@ export function NotesWorkspace({
     () => notes.find((note) => note.id === selectedId) ?? notes[0] ?? null,
     [notes, selectedId],
   );
-  const recentNotes = useMemo(() => sortWorkspaceNotes(notes).slice(0, 8), [notes]);
+  const recentNotes = useMemo(
+    () => sortWorkspaceNotes(notes).slice(0, 8),
+    [notes],
+  );
   const groupedNotes = useMemo(
     () => [
       ...classes.map((item) => ({
@@ -288,7 +318,10 @@ export function NotesWorkspace({
 
   function mergeNote(nextNote: WorkspaceNote) {
     setNotes((current) =>
-      sortWorkspaceNotes([nextNote, ...current.filter((n) => n.id !== nextNote.id)]),
+      sortWorkspaceNotes([
+        nextNote,
+        ...current.filter((n) => n.id !== nextNote.id),
+      ]),
     );
   }
 
@@ -375,11 +408,16 @@ export function NotesWorkspace({
       });
       const created = await readNoteRecord(response);
       setNotes((current) =>
-        sortWorkspaceNotes([created, ...current.filter((n) => n.id !== temp.id)]),
+        sortWorkspaceNotes([
+          created,
+          ...current.filter((n) => n.id !== temp.id),
+        ]),
       );
       setSelectedId((prev) => (prev === temp.id ? created.id : prev));
       setTitleDraftState((prev) =>
-        prev.noteId === temp.id ? { noteId: created.id, value: created.title } : prev,
+        prev.noteId === temp.id
+          ? { noteId: created.id, value: created.title }
+          : prev,
       );
       selectedIdRef.current = created.id;
     } catch (err) {
@@ -417,9 +455,13 @@ export function NotesWorkspace({
     setSelectedId(nextNote?.id ?? null);
 
     try {
-      const response = await fetch(`/api/notes/${noteToDelete.id}`, { method: "DELETE" });
+      const response = await fetch(`/api/notes/${noteToDelete.id}`, {
+        method: "DELETE",
+      });
       if (!response.ok) {
-        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        const payload = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
         throw new Error(payload?.error || "Could not delete the note.");
       }
     } catch (err) {
@@ -461,11 +503,16 @@ export function NotesWorkspace({
       });
       const created = await readNoteRecord(response);
       setNotes((current) =>
-        sortWorkspaceNotes([created, ...current.filter((n) => n.id !== temp.id)]),
+        sortWorkspaceNotes([
+          created,
+          ...current.filter((n) => n.id !== temp.id),
+        ]),
       );
       setSelectedId((prev) => (prev === temp.id ? created.id : prev));
       setTitleDraftState((prev) =>
-        prev.noteId === temp.id ? { noteId: created.id, value: created.title } : prev,
+        prev.noteId === temp.id
+          ? { noteId: created.id, value: created.title }
+          : prev,
       );
       selectedIdRef.current = created.id;
     } catch (err) {
@@ -491,23 +538,37 @@ export function NotesWorkspace({
     try {
       const formData = new FormData();
       formData.set("file", file);
-      formData.set("title", file.name.replace(/\.[^.]+$/, "") || "Uploaded Note");
+      formData.set(
+        "title",
+        file.name.replace(/\.[^.]+$/, "") || "Uploaded Note",
+      );
       if (classId) formData.set("classId", classId);
 
-      toast.loading("Generating notes with AI…", { id: toastId, description: undefined });
+      toast.loading("Generating notes with AI…", {
+        id: toastId,
+        description: undefined,
+      });
 
-      const response = await fetch("/api/notes/upload", { method: "POST", body: formData });
+      const response = await fetch("/api/notes/upload", {
+        method: "POST",
+        body: formData,
+      });
       const payload = (await response.json().catch(() => null)) as {
         notes?: NoteRecord[];
         error?: string;
       } | null;
 
       if (!response.ok) {
-        throw new Error(payload?.error ?? "Could not generate notes from the uploaded file.");
+        throw new Error(
+          payload?.error ?? "Could not generate notes from the uploaded file.",
+        );
       }
 
-      const created = (payload?.notes ?? []).map((r) => noteRecordToWorkspaceNote(r));
-      if (created.length === 0) throw new Error("No notes returned from generation pipeline.");
+      const created = (payload?.notes ?? []).map((r) =>
+        noteRecordToWorkspaceNote(r),
+      );
+      if (created.length === 0)
+        throw new Error("No notes returned from generation pipeline.");
 
       mergeNotes(created);
       setSelectedId(created[0].id);
@@ -519,7 +580,8 @@ export function NotesWorkspace({
     } catch (err) {
       toast.error("Generation failed", {
         id: toastId,
-        description: err instanceof Error ? err.message : "Could not generate notes.",
+        description:
+          err instanceof Error ? err.message : "Could not generate notes.",
         duration: 6000,
       });
       throw err;
@@ -527,7 +589,9 @@ export function NotesWorkspace({
   }
 
   async function handleImportMdFile(file: File, classId?: string | null) {
-    const toastId = toast.loading(`Importing ${file.name}…`, { duration: Infinity });
+    const toastId = toast.loading(`Importing ${file.name}…`, {
+      duration: Infinity,
+    });
 
     try {
       const text = await file.text();
@@ -537,18 +601,27 @@ export function NotesWorkspace({
       const response = await fetch("/api/notes", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title, classId: classId ?? null, content: document }),
+        body: JSON.stringify({
+          title,
+          classId: classId ?? null,
+          content: document,
+        }),
       });
 
       const created = await readNoteRecord(response);
       mergeNote(created);
       setSelectedId(created.id);
       setTitleDraftState({ noteId: created.id, value: created.title });
-      toast.success("Note imported", { id: toastId, description: title, duration: 3000 });
+      toast.success("Note imported", {
+        id: toastId,
+        description: title,
+        duration: 3000,
+      });
     } catch (err) {
       toast.error("Import failed", {
         id: toastId,
-        description: err instanceof Error ? err.message : "Could not import the file.",
+        description:
+          err instanceof Error ? err.message : "Could not import the file.",
         duration: 6000,
       });
       throw err;
@@ -560,7 +633,8 @@ export function NotesWorkspace({
 
     const nextTitle = draftTitle.trim() || "Untitled";
     if (nextTitle === getRenderableTitle(selectedNote.title)) {
-      if (selectedNote.title !== nextTitle) mergeNote({ ...selectedNote, title: nextTitle });
+      if (selectedNote.title !== nextTitle)
+        mergeNote({ ...selectedNote, title: nextTitle });
       return;
     }
 
@@ -583,15 +657,18 @@ export function NotesWorkspace({
     if (!note || note.classId === groupClassId || isTempNote(noteId)) return;
 
     setNotes((current) =>
-      current.map((n) => (n.id === noteId ? { ...n, classId: groupClassId } : n)),
+      current.map((n) =>
+        n.id === noteId ? { ...n, classId: groupClassId } : n,
+      ),
     );
-    startTransition(() =>
-      void saveNote(noteId, { classId: groupClassId }).catch((err) => {
-        toast.error("Could not move note", {
-          description: err instanceof Error ? err.message : undefined,
-          duration: 5000,
-        });
-      }),
+    startTransition(
+      () =>
+        void saveNote(noteId, { classId: groupClassId }).catch((err) => {
+          toast.error("Could not move note", {
+            description: err instanceof Error ? err.message : undefined,
+            duration: 5000,
+          });
+        }),
     );
   }
 
@@ -616,7 +693,9 @@ export function NotesWorkspace({
     const toIdx = sorted.findIndex((n) => n.id === toId);
     if (fromIdx === -1 || toIdx === -1) return;
     const [start, end] = fromIdx < toIdx ? [fromIdx, toIdx] : [toIdx, fromIdx];
-    setSidebarSelectedIds(new Set(sorted.slice(start, end + 1).map((n) => n.id)));
+    setSidebarSelectedIds(
+      new Set(sorted.slice(start, end + 1).map((n) => n.id)),
+    );
     setLastSidebarSelectedId(toId);
   }
 
@@ -638,14 +717,19 @@ export function NotesWorkspace({
     clearSidebarSelect();
 
     await Promise.allSettled(
-      ids.map((id) => !isTempNote(id) && fetch(`/api/notes/${id}`, { method: "DELETE" })),
+      ids.map(
+        (id) =>
+          !isTempNote(id) && fetch(`/api/notes/${id}`, { method: "DELETE" }),
+      ),
     );
     // On partial failure we could restore, but for now just log
   }
 
   async function handleBulkDuplicate() {
     if (sidebarSelectedIds.size === 0) return;
-    const sources = notes.filter((n) => sidebarSelectedIds.has(n.id) && !isTempNote(n.id));
+    const sources = notes.filter(
+      (n) => sidebarSelectedIds.has(n.id) && !isTempNote(n.id),
+    );
     if (sources.length === 0) return;
 
     const temps = sources.map((source) =>
@@ -673,7 +757,10 @@ export function NotesWorkspace({
           });
           const created = await readNoteRecord(response);
           setNotes((current) =>
-            sortWorkspaceNotes([created, ...current.filter((n) => n.id !== temp.id)]),
+            sortWorkspaceNotes([
+              created,
+              ...current.filter((n) => n.id !== temp.id),
+            ]),
           );
         } catch {
           setNotes((current) => current.filter((n) => n.id !== temp.id));
@@ -687,7 +774,9 @@ export function NotesWorkspace({
     const ids = [...sidebarSelectedIds];
 
     setNotes((current) =>
-      current.map((n) => (ids.includes(n.id) ? { ...n, classId: targetClassId } : n)),
+      current.map((n) =>
+        ids.includes(n.id) ? { ...n, classId: targetClassId } : n,
+      ),
     );
     clearSidebarSelect();
 
@@ -723,11 +812,16 @@ export function NotesWorkspace({
       });
       const created = await readNoteRecord(response);
       setNotes((current) =>
-        sortWorkspaceNotes([created, ...current.filter((n) => n.id !== temp.id)]),
+        sortWorkspaceNotes([
+          created,
+          ...current.filter((n) => n.id !== temp.id),
+        ]),
       );
       setSelectedId((prev) => (prev === temp.id ? created.id : prev));
       setTitleDraftState((prev) =>
-        prev.noteId === temp.id ? { noteId: created.id, value: created.title } : prev,
+        prev.noteId === temp.id
+          ? { noteId: created.id, value: created.title }
+          : prev,
       );
       selectedIdRef.current = created.id;
     } catch (err) {
@@ -746,9 +840,13 @@ export function NotesWorkspace({
     setNotes((current) => current.filter((n) => n.id !== target.id));
     if (selectedNote?.id === target.id) setSelectedId(nextNote?.id ?? null);
     try {
-      const response = await fetch(`/api/notes/${target.id}`, { method: "DELETE" });
+      const response = await fetch(`/api/notes/${target.id}`, {
+        method: "DELETE",
+      });
       if (!response.ok) {
-        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        const payload = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
         throw new Error(payload?.error || "Could not delete the note.");
       }
     } catch (err) {
@@ -764,11 +862,16 @@ export function NotesWorkspace({
   // Note item renderer
   // -------------------------------------------------------------------------
 
-  const renderNoteItem = (note: WorkspaceNote, options?: { compact?: boolean }) => {
+  const renderNoteItem = (
+    note: WorkspaceNote,
+    options?: { compact?: boolean },
+  ) => {
     const isOpen = note.id === selectedNote?.id;
     const isSidebarSelected = sidebarSelectedIds.has(note.id);
     const isTemp = isTempNote(note.id);
-    const linkedClass = note.classId ? (classesById.get(note.classId) ?? null) : null;
+    const linkedClass = note.classId
+      ? (classesById.get(note.classId) ?? null)
+      : null;
     const hasSelection = sidebarSelectedIds.size > 0;
 
     return (
@@ -795,7 +898,8 @@ export function NotesWorkspace({
           isSidebarSelected && "bg-accent-soft",
           draggedNoteId &&
             (draggedNoteId === note.id ||
-              (sidebarSelectedIds.has(draggedNoteId) && sidebarSelectedIds.has(note.id))) &&
+              (sidebarSelectedIds.has(draggedNoteId) &&
+                sidebarSelectedIds.has(note.id))) &&
             "opacity-40",
         )}
       >
@@ -808,13 +912,18 @@ export function NotesWorkspace({
           }}
           className={cx(
             "flex h-7 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:text-foreground",
-            hasSelection || isSidebarSelected ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+            hasSelection || isSidebarSelected
+              ? "opacity-100"
+              : "opacity-0 group-hover:opacity-100",
           )}
           aria-label={isSidebarSelected ? "Deselect note" : "Select note"}
           tabIndex={-1}
         >
           {isSidebarSelected ? (
-            <CheckSquare className="h-3.5 w-3.5 text-accent" aria-hidden="true" />
+            <CheckSquare
+              className="h-3.5 w-3.5 text-accent"
+              aria-hidden="true"
+            />
           ) : (
             <Square className="h-3.5 w-3.5" aria-hidden="true" />
           )}
@@ -846,7 +955,10 @@ export function NotesWorkspace({
             isTemp && "animate-pulse opacity-60",
           )}
         >
-          <FileText className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+          <FileText
+            className="h-4 w-4 shrink-0 opacity-70"
+            aria-hidden="true"
+          />
           <span className="min-w-0 flex-1 truncate font-medium">
             {getRenderableTitle(note.title)}
           </span>
@@ -885,9 +997,12 @@ export function NotesWorkspace({
           event.currentTarget.value = "";
           if (!file) return;
           startTransition(() => {
-            void handleGenerateFromFile(file, selectedNote?.classId ?? fallbackClassId).catch(
-              () => { /* toast already shown inside handler */ },
-            );
+            void handleGenerateFromFile(
+              file,
+              selectedNote?.classId ?? fallbackClassId,
+            ).catch(() => {
+              /* toast already shown inside handler */
+            });
           });
         }}
       />
@@ -903,9 +1018,12 @@ export function NotesWorkspace({
           event.currentTarget.value = "";
           if (!file) return;
           startTransition(() => {
-            void handleImportMdFile(file, selectedNote?.classId ?? fallbackClassId).catch(
-              () => { /* toast already shown inside handler */ },
-            );
+            void handleImportMdFile(
+              file,
+              selectedNote?.classId ?? fallbackClassId,
+            ).catch(() => {
+              /* toast already shown inside handler */
+            });
           });
         }}
       />
@@ -943,7 +1061,7 @@ export function NotesWorkspace({
               <Plus className="h-4 w-4 shrink-0" aria-hidden="true" />
               <span className="truncate">New page</span>
             </button>
-            <button
+            {/* <button
               type="button"
               onClick={() => setIsUploadModalOpen(true)}
               disabled={isPending}
@@ -952,37 +1070,53 @@ export function NotesWorkspace({
               aria-label="Import or generate notes"
             >
               <Upload className="h-4 w-4" aria-hidden="true" />
-            </button>
+            </button> */}
           </div>
 
           {/* Note list */}
           <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 py-3">
             {recentNotes.length > 0 ? (
               <section className="mb-5">
-                <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">Recents</div>
+                <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">
+                  Recents
+                </div>
                 <div className="space-y-0.5">
-                  {recentNotes.map((note) => renderNoteItem(note, { compact: true }))}
+                  {recentNotes.map((note) =>
+                    renderNoteItem(note, { compact: true }),
+                  )}
                 </div>
               </section>
             ) : null}
 
             <section className="space-y-1">
-              <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">Private</div>
+              <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">
+                Private
+              </div>
               {groupedNotes.map((group) => {
                 const isCollapsed = collapsedGroups.has(group.id);
-                const isDragTarget = dragOverGroupId === group.id && draggedNoteId !== null;
+                const isDragTarget =
+                  dragOverGroupId === group.id && draggedNoteId !== null;
                 const draggedNote = draggedNoteId
                   ? notes.find((n) => n.id === draggedNoteId)
                   : null;
                 // When dragging a selected note, at least one selected note must
                 // differ from this group's class for the drop to be meaningful.
-                const canDrop = draggedNote && (() => {
-                  const id = draggedNoteId!;
-                  if (sidebarSelectedIds.has(id) && sidebarSelectedIds.size > 1) {
-                    return notes.some((n) => sidebarSelectedIds.has(n.id) && n.classId !== group.classId);
-                  }
-                  return draggedNote.classId !== group.classId;
-                })();
+                const canDrop =
+                  draggedNote &&
+                  (() => {
+                    const id = draggedNoteId!;
+                    if (
+                      sidebarSelectedIds.has(id) &&
+                      sidebarSelectedIds.size > 1
+                    ) {
+                      return notes.some(
+                        (n) =>
+                          sidebarSelectedIds.has(n.id) &&
+                          n.classId !== group.classId,
+                      );
+                    }
+                    return draggedNote.classId !== group.classId;
+                  })();
 
                 return (
                   <div
@@ -1009,7 +1143,10 @@ export function NotesWorkspace({
                       if (draggedNoteId && canDrop) {
                         // If the dragged note is part of the sidebar selection,
                         // move all selected notes. Otherwise just move the one.
-                        if (sidebarSelectedIds.has(draggedNoteId) && sidebarSelectedIds.size > 1) {
+                        if (
+                          sidebarSelectedIds.has(draggedNoteId) &&
+                          sidebarSelectedIds.size > 1
+                        ) {
                           handleBulkMove(group.classId);
                         } else {
                           handleNoteDrop(group.classId, draggedNoteId);
@@ -1019,7 +1156,9 @@ export function NotesWorkspace({
                     }}
                     className={cx(
                       "rounded-lg transition-colors",
-                      isDragTarget && canDrop ? "bg-accent-soft ring-1 ring-accent/30" : "",
+                      isDragTarget && canDrop
+                        ? "bg-accent-soft ring-1 ring-accent/30"
+                        : "",
                     )}
                   >
                     <div className="group flex items-center gap-1 rounded-md text-muted-foreground hover:bg-surface hover:text-foreground">
@@ -1030,9 +1169,15 @@ export function NotesWorkspace({
                         aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group.title}`}
                       >
                         {isCollapsed ? (
-                          <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+                          <ChevronRight
+                            className="h-3.5 w-3.5"
+                            aria-hidden="true"
+                          />
                         ) : (
-                          <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                          <ChevronDown
+                            className="h-3.5 w-3.5"
+                            aria-hidden="true"
+                          />
                         )}
                       </button>
                       <button
@@ -1040,7 +1185,10 @@ export function NotesWorkspace({
                         onClick={() => toggleGroup(group.id)}
                         className="flex min-w-0 flex-1 items-center gap-2 py-1.5 text-left text-sm font-medium"
                       >
-                        <Folder className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+                        <Folder
+                          className="h-4 w-4 shrink-0 opacity-70"
+                          aria-hidden="true"
+                        />
                         <span className="truncate" title={group.title}>
                           {group.shortTitle}
                         </span>
@@ -1051,7 +1199,9 @@ export function NotesWorkspace({
                       <button
                         type="button"
                         onClick={() =>
-                          startTransition(() => void handleCreateNote(group.classId))
+                          startTransition(
+                            () => void handleCreateNote(group.classId),
+                          )
                         }
                         disabled={isPending}
                         className="mr-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md opacity-0 hover:bg-surface-elevated group-hover:opacity-100 disabled:opacity-40"
@@ -1102,7 +1252,10 @@ export function NotesWorkspace({
                     onClick={() => setIsBulkMoveOpen((v) => !v)}
                     className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-surface hover:text-foreground"
                   >
-                    <FolderInput className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    <FolderInput
+                      className="h-3.5 w-3.5 shrink-0"
+                      aria-hidden="true"
+                    />
                     Move to…
                     <ChevronDown
                       className={cx(
@@ -1119,7 +1272,10 @@ export function NotesWorkspace({
                         onClick={() => handleBulkMove(null)}
                         className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-surface-muted hover:text-foreground"
                       >
-                        <Folder className="h-3.5 w-3.5 shrink-0 opacity-60" aria-hidden="true" />
+                        <Folder
+                          className="h-3.5 w-3.5 shrink-0 opacity-60"
+                          aria-hidden="true"
+                        />
                         Unfiled
                       </button>
                       {classes.map((cls) => (
@@ -1130,8 +1286,13 @@ export function NotesWorkspace({
                           title={getClassLabel(cls)}
                           className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-surface-muted hover:text-foreground"
                         >
-                          <Folder className="h-3.5 w-3.5 shrink-0 opacity-60" aria-hidden="true" />
-                          <span className="truncate">{getClassShortLabel(cls)}</span>
+                          <Folder
+                            className="h-3.5 w-3.5 shrink-0 opacity-60"
+                            aria-hidden="true"
+                          />
+                          <span className="truncate">
+                            {getClassShortLabel(cls)}
+                          </span>
                         </button>
                       ))}
                     </div>
@@ -1220,10 +1381,15 @@ export function NotesWorkspace({
                         value={draftTitle}
                         onChange={(event) => {
                           const nextTitle = event.currentTarget.value;
-                          setTitleDraftState({ noteId: selectedNote.id, value: nextTitle });
+                          setTitleDraftState({
+                            noteId: selectedNote.id,
+                            value: nextTitle,
+                          });
                           setNotes((current) =>
                             current.map((n) =>
-                              n.id === selectedNote.id ? { ...n, title: nextTitle } : n,
+                              n.id === selectedNote.id
+                                ? { ...n, title: nextTitle }
+                                : n,
                             ),
                           );
                         }}
@@ -1237,7 +1403,9 @@ export function NotesWorkspace({
                       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                         <span>{formatTimestamp(selectedNote.updatedAt)}</span>
                         {selectedNote.fileName ? (
-                          <span className="truncate">{selectedNote.fileName}</span>
+                          <span className="truncate">
+                            {selectedNote.fileName}
+                          </span>
                         ) : null}
                       </div>
                     </div>
@@ -1251,7 +1419,9 @@ export function NotesWorkspace({
                     } catch (saveError) {
                       toast.error("Could not save note", {
                         description:
-                          saveError instanceof Error ? saveError.message : undefined,
+                          saveError instanceof Error
+                            ? saveError.message
+                            : undefined,
                         duration: 5000,
                       });
                     }
@@ -1265,7 +1435,9 @@ export function NotesWorkspace({
                 <Button
                   type="button"
                   onClick={() =>
-                    startTransition(() => void handleCreateNote(fallbackClassId))
+                    startTransition(
+                      () => void handleCreateNote(fallbackClassId),
+                    )
                   }
                   disabled={isPending}
                 >
@@ -1310,7 +1482,9 @@ export function NotesWorkspace({
             <button
               type="button"
               className="w-full px-3 py-1.5 text-left text-sm text-foreground hover:bg-surface"
-              onClick={() => void handleContextMenuDuplicate(noteContextMenu.note)}
+              onClick={() =>
+                void handleContextMenuDuplicate(noteContextMenu.note)
+              }
             >
               Duplicate
             </button>

--- a/app/notes/notes-workspace.tsx
+++ b/app/notes/notes-workspace.tsx
@@ -8,19 +8,25 @@ import {
   useState,
   useTransition,
 } from "react";
+import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import {
+  CheckSquare,
   ChevronDown,
   ChevronRight,
+  Copy,
   FileText,
   Folder,
+  FolderInput,
   Plus,
+  Sparkles,
+  Square,
   Trash2,
   Upload,
+  X,
 } from "lucide-react";
 import { NoteSurface } from "@/components/note-editor/note-surface";
 import { Button } from "@/components/ui/button";
-import { Select } from "@/components/ui/input";
 import { cx } from "@/lib/utils";
 import {
   noteRecordToWorkspaceNote,
@@ -29,6 +35,7 @@ import {
   type WorkspaceNote,
 } from "@/lib/notes/records";
 import { emptyNoteDocument, type NoteContent } from "@/lib/notes/types";
+import { parseMarkdownToNoteDocument } from "@/lib/notes/markdown";
 
 type WorkspaceClass = {
   id: string;
@@ -59,9 +66,125 @@ function getRenderableTitle(value: string) {
   return value.trim() || "Untitled";
 }
 
+/** Full label used in tooltips and accessible names */
 function getClassLabel(item: WorkspaceClass) {
   return item.courseCode ? `${item.courseCode} ${item.title}` : item.title;
 }
+
+/**
+ * Short label for compact sidebar contexts.
+ * Uses the course code when available (e.g. "CS/CE 4337.006").
+ * Falls back to an acronym when there is no code.
+ */
+function getClassShortLabel(item: WorkspaceClass) {
+  if (item.courseCode) return item.courseCode;
+  const skip = new Set(["a", "an", "the", "of", "in", "to", "for", "and", "or", "at", "by"]);
+  const words = item.title.split(/\s+/).filter(Boolean);
+  const acronym = words
+    .filter((w) => !skip.has(w.toLowerCase()))
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+  if (acronym.length <= 1 || item.title.length <= 18) return item.title;
+  return acronym;
+}
+
+const isTempNote = (id: string) => id.startsWith("temp-");
+
+function createTempNote(classId: string | null, overrides?: Partial<WorkspaceNote>): WorkspaceNote {
+  const now = new Date().toISOString();
+  return {
+    id: `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    title: "Untitled",
+    classId,
+    sourceType: "manual",
+    fileName: null,
+    mimeType: null,
+    fileSize: null,
+    embedding: null,
+    createdAt: now,
+    updatedAt: now,
+    content: { markdown: "", document: { time: Date.now(), blocks: [] } },
+    generation: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Upload modal
+// ---------------------------------------------------------------------------
+
+type UploadModalProps = {
+  onClose: () => void;
+  onUploadMd: () => void;
+  onGenerate: () => void;
+};
+
+function UploadModal({ onClose, onUploadMd, onGenerate }: UploadModalProps) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add notes"
+      className="fixed inset-0 z-50 flex items-end justify-center p-4 sm:items-center"
+    >
+      <div
+        className="absolute inset-0 bg-background/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative z-10 w-full max-w-sm rounded-2xl border border-border bg-surface p-5 shadow-[var(--shadow-card)]">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-foreground">Add notes</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-surface-muted hover:text-foreground"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={onUploadMd}
+            className="flex w-full items-start gap-3 rounded-xl border border-border bg-surface-muted/60 px-4 py-3 text-left transition hover:border-border-strong hover:bg-surface-muted"
+          >
+            <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface text-muted-foreground shadow-[inset_0_0_0_1px_var(--border)]">
+              <FileText className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-foreground">Upload .md file</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                Import a Markdown document directly
+              </span>
+            </span>
+          </button>
+
+          <button
+            type="button"
+            onClick={onGenerate}
+            className="flex w-full items-start gap-3 rounded-xl border border-border bg-surface-muted/60 px-4 py-3 text-left transition hover:border-border-strong hover:bg-surface-muted"
+          >
+            <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--accent)_20%,transparent)]">
+              <Sparkles className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-foreground">Generate from study material</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                Upload slides, PDFs, or images — AI writes the notes
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workspace
+// ---------------------------------------------------------------------------
 
 export function NotesWorkspace({
   initialNotes,
@@ -73,10 +196,9 @@ export function NotesWorkspace({
   const router = useRouter();
   const [notes, setNotes] = useState(() => sortWorkspaceNotes(initialNotes));
   const initialSelectedNote = initialClassId
-    ? (initialNotes.find((note) => note.classId === initialClassId) ??
-      initialNotes[0] ??
-      null)
+    ? (initialNotes.find((note) => note.classId === initialClassId) ?? initialNotes[0] ?? null)
     : (initialNotes[0] ?? null);
+
   const [selectedId, setSelectedId] = useState<string | null>(
     () => initialSelectedNote?.id ?? null,
   );
@@ -84,15 +206,33 @@ export function NotesWorkspace({
     noteId: initialSelectedNote?.id ?? null,
     value: initialSelectedNote?.title ?? "Untitled",
   }));
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<string | null>(null);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
   const [isPending, startTransition] = useTransition();
+
+  // Sidebar drag-and-drop state
+  const [draggedNoteId, setDraggedNoteId] = useState<string | null>(null);
+  const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null);
+
+  // Sidebar multi-select state
+  const [sidebarSelectedIds, setSidebarSelectedIds] = useState<Set<string>>(() => new Set());
+  const [lastSidebarSelectedId, setLastSidebarSelectedId] = useState<string | null>(null);
+  const [isBulkMoveOpen, setIsBulkMoveOpen] = useState(false);
+
+  // Sidebar note context menu
+  const [noteContextMenu, setNoteContextMenu] = useState<{
+    x: number;
+    y: number;
+    note: WorkspaceNote;
+  } | null>(null);
+
+  // Upload modal
+  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+
   const hasHandledCreateOnMountRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const mdFileInputRef = useRef<HTMLInputElement | null>(null);
   const selectedIdRef = useRef<string | null>(initialSelectedNote?.id ?? null);
+
   const classesById = useMemo(
     () => new Map(classes.map((item) => [item.id, item])),
     [classes],
@@ -101,22 +241,21 @@ export function NotesWorkspace({
     () => notes.find((note) => note.id === selectedId) ?? notes[0] ?? null,
     [notes, selectedId],
   );
-  const recentNotes = useMemo(
-    () => sortWorkspaceNotes(notes).slice(0, 8),
-    [notes],
-  );
+  const recentNotes = useMemo(() => sortWorkspaceNotes(notes).slice(0, 8), [notes]);
   const groupedNotes = useMemo(
     () => [
       ...classes.map((item) => ({
         id: item.id,
         title: getClassLabel(item),
-        classId: item.id,
+        shortTitle: getClassShortLabel(item),
+        classId: item.id as string | null,
         notes: notes.filter((note) => note.classId === item.id),
       })),
       {
         id: "unfiled",
         title: "Unfiled",
-        classId: null,
+        shortTitle: "Unfiled",
+        classId: null as string | null,
         notes: notes.filter((note) => !note.classId),
       },
     ],
@@ -132,25 +271,24 @@ export function NotesWorkspace({
     selectedIdRef.current = selectedNote?.id ?? null;
   }, [selectedNote?.id]);
 
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
   async function readNoteRecord(response: Response) {
     const payload = (await response.json().catch(() => null)) as
       | (NoteRecord & { error?: string })
       | { error?: string }
       | null;
-
     if (!response.ok) {
       throw new Error(payload?.error || "The notes request failed.");
     }
-
     return noteRecordToWorkspaceNote(payload as NoteRecord);
   }
 
   function mergeNote(nextNote: WorkspaceNote) {
     setNotes((current) =>
-      sortWorkspaceNotes([
-        nextNote,
-        ...current.filter((note) => note.id !== nextNote.id),
-      ]),
+      sortWorkspaceNotes([nextNote, ...current.filter((n) => n.id !== nextNote.id)]),
     );
   }
 
@@ -158,9 +296,7 @@ export function NotesWorkspace({
     setNotes((current) =>
       sortWorkspaceNotes([
         ...nextNotes,
-        ...current.filter(
-          (note) => !nextNotes.some((nextNote) => nextNote.id === note.id),
-        ),
+        ...current.filter((n) => !nextNotes.some((nn) => nn.id === n.id)),
       ]),
     );
   }
@@ -168,37 +304,30 @@ export function NotesWorkspace({
   function toggleGroup(groupId: string) {
     setCollapsedGroups((current) => {
       const next = new Set(current);
-      if (next.has(groupId)) {
-        next.delete(groupId);
-      } else {
-        next.add(groupId);
-      }
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
       return next;
     });
   }
 
   function selectNote(note: WorkspaceNote) {
-    setError(null);
-    setStatus(null);
     setSelectedId(note.id);
-    setTitleDraftState({
-      noteId: note.id,
-      value: note.title,
-    });
+    setTitleDraftState({ noteId: note.id, value: note.title });
   }
+
+  // -------------------------------------------------------------------------
+  // Save (guards temp IDs)
+  // -------------------------------------------------------------------------
 
   async function saveNote(
     noteId: string,
     patch: { title?: string; content?: NoteContent; classId?: string | null },
   ) {
-    setError(null);
-    setStatus("Saving note...");
+    if (isTempNote(noteId)) return; // creation pending — skip
 
     const response = await fetch(`/api/notes/${noteId}`, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         ...(patch.title !== undefined ? { title: patch.title } : {}),
         ...(patch.content ? { content: patch.content.document } : {}),
@@ -213,45 +342,54 @@ export function NotesWorkspace({
         ? { noteId: updatedNote.id, value: updatedNote.title }
         : current,
     );
-    if (selectedIdRef.current === updatedNote.id) {
-      setStatus(`Saved ${formatTimestamp(updatedNote.updatedAt)}`);
-    }
   }
 
+  // -------------------------------------------------------------------------
+  // Create (optimistic)
+  // -------------------------------------------------------------------------
+
   async function handleCreateNote(classId?: string | null, silent = false) {
-    setError(null);
-    setStatus("Creating a new note...");
+    const temp = createTempNote(classId ?? null);
 
-    const response = await fetch("/api/notes", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        title: "Untitled",
-        classId: classId ?? null,
-        content: {
-          ...emptyNoteDocument,
-          blocks: [],
-        },
-      }),
-    });
+    setNotes((current) => sortWorkspaceNotes([temp, ...current]));
+    setSelectedId(temp.id);
+    setTitleDraftState({ noteId: temp.id, value: "Untitled" });
 
-    const createdNote = await readNoteRecord(response);
-    mergeNote(createdNote);
-    setSelectedId(createdNote.id);
-    setTitleDraftState({
-      noteId: createdNote.id,
-      value: createdNote.title,
-    });
-    if (!silent && createdNote.classId) {
+    if (!silent && classId) {
       setCollapsedGroups((current) => {
         const next = new Set(current);
-        next.delete(createdNote.classId ?? "");
+        next.delete(classId);
         return next;
       });
     }
-    setStatus("New note created.");
+
+    try {
+      const response = await fetch("/api/notes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Untitled",
+          classId: classId ?? null,
+          content: { ...emptyNoteDocument, blocks: [] },
+        }),
+      });
+      const created = await readNoteRecord(response);
+      setNotes((current) =>
+        sortWorkspaceNotes([created, ...current.filter((n) => n.id !== temp.id)]),
+      );
+      setSelectedId((prev) => (prev === temp.id ? created.id : prev));
+      setTitleDraftState((prev) =>
+        prev.noteId === temp.id ? { noteId: created.id, value: created.title } : prev,
+      );
+      selectedIdRef.current = created.id;
+    } catch (err) {
+      setNotes((current) => current.filter((n) => n.id !== temp.id));
+      setSelectedId((prev) => (prev === temp.id ? null : prev));
+      toast.error("Could not create note", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
+    }
   }
 
   const createNoteFromCurrentFilter = useEffectEvent((silent: boolean) => {
@@ -259,158 +397,484 @@ export function NotesWorkspace({
   });
 
   useEffect(() => {
-    if (!shouldCreateOnMount || hasHandledCreateOnMountRef.current) {
-      return;
-    }
-
+    if (!shouldCreateOnMount || hasHandledCreateOnMountRef.current) return;
     hasHandledCreateOnMountRef.current = true;
     createNoteFromCurrentFilter(true);
     router.replace(resetHref);
   }, [resetHref, router, shouldCreateOnMount]);
 
+  // -------------------------------------------------------------------------
+  // Delete (optimistic, no dialog)
+  // -------------------------------------------------------------------------
+
   async function handleDeleteNote() {
-    if (!selectedNote) {
-      return;
+    if (!selectedNote || isTempNote(selectedNote.id)) return;
+
+    const noteToDelete = selectedNote;
+    const nextNote = notes.find((n) => n.id !== noteToDelete.id) ?? null;
+
+    setNotes((current) => current.filter((n) => n.id !== noteToDelete.id));
+    setSelectedId(nextNote?.id ?? null);
+
+    try {
+      const response = await fetch(`/api/notes/${noteToDelete.id}`, { method: "DELETE" });
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error || "Could not delete the note.");
+      }
+    } catch (err) {
+      setNotes((current) => sortWorkspaceNotes([noteToDelete, ...current]));
+      setSelectedId(noteToDelete.id);
+      toast.error("Could not delete note", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
     }
-
-    if (
-      !window.confirm(`Delete "${getRenderableTitle(selectedNote.title)}"?`)
-    ) {
-      return;
-    }
-
-    setError(null);
-    setStatus("Deleting note...");
-
-    const response = await fetch(`/api/notes/${selectedNote.id}`, {
-      method: "DELETE",
-    });
-    const payload = (await response.json().catch(() => null)) as {
-      error?: string;
-    } | null;
-
-    if (!response.ok) {
-      setError(payload?.error || "Could not delete the selected note.");
-      setStatus(null);
-      return;
-    }
-
-    setNotes((current) =>
-      current.filter((note) => note.id !== selectedNote.id),
-    );
-    setStatus("Note deleted.");
   }
 
-  async function handleUploadFile(file: File, classId?: string | null) {
-    setError(null);
-    setStatus(`Generating notes from ${file.name}...`);
+  // -------------------------------------------------------------------------
+  // Duplicate (optimistic)
+  // -------------------------------------------------------------------------
 
-    const formData = new FormData();
-    formData.set("file", file);
-    formData.set("title", file.name.replace(/\.[^.]+$/, "") || "Uploaded Note");
-    if (classId) {
-      formData.set("classId", classId);
-    }
+  async function handleDuplicateNote() {
+    if (!selectedNote || isTempNote(selectedNote.id)) return;
 
-    const response = await fetch("/api/notes/upload", {
-      method: "POST",
-      body: formData,
+    const source = selectedNote;
+    const temp = createTempNote(source.classId, {
+      title: `${source.title} (copy)`,
+      content: source.content,
     });
 
-    const payload = (await response.json().catch(() => null)) as {
-      notes?: NoteRecord[];
-      parsedTextLength?: number;
-      error?: string;
-    } | null;
+    setNotes((current) => sortWorkspaceNotes([temp, ...current]));
+    setSelectedId(temp.id);
+    setTitleDraftState({ noteId: temp.id, value: temp.title });
 
-    if (!response.ok) {
-      throw new Error(
-        payload?.error || "Could not generate notes from the uploaded file.",
+    try {
+      const response = await fetch("/api/notes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: temp.title,
+          classId: temp.classId,
+          content: source.content.document,
+        }),
+      });
+      const created = await readNoteRecord(response);
+      setNotes((current) =>
+        sortWorkspaceNotes([created, ...current.filter((n) => n.id !== temp.id)]),
       );
-    }
-
-    const createdNotes = (payload?.notes ?? []).map((record) =>
-      noteRecordToWorkspaceNote(record),
-    );
-    if (createdNotes.length === 0) {
-      throw new Error(
-        "The note generation pipeline completed without returning notes.",
+      setSelectedId((prev) => (prev === temp.id ? created.id : prev));
+      setTitleDraftState((prev) =>
+        prev.noteId === temp.id ? { noteId: created.id, value: created.title } : prev,
       );
+      selectedIdRef.current = created.id;
+    } catch (err) {
+      setNotes((current) => current.filter((n) => n.id !== temp.id));
+      setSelectedId(source.id);
+      toast.error("Could not duplicate note", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
     }
+  }
 
-    mergeNotes(createdNotes);
-    setSelectedId(createdNotes[0].id);
-    setStatus(
-      `Generated ${createdNotes.length} topic note${createdNotes.length === 1 ? "" : "s"} from ${file.name}.`,
-    );
+  // -------------------------------------------------------------------------
+  // File upload / import
+  // -------------------------------------------------------------------------
+
+  async function handleGenerateFromFile(file: File, classId?: string | null) {
+    const toastId = toast.loading(`Parsing ${file.name}…`, {
+      description: "This can take up to a minute for large files.",
+      duration: Infinity,
+    });
+
+    try {
+      const formData = new FormData();
+      formData.set("file", file);
+      formData.set("title", file.name.replace(/\.[^.]+$/, "") || "Uploaded Note");
+      if (classId) formData.set("classId", classId);
+
+      toast.loading("Generating notes with AI…", { id: toastId, description: undefined });
+
+      const response = await fetch("/api/notes/upload", { method: "POST", body: formData });
+      const payload = (await response.json().catch(() => null)) as {
+        notes?: NoteRecord[];
+        error?: string;
+      } | null;
+
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "Could not generate notes from the uploaded file.");
+      }
+
+      const created = (payload?.notes ?? []).map((r) => noteRecordToWorkspaceNote(r));
+      if (created.length === 0) throw new Error("No notes returned from generation pipeline.");
+
+      mergeNotes(created);
+      setSelectedId(created[0].id);
+
+      toast.success(
+        `Generated ${created.length} note${created.length === 1 ? "" : "s"}`,
+        { id: toastId, description: file.name, duration: 4000 },
+      );
+    } catch (err) {
+      toast.error("Generation failed", {
+        id: toastId,
+        description: err instanceof Error ? err.message : "Could not generate notes.",
+        duration: 6000,
+      });
+      throw err;
+    }
+  }
+
+  async function handleImportMdFile(file: File, classId?: string | null) {
+    const toastId = toast.loading(`Importing ${file.name}…`, { duration: Infinity });
+
+    try {
+      const text = await file.text();
+      const document = parseMarkdownToNoteDocument(text);
+      const title = file.name.replace(/\.md$/i, "").trim() || "Imported Note";
+
+      const response = await fetch("/api/notes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, classId: classId ?? null, content: document }),
+      });
+
+      const created = await readNoteRecord(response);
+      mergeNote(created);
+      setSelectedId(created.id);
+      setTitleDraftState({ noteId: created.id, value: created.title });
+      toast.success("Note imported", { id: toastId, description: title, duration: 3000 });
+    } catch (err) {
+      toast.error("Import failed", {
+        id: toastId,
+        description: err instanceof Error ? err.message : "Could not import the file.",
+        duration: 6000,
+      });
+      throw err;
+    }
   }
 
   async function handleTitleCommit() {
-    if (!selectedNote) {
-      return;
-    }
+    if (!selectedNote || isTempNote(selectedNote.id)) return;
 
     const nextTitle = draftTitle.trim() || "Untitled";
     if (nextTitle === getRenderableTitle(selectedNote.title)) {
-      if (selectedNote.title !== nextTitle) {
-        mergeNote({ ...selectedNote, title: nextTitle });
-      }
+      if (selectedNote.title !== nextTitle) mergeNote({ ...selectedNote, title: nextTitle });
       return;
     }
 
     try {
       await saveNote(selectedNote.id, { title: nextTitle });
     } catch (saveError) {
-      setError(
-        saveError instanceof Error
-          ? saveError.message
-          : "Could not update the note title.",
-      );
-      setStatus(null);
+      toast.error("Could not save title", {
+        description: saveError instanceof Error ? saveError.message : undefined,
+        duration: 5000,
+      });
     }
   }
 
-  const renderNoteItem = (
-    note: WorkspaceNote,
-    options?: { compact?: boolean },
-  ) => {
-    const isSelected = note.id === selectedNote?.id;
-    const linkedClass = note.classId
-      ? (classesById.get(note.classId) ?? null)
-      : null;
+  // -------------------------------------------------------------------------
+  // Sidebar drag-and-drop: move note to a different class
+  // -------------------------------------------------------------------------
+
+  function handleNoteDrop(groupClassId: string | null, noteId: string) {
+    const note = notes.find((n) => n.id === noteId);
+    if (!note || note.classId === groupClassId || isTempNote(noteId)) return;
+
+    setNotes((current) =>
+      current.map((n) => (n.id === noteId ? { ...n, classId: groupClassId } : n)),
+    );
+    startTransition(() =>
+      void saveNote(noteId, { classId: groupClassId }).catch((err) => {
+        toast.error("Could not move note", {
+          description: err instanceof Error ? err.message : undefined,
+          duration: 5000,
+        });
+      }),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Sidebar multi-select
+  // -------------------------------------------------------------------------
+
+  function toggleSidebarSelect(noteId: string) {
+    setSidebarSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(noteId)) next.delete(noteId);
+      else next.add(noteId);
+      return next;
+    });
+    setLastSidebarSelectedId(noteId);
+    setIsBulkMoveOpen(false);
+  }
+
+  function rangeSidebarSelect(fromId: string, toId: string) {
+    const sorted = sortWorkspaceNotes(notes);
+    const fromIdx = sorted.findIndex((n) => n.id === fromId);
+    const toIdx = sorted.findIndex((n) => n.id === toId);
+    if (fromIdx === -1 || toIdx === -1) return;
+    const [start, end] = fromIdx < toIdx ? [fromIdx, toIdx] : [toIdx, fromIdx];
+    setSidebarSelectedIds(new Set(sorted.slice(start, end + 1).map((n) => n.id)));
+    setLastSidebarSelectedId(toId);
+  }
+
+  function clearSidebarSelect() {
+    setSidebarSelectedIds(new Set());
+    setLastSidebarSelectedId(null);
+    setIsBulkMoveOpen(false);
+  }
+
+  async function handleBulkDelete() {
+    if (sidebarSelectedIds.size === 0) return;
+    const ids = [...sidebarSelectedIds];
+    const deleted = notes.filter((n) => ids.includes(n.id));
+
+    setNotes((current) => current.filter((n) => !ids.includes(n.id)));
+    if (selectedNote && ids.includes(selectedNote.id)) {
+      setSelectedId(notes.find((n) => !ids.includes(n.id))?.id ?? null);
+    }
+    clearSidebarSelect();
+
+    await Promise.allSettled(
+      ids.map((id) => !isTempNote(id) && fetch(`/api/notes/${id}`, { method: "DELETE" })),
+    );
+    // On partial failure we could restore, but for now just log
+  }
+
+  async function handleBulkDuplicate() {
+    if (sidebarSelectedIds.size === 0) return;
+    const sources = notes.filter((n) => sidebarSelectedIds.has(n.id) && !isTempNote(n.id));
+    if (sources.length === 0) return;
+
+    const temps = sources.map((source) =>
+      createTempNote(source.classId, {
+        title: `${source.title} (copy)`,
+        content: source.content,
+      }),
+    );
+
+    setNotes((current) => sortWorkspaceNotes([...temps, ...current]));
+    clearSidebarSelect();
+
+    await Promise.all(
+      sources.map(async (source, i) => {
+        const temp = temps[i]!;
+        try {
+          const response = await fetch("/api/notes", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              title: temp.title,
+              classId: temp.classId,
+              content: source.content.document,
+            }),
+          });
+          const created = await readNoteRecord(response);
+          setNotes((current) =>
+            sortWorkspaceNotes([created, ...current.filter((n) => n.id !== temp.id)]),
+          );
+        } catch {
+          setNotes((current) => current.filter((n) => n.id !== temp.id));
+        }
+      }),
+    );
+  }
+
+  function handleBulkMove(targetClassId: string | null) {
+    if (sidebarSelectedIds.size === 0) return;
+    const ids = [...sidebarSelectedIds];
+
+    setNotes((current) =>
+      current.map((n) => (ids.includes(n.id) ? { ...n, classId: targetClassId } : n)),
+    );
+    clearSidebarSelect();
+
+    for (const id of ids) {
+      if (!isTempNote(id)) {
+        void saveNote(id, { classId: targetClassId }).catch(console.error);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Note context menu actions (single-note, independent of selection)
+  // -------------------------------------------------------------------------
+
+  async function handleContextMenuDuplicate(source: WorkspaceNote) {
+    setNoteContextMenu(null);
+    const temp = createTempNote(source.classId, {
+      title: `${source.title} (copy)`,
+      content: source.content,
+    });
+    setNotes((current) => sortWorkspaceNotes([temp, ...current]));
+    setSelectedId(temp.id);
+    setTitleDraftState({ noteId: temp.id, value: temp.title });
+    try {
+      const response = await fetch("/api/notes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: temp.title,
+          classId: temp.classId,
+          content: source.content.document,
+        }),
+      });
+      const created = await readNoteRecord(response);
+      setNotes((current) =>
+        sortWorkspaceNotes([created, ...current.filter((n) => n.id !== temp.id)]),
+      );
+      setSelectedId((prev) => (prev === temp.id ? created.id : prev));
+      setTitleDraftState((prev) =>
+        prev.noteId === temp.id ? { noteId: created.id, value: created.title } : prev,
+      );
+      selectedIdRef.current = created.id;
+    } catch (err) {
+      setNotes((current) => current.filter((n) => n.id !== temp.id));
+      toast.error("Could not duplicate note", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
+    }
+  }
+
+  async function handleContextMenuDelete(target: WorkspaceNote) {
+    setNoteContextMenu(null);
+    if (isTempNote(target.id)) return;
+    const nextNote = notes.find((n) => n.id !== target.id) ?? null;
+    setNotes((current) => current.filter((n) => n.id !== target.id));
+    if (selectedNote?.id === target.id) setSelectedId(nextNote?.id ?? null);
+    try {
+      const response = await fetch(`/api/notes/${target.id}`, { method: "DELETE" });
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error || "Could not delete the note.");
+      }
+    } catch (err) {
+      setNotes((current) => sortWorkspaceNotes([target, ...current]));
+      toast.error("Could not delete note", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Note item renderer
+  // -------------------------------------------------------------------------
+
+  const renderNoteItem = (note: WorkspaceNote, options?: { compact?: boolean }) => {
+    const isOpen = note.id === selectedNote?.id;
+    const isSidebarSelected = sidebarSelectedIds.has(note.id);
+    const isTemp = isTempNote(note.id);
+    const linkedClass = note.classId ? (classesById.get(note.classId) ?? null) : null;
+    const hasSelection = sidebarSelectedIds.size > 0;
 
     return (
-      <button
+      <div
         key={note.id}
-        type="button"
-        onClick={() => selectNote(note)}
+        draggable={!isTemp}
+        onDragStart={(e) => {
+          setDraggedNoteId(note.id);
+          e.dataTransfer.effectAllowed = "move";
+        }}
+        onDragEnd={() => {
+          setDraggedNoteId(null);
+          setDragOverGroupId(null);
+        }}
+        onContextMenu={(e) => {
+          if (isTemp) return;
+          e.preventDefault();
+          const x = Math.min(e.clientX, window.innerWidth - 180);
+          const y = Math.min(e.clientY, window.innerHeight - 200);
+          setNoteContextMenu({ x, y, note });
+        }}
         className={cx(
-          "group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition",
-          isSelected
-            ? "bg-surface-elevated text-foreground"
-            : "text-muted-foreground hover:bg-surface hover:text-foreground",
+          "group relative flex items-center rounded-md transition",
+          isSidebarSelected && "bg-accent-soft",
+          draggedNoteId &&
+            (draggedNoteId === note.id ||
+              (sidebarSelectedIds.has(draggedNoteId) && sidebarSelectedIds.has(note.id))) &&
+            "opacity-40",
         )}
       >
-        <FileText className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
-        <span className="min-w-0 flex-1 truncate font-medium">
-          {getRenderableTitle(note.title)}
-        </span>
-        {options?.compact ? null : (
-          <span className="shrink-0 text-[11px] text-muted-foreground">
-            {formatTimestamp(note.updatedAt)}
+        {/* Selection checkbox */}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleSidebarSelect(note.id);
+          }}
+          className={cx(
+            "flex h-7 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:text-foreground",
+            hasSelection || isSidebarSelected ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+          )}
+          aria-label={isSidebarSelected ? "Deselect note" : "Select note"}
+          tabIndex={-1}
+        >
+          {isSidebarSelected ? (
+            <CheckSquare className="h-3.5 w-3.5 text-accent" aria-hidden="true" />
+          ) : (
+            <Square className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+        </button>
+
+        {/* Main tap area */}
+        <button
+          type="button"
+          disabled={isTemp}
+          onClick={(e) => {
+            if (e.metaKey || e.ctrlKey) {
+              toggleSidebarSelect(note.id);
+              return;
+            }
+            if (e.shiftKey && lastSidebarSelectedId) {
+              rangeSidebarSelect(lastSidebarSelectedId, note.id);
+              return;
+            }
+            clearSidebarSelect();
+            selectNote(note);
+          }}
+          className={cx(
+            "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition",
+            isOpen && !isSidebarSelected
+              ? "bg-surface-elevated text-foreground"
+              : isSidebarSelected
+                ? "text-accent"
+                : "text-muted-foreground hover:bg-surface hover:text-foreground",
+            isTemp && "animate-pulse opacity-60",
+          )}
+        >
+          <FileText className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+          <span className="min-w-0 flex-1 truncate font-medium">
+            {getRenderableTitle(note.title)}
           </span>
-        )}
-        {options?.compact && linkedClass ? (
-          <span className="max-w-20 shrink-0 truncate text-[11px] text-muted-foreground">
-            {getClassLabel(linkedClass)}
-          </span>
-        ) : null}
-      </button>
+          {options?.compact ? null : (
+            <span className="shrink-0 text-[11px] text-muted-foreground">
+              {formatTimestamp(note.updatedAt)}
+            </span>
+          )}
+          {options?.compact && linkedClass ? (
+            <span
+              title={getClassLabel(linkedClass)}
+              className="max-w-24 shrink-0 truncate text-[11px] text-muted-foreground"
+            >
+              {getClassShortLabel(linkedClass)}
+            </span>
+          ) : null}
+        </button>
+      </div>
     );
   };
 
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
   return (
     <div className="h-full min-h-0 overflow-hidden bg-surface">
+      {/* Hidden file input — AI generation */}
       <input
         ref={fileInputRef}
         type="file"
@@ -419,27 +883,54 @@ export function NotesWorkspace({
         onChange={(event) => {
           const file = event.currentTarget.files?.[0];
           event.currentTarget.value = "";
-          if (!file) {
-            return;
-          }
+          if (!file) return;
           startTransition(() => {
-            void handleUploadFile(
-              file,
-              selectedNote?.classId ?? fallbackClassId,
-            ).catch((uploadError) => {
-              setError(
-                uploadError instanceof Error
-                  ? uploadError.message
-                  : "Could not generate notes from the uploaded file.",
-              );
-              setStatus(null);
-            });
+            void handleGenerateFromFile(file, selectedNote?.classId ?? fallbackClassId).catch(
+              () => { /* toast already shown inside handler */ },
+            );
           });
         }}
       />
 
+      {/* Hidden file input — .md import */}
+      <input
+        ref={mdFileInputRef}
+        type="file"
+        accept=".md,text/markdown"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          event.currentTarget.value = "";
+          if (!file) return;
+          startTransition(() => {
+            void handleImportMdFile(file, selectedNote?.classId ?? fallbackClassId).catch(
+              () => { /* toast already shown inside handler */ },
+            );
+          });
+        }}
+      />
+
+      {/* Upload / Generate modal */}
+      {isUploadModalOpen ? (
+        <UploadModal
+          onClose={() => setIsUploadModalOpen(false)}
+          onUploadMd={() => {
+            setIsUploadModalOpen(false);
+            mdFileInputRef.current?.click();
+          }}
+          onGenerate={() => {
+            setIsUploadModalOpen(false);
+            fileInputRef.current?.click();
+          }}
+        />
+      ) : null}
+
       <div className="grid h-full min-h-0 lg:grid-cols-[292px_minmax(0,1fr)]">
+        {/* ---------------------------------------------------------------- */}
+        {/* Sidebar                                                           */}
+        {/* ---------------------------------------------------------------- */}
         <aside className="flex h-full min-h-0 flex-col border-b border-border bg-surface-muted/70 lg:border-b-0 lg:border-r">
+          {/* Toolbar */}
           <div className="flex h-12 items-center gap-2 border-b border-border px-3">
             <button
               type="button"
@@ -452,30 +943,85 @@ export function NotesWorkspace({
               <Plus className="h-4 w-4 shrink-0" aria-hidden="true" />
               <span className="truncate">New page</span>
             </button>
+            <button
+              type="button"
+              onClick={() => setIsUploadModalOpen(true)}
+              disabled={isPending}
+              title="Import or generate notes"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-surface hover:text-foreground disabled:opacity-60"
+              aria-label="Import or generate notes"
+            >
+              <Upload className="h-4 w-4" aria-hidden="true" />
+            </button>
           </div>
 
+          {/* Note list */}
           <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 py-3">
             {recentNotes.length > 0 ? (
               <section className="mb-5">
-                <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">
-                  Recents
-                </div>
+                <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">Recents</div>
                 <div className="space-y-0.5">
-                  {recentNotes.map((note) =>
-                    renderNoteItem(note, { compact: true }),
-                  )}
+                  {recentNotes.map((note) => renderNoteItem(note, { compact: true }))}
                 </div>
               </section>
             ) : null}
 
             <section className="space-y-1">
-              <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">
-                Private
-              </div>
+              <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">Private</div>
               {groupedNotes.map((group) => {
                 const isCollapsed = collapsedGroups.has(group.id);
+                const isDragTarget = dragOverGroupId === group.id && draggedNoteId !== null;
+                const draggedNote = draggedNoteId
+                  ? notes.find((n) => n.id === draggedNoteId)
+                  : null;
+                // When dragging a selected note, at least one selected note must
+                // differ from this group's class for the drop to be meaningful.
+                const canDrop = draggedNote && (() => {
+                  const id = draggedNoteId!;
+                  if (sidebarSelectedIds.has(id) && sidebarSelectedIds.size > 1) {
+                    return notes.some((n) => sidebarSelectedIds.has(n.id) && n.classId !== group.classId);
+                  }
+                  return draggedNote.classId !== group.classId;
+                })();
+
                 return (
-                  <div key={group.id}>
+                  <div
+                    key={group.id}
+                    onDragOver={(e) => {
+                      if (!canDrop) return;
+                      e.preventDefault();
+                      e.dataTransfer.dropEffect = "move";
+                      setDragOverGroupId(group.id);
+                    }}
+                    onDragEnter={(e) => {
+                      if (!canDrop) return;
+                      e.preventDefault();
+                      setDragOverGroupId(group.id);
+                    }}
+                    onDragLeave={(e) => {
+                      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                        setDragOverGroupId(null);
+                      }
+                    }}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      setDragOverGroupId(null);
+                      if (draggedNoteId && canDrop) {
+                        // If the dragged note is part of the sidebar selection,
+                        // move all selected notes. Otherwise just move the one.
+                        if (sidebarSelectedIds.has(draggedNoteId) && sidebarSelectedIds.size > 1) {
+                          handleBulkMove(group.classId);
+                        } else {
+                          handleNoteDrop(group.classId, draggedNoteId);
+                        }
+                      }
+                      setDraggedNoteId(null);
+                    }}
+                    className={cx(
+                      "rounded-lg transition-colors",
+                      isDragTarget && canDrop ? "bg-accent-soft ring-1 ring-accent/30" : "",
+                    )}
+                  >
                     <div className="group flex items-center gap-1 rounded-md text-muted-foreground hover:bg-surface hover:text-foreground">
                       <button
                         type="button"
@@ -484,15 +1030,9 @@ export function NotesWorkspace({
                         aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group.title}`}
                       >
                         {isCollapsed ? (
-                          <ChevronRight
-                            className="h-3.5 w-3.5"
-                            aria-hidden="true"
-                          />
+                          <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
                         ) : (
-                          <ChevronDown
-                            className="h-3.5 w-3.5"
-                            aria-hidden="true"
-                          />
+                          <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
                         )}
                       </button>
                       <button
@@ -500,11 +1040,10 @@ export function NotesWorkspace({
                         onClick={() => toggleGroup(group.id)}
                         className="flex min-w-0 flex-1 items-center gap-2 py-1.5 text-left text-sm font-medium"
                       >
-                        <Folder
-                          className="h-4 w-4 shrink-0 opacity-70"
-                          aria-hidden="true"
-                        />
-                        <span className="truncate">{group.title}</span>
+                        <Folder className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+                        <span className="truncate" title={group.title}>
+                          {group.shortTitle}
+                        </span>
                         <span className="ml-auto pr-1 text-[11px] text-muted-foreground">
                           {group.notes.length}
                         </span>
@@ -512,9 +1051,7 @@ export function NotesWorkspace({
                       <button
                         type="button"
                         onClick={() =>
-                          startTransition(
-                            () => void handleCreateNote(group.classId),
-                          )
+                          startTransition(() => void handleCreateNote(group.classId))
                         }
                         disabled={isPending}
                         className="mr-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md opacity-0 hover:bg-surface-elevated group-hover:opacity-100 disabled:opacity-40"
@@ -523,9 +1060,16 @@ export function NotesWorkspace({
                         <Plus className="h-3.5 w-3.5" aria-hidden="true" />
                       </button>
                     </div>
+
                     {!isCollapsed && group.notes.length > 0 ? (
-                      <div className="ml-5 space-y-0.5 border-l border-border/70 pl-1.5">
+                      <div className="ml-3 space-y-0.5 border-l border-border/70 pl-1">
                         {group.notes.map((note) => renderNoteItem(note))}
+                      </div>
+                    ) : null}
+
+                    {isDragTarget && canDrop ? (
+                      <div className="mx-2 mb-1 rounded-md border border-dashed border-accent/50 bg-accent/5 px-2 py-1.5 text-center text-xs text-accent">
+                        Drop to move here
                       </div>
                     ) : null}
                   </div>
@@ -533,8 +1077,94 @@ export function NotesWorkspace({
               })}
             </section>
           </div>
+
+          {/* Bulk selection action bar */}
+          {sidebarSelectedIds.size > 0 ? (
+            <div className="border-t border-border p-2">
+              <div className="mb-2 flex items-center justify-between px-1">
+                <span className="text-xs font-medium text-foreground">
+                  {sidebarSelectedIds.size} selected
+                </span>
+                <button
+                  type="button"
+                  onClick={clearSidebarSelect}
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                >
+                  Clear
+                </button>
+              </div>
+
+              <div className="space-y-0.5">
+                {/* Move to */}
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setIsBulkMoveOpen((v) => !v)}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-surface hover:text-foreground"
+                  >
+                    <FolderInput className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    Move to…
+                    <ChevronDown
+                      className={cx(
+                        "ml-auto h-3 w-3 transition-transform",
+                        isBulkMoveOpen && "rotate-180",
+                      )}
+                      aria-hidden="true"
+                    />
+                  </button>
+                  {isBulkMoveOpen ? (
+                    <div className="absolute bottom-full left-0 mb-1 w-full overflow-hidden rounded-lg border border-border bg-surface p-1 shadow-[var(--shadow-card)]">
+                      <button
+                        type="button"
+                        onClick={() => handleBulkMove(null)}
+                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-surface-muted hover:text-foreground"
+                      >
+                        <Folder className="h-3.5 w-3.5 shrink-0 opacity-60" aria-hidden="true" />
+                        Unfiled
+                      </button>
+                      {classes.map((cls) => (
+                        <button
+                          key={cls.id}
+                          type="button"
+                          onClick={() => handleBulkMove(cls.id)}
+                          title={getClassLabel(cls)}
+                          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-surface-muted hover:text-foreground"
+                        >
+                          <Folder className="h-3.5 w-3.5 shrink-0 opacity-60" aria-hidden="true" />
+                          <span className="truncate">{getClassShortLabel(cls)}</span>
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => void handleBulkDuplicate()}
+                  disabled={isPending}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-surface hover:text-foreground disabled:opacity-50"
+                >
+                  <Copy className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  Duplicate
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => void handleBulkDelete()}
+                  disabled={isPending}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-danger hover:bg-danger-soft disabled:opacity-50"
+                >
+                  <Trash2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  Delete
+                </button>
+              </div>
+            </div>
+          ) : null}
         </aside>
 
+        {/* ---------------------------------------------------------------- */}
+        {/* Editor area                                                        */}
+        {/* ---------------------------------------------------------------- */}
         <section className="h-full min-h-0 bg-background">
           {selectedNote ? (
             <div className="flex h-full min-h-0 flex-col">
@@ -546,71 +1176,40 @@ export function NotesWorkspace({
                   </span>
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
-                  <div className="pr-1">
-                    {status ? (
-                      <span className="hidden text-xs text-muted-foreground md:inline">
-                        {status}
-                      </span>
-                    ) : null}
-                    {error ? (
-                      <span className="hidden text-xs text-danger md:inline">
-                        {error}
-                      </span>
-                    ) : null}
-                  </div>
-
-                  <Select
-                    aria-label="Select class"
-                    value={selectedNote.classId ?? ""}
-                    onChange={(event) => {
-                      const nextClassId = event.currentTarget.value || null;
-                      setNotes((current) =>
-                        current.map((note) =>
-                          note.id === selectedNote.id
-                            ? { ...note, classId: nextClassId }
-                            : note,
-                        ),
-                      );
-                      startTransition(
-                        () =>
-                          void saveNote(selectedNote.id, {
-                            classId: nextClassId,
-                          }),
-                      );
-                    }}
-                    className="h-8 w-36 border-transparent bg-transparent px-2 py-1 text-xs text-muted-foreground shadow-none hover:bg-surface-muted focus:border-border focus-visible:ring-0 md:w-44"
-                  >
-                    <option value="">No class</option>
-                    {classes.map((item) => (
-                      <option key={item.id} value={item.id}>
-                        {getClassLabel(item)}
-                      </option>
-                    ))}
-                  </Select>
                   <button
                     type="button"
-                    onClick={() => fileInputRef.current?.click()}
+                    onClick={() => setIsUploadModalOpen(true)}
                     disabled={isPending}
                     className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-surface-muted hover:text-foreground disabled:opacity-60"
-                    aria-label="Import file"
+                    aria-label="Import or generate notes"
+                    title="Import or generate notes"
                   >
                     <Upload className="h-4 w-4" aria-hidden="true" />
                   </button>
                   <button
                     type="button"
-                    onClick={() =>
-                      startTransition(() => void handleDeleteNote())
-                    }
-                    disabled={isPending}
+                    onClick={() => void handleDuplicateNote()}
+                    disabled={isPending || isTempNote(selectedNote.id)}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-surface-muted hover:text-foreground disabled:opacity-60"
+                    aria-label="Duplicate note"
+                    title="Duplicate note"
+                  >
+                    <Copy className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleDeleteNote()}
+                    disabled={isPending || isTempNote(selectedNote.id)}
                     className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-danger-soft hover:text-danger disabled:opacity-60"
                     aria-label="Delete note"
+                    title="Delete note"
                   >
                     <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </button>
                 </div>
               </div>
 
-              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pt-0">
+              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
                 <NoteSurface
                   initialDocument={selectedNote.content.document}
                   keepEditingWhenEmpty
@@ -621,23 +1220,16 @@ export function NotesWorkspace({
                         value={draftTitle}
                         onChange={(event) => {
                           const nextTitle = event.currentTarget.value;
-                          setTitleDraftState({
-                            noteId: selectedNote.id,
-                            value: nextTitle,
-                          });
+                          setTitleDraftState({ noteId: selectedNote.id, value: nextTitle });
                           setNotes((current) =>
-                            current.map((note) =>
-                              note.id === selectedNote.id
-                                ? { ...note, title: nextTitle }
-                                : note,
+                            current.map((n) =>
+                              n.id === selectedNote.id ? { ...n, title: nextTitle } : n,
                             ),
                           );
                         }}
                         onBlur={() => void handleTitleCommit()}
                         onKeyDown={(event) => {
-                          if (event.key === "Enter") {
-                            event.currentTarget.blur();
-                          }
+                          if (event.key === "Enter") event.currentTarget.blur();
                         }}
                         className="w-full border-none bg-transparent p-0 text-4xl font-semibold tracking-tight text-foreground outline-none placeholder:text-muted-foreground/50"
                         placeholder="Untitled"
@@ -645,9 +1237,7 @@ export function NotesWorkspace({
                       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                         <span>{formatTimestamp(selectedNote.updatedAt)}</span>
                         {selectedNote.fileName ? (
-                          <span className="truncate">
-                            {selectedNote.fileName}
-                          </span>
+                          <span className="truncate">{selectedNote.fileName}</span>
                         ) : null}
                       </div>
                     </div>
@@ -659,12 +1249,11 @@ export function NotesWorkspace({
                         content: nextContent,
                       });
                     } catch (saveError) {
-                      setError(
-                        saveError instanceof Error
-                          ? saveError.message
-                          : "Could not save note changes.",
-                      );
-                      setStatus(null);
+                      toast.error("Could not save note", {
+                        description:
+                          saveError instanceof Error ? saveError.message : undefined,
+                        duration: 5000,
+                      });
                     }
                   }}
                 />
@@ -676,9 +1265,7 @@ export function NotesWorkspace({
                 <Button
                   type="button"
                   onClick={() =>
-                    startTransition(
-                      () => void handleCreateNote(fallbackClassId),
-                    )
+                    startTransition(() => void handleCreateNote(fallbackClassId))
                   }
                   disabled={isPending}
                 >
@@ -687,7 +1274,7 @@ export function NotesWorkspace({
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={() => fileInputRef.current?.click()}
+                  onClick={() => setIsUploadModalOpen(true)}
                   disabled={isPending}
                 >
                   Import
@@ -697,6 +1284,47 @@ export function NotesWorkspace({
           )}
         </section>
       </div>
+
+      {/* Sidebar note context menu */}
+      {noteContextMenu && (
+        <>
+          {/* backdrop */}
+          <div
+            className="fixed inset-0 z-40"
+            onMouseDown={() => setNoteContextMenu(null)}
+          />
+          <div
+            className="fixed z-50 min-w-[160px] overflow-hidden rounded-lg border border-border bg-surface-elevated py-1 shadow-lg"
+            style={{ left: noteContextMenu.x, top: noteContextMenu.y }}
+          >
+            <button
+              type="button"
+              className="w-full px-3 py-1.5 text-left text-sm text-foreground hover:bg-surface"
+              onClick={() => {
+                selectNote(noteContextMenu.note);
+                setNoteContextMenu(null);
+              }}
+            >
+              Open
+            </button>
+            <button
+              type="button"
+              className="w-full px-3 py-1.5 text-left text-sm text-foreground hover:bg-surface"
+              onClick={() => void handleContextMenuDuplicate(noteContextMenu.note)}
+            >
+              Duplicate
+            </button>
+            <div className="my-1 h-px bg-border" />
+            <button
+              type="button"
+              className="w-full px-3 py-1.5 text-left text-sm text-red-400 hover:bg-surface"
+              onClick={() => void handleContextMenuDelete(noteContextMenu.note)}
+            >
+              Delete
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/app/notes/notes-workspace.tsx
+++ b/app/notes/notes-workspace.tsx
@@ -708,7 +708,6 @@ export function NotesWorkspace({
   async function handleBulkDelete() {
     if (sidebarSelectedIds.size === 0) return;
     const ids = [...sidebarSelectedIds];
-    const deleted = notes.filter((n) => ids.includes(n.id));
 
     setNotes((current) => current.filter((n) => !ids.includes(n.id)));
     if (selectedNote && ids.includes(selectedNote.id)) {

--- a/app/notes/notes-workspace.tsx
+++ b/app/notes/notes-workspace.tsx
@@ -1,20 +1,30 @@
 "use client";
 
-import { useEffect, useEffectEvent, useMemo, useRef, useState, useTransition } from "react";
-import Link from "next/link";
+import {
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { useRouter } from "next/navigation";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  Plus,
+  Trash2,
+  Upload,
+} from "lucide-react";
 import { NoteSurface } from "@/components/note-editor/note-surface";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { EmptyState } from "@/components/ui/empty-state";
-import { PageHeader } from "@/components/ui/page-header";
 import { Select } from "@/components/ui/input";
 import { cx } from "@/lib/utils";
 import {
   noteRecordToWorkspaceNote,
   sortWorkspaceNotes,
-  type NoteGenerationMetadata,
   type NoteRecord,
   type WorkspaceNote,
 } from "@/lib/notes/records";
@@ -36,60 +46,21 @@ type NotesWorkspaceProps = {
   resetHref: string;
 };
 
-type GenerationResult = {
-  fileName: string;
-  parsedTextLength: number;
-  topics: Array<{
-    noteId: string;
-    title: string;
-    markdown: string;
-    embedding: number[];
-  }>;
-};
-
 const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  dateStyle: "medium",
-  timeStyle: "short",
+  month: "short",
+  day: "numeric",
 });
 
 function formatTimestamp(value: string) {
   return TIMESTAMP_FORMATTER.format(new Date(value));
 }
 
-function formatFileSize(value: number | null) {
-  if (!value) {
-    return null;
-  }
-
-  if (value < 1024 * 1024) {
-    return `${Math.max(1, Math.round(value / 1024))} KB`;
-  }
-
-  return `${(value / 1024 / 1024).toFixed(1)} MB`;
-}
-
 function getRenderableTitle(value: string) {
   return value.trim() || "Untitled";
 }
 
-function getClassFilterId(selectedFilter: string) {
-  if (selectedFilter === "all" || selectedFilter === "unfiled") {
-    return null;
-  }
-
-  return selectedFilter;
-}
-
-function formatVectorPreview(values: number[]) {
-  return values.slice(0, 8).map((value) => value.toFixed(4)).join(", ");
-}
-
-function getVectorMagnitude(values: number[]) {
-  return Math.sqrt(values.reduce((sum, value) => sum + value * value, 0));
-}
-
-function formatFullVector(values: number[]) {
-  return `[${values.map((value) => Number(value.toFixed(8))).join(", ")}]`;
+function getClassLabel(item: WorkspaceClass) {
+  return item.courseCode ? `${item.courseCode} ${item.title}` : item.title;
 }
 
 export function NotesWorkspace({
@@ -101,38 +72,65 @@ export function NotesWorkspace({
 }: NotesWorkspaceProps) {
   const router = useRouter();
   const [notes, setNotes] = useState(() => sortWorkspaceNotes(initialNotes));
-  const [selectedFilter, setSelectedFilter] = useState(() => initialClassId ?? "all");
-  const [selectedId, setSelectedId] = useState<string | null>(() => initialNotes[0]?.id ?? null);
+  const initialSelectedNote = initialClassId
+    ? (initialNotes.find((note) => note.classId === initialClassId) ??
+      initialNotes[0] ??
+      null)
+    : (initialNotes[0] ?? null);
+  const [selectedId, setSelectedId] = useState<string | null>(
+    () => initialSelectedNote?.id ?? null,
+  );
   const [titleDraftState, setTitleDraftState] = useState(() => ({
-    noteId: initialNotes[0]?.id ?? null,
-    value: initialNotes[0]?.title ?? "Untitled",
+    noteId: initialSelectedNote?.id ?? null,
+    value: initialSelectedNote?.title ?? "Untitled",
   }));
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
-  const [generationResult, setGenerationResult] = useState<GenerationResult | null>(null);
   const [isPending, startTransition] = useTransition();
   const hasHandledCreateOnMountRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const classesById = useMemo(() => new Map(classes.map((item) => [item.id, item])), [classes]);
-  const filteredNotes = useMemo(() => {
-    if (selectedFilter === "all") {
-      return notes;
-    }
-
-    if (selectedFilter === "unfiled") {
-      return notes.filter((note) => !note.classId);
-    }
-
-    return notes.filter((note) => note.classId === selectedFilter);
-  }, [notes, selectedFilter]);
+  const selectedIdRef = useRef<string | null>(initialSelectedNote?.id ?? null);
+  const classesById = useMemo(
+    () => new Map(classes.map((item) => [item.id, item])),
+    [classes],
+  );
   const selectedNote = useMemo(
-    () => filteredNotes.find((note) => note.id === selectedId) ?? filteredNotes[0] ?? null,
-    [filteredNotes, selectedId],
+    () => notes.find((note) => note.id === selectedId) ?? notes[0] ?? null,
+    [notes, selectedId],
+  );
+  const recentNotes = useMemo(
+    () => sortWorkspaceNotes(notes).slice(0, 8),
+    [notes],
+  );
+  const groupedNotes = useMemo(
+    () => [
+      ...classes.map((item) => ({
+        id: item.id,
+        title: getClassLabel(item),
+        classId: item.id,
+        notes: notes.filter((note) => note.classId === item.id),
+      })),
+      {
+        id: "unfiled",
+        title: "Unfiled",
+        classId: null,
+        notes: notes.filter((note) => !note.classId),
+      },
+    ],
+    [classes, notes],
   );
   const draftTitle =
     selectedNote && titleDraftState.noteId === selectedNote.id
       ? titleDraftState.value
       : (selectedNote?.title ?? "Untitled");
+  const fallbackClassId = initialClassId ?? selectedNote?.classId ?? null;
+
+  useEffect(() => {
+    selectedIdRef.current = selectedNote?.id ?? null;
+  }, [selectedNote?.id]);
 
   async function readNoteRecord(response: Response) {
     const payload = (await response.json().catch(() => null)) as
@@ -149,7 +147,10 @@ export function NotesWorkspace({
 
   function mergeNote(nextNote: WorkspaceNote) {
     setNotes((current) =>
-      sortWorkspaceNotes([nextNote, ...current.filter((note) => note.id !== nextNote.id)]),
+      sortWorkspaceNotes([
+        nextNote,
+        ...current.filter((note) => note.id !== nextNote.id),
+      ]),
     );
   }
 
@@ -157,9 +158,33 @@ export function NotesWorkspace({
     setNotes((current) =>
       sortWorkspaceNotes([
         ...nextNotes,
-        ...current.filter((note) => !nextNotes.some((nextNote) => nextNote.id === note.id)),
+        ...current.filter(
+          (note) => !nextNotes.some((nextNote) => nextNote.id === note.id),
+        ),
       ]),
     );
+  }
+
+  function toggleGroup(groupId: string) {
+    setCollapsedGroups((current) => {
+      const next = new Set(current);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
+  }
+
+  function selectNote(note: WorkspaceNote) {
+    setError(null);
+    setStatus(null);
+    setSelectedId(note.id);
+    setTitleDraftState({
+      noteId: note.id,
+      value: note.title,
+    });
   }
 
   async function saveNote(
@@ -184,15 +209,18 @@ export function NotesWorkspace({
     const updatedNote = await readNoteRecord(response);
     mergeNote(updatedNote);
     setTitleDraftState((current) =>
-      current.noteId === updatedNote.id ? { noteId: updatedNote.id, value: updatedNote.title } : current,
+      current.noteId === updatedNote.id
+        ? { noteId: updatedNote.id, value: updatedNote.title }
+        : current,
     );
-    setStatus(`Saved ${formatTimestamp(updatedNote.updatedAt)}`);
+    if (selectedIdRef.current === updatedNote.id) {
+      setStatus(`Saved ${formatTimestamp(updatedNote.updatedAt)}`);
+    }
   }
 
   async function handleCreateNote(classId?: string | null, silent = false) {
     setError(null);
     setStatus("Creating a new note...");
-    setGenerationResult(null);
 
     const response = await fetch("/api/notes", {
       method: "POST",
@@ -217,13 +245,17 @@ export function NotesWorkspace({
       value: createdNote.title,
     });
     if (!silent && createdNote.classId) {
-      setSelectedFilter(createdNote.classId);
+      setCollapsedGroups((current) => {
+        const next = new Set(current);
+        next.delete(createdNote.classId ?? "");
+        return next;
+      });
     }
     setStatus("New note created.");
   }
 
   const createNoteFromCurrentFilter = useEffectEvent((silent: boolean) => {
-    startTransition(() => void handleCreateNote(getClassFilterId(selectedFilter), silent));
+    startTransition(() => void handleCreateNote(fallbackClassId, silent));
   });
 
   useEffect(() => {
@@ -241,18 +273,21 @@ export function NotesWorkspace({
       return;
     }
 
-    if (!window.confirm(`Delete "${getRenderableTitle(selectedNote.title)}"?`)) {
+    if (
+      !window.confirm(`Delete "${getRenderableTitle(selectedNote.title)}"?`)
+    ) {
       return;
     }
 
     setError(null);
     setStatus("Deleting note...");
-    setGenerationResult(null);
 
     const response = await fetch(`/api/notes/${selectedNote.id}`, {
       method: "DELETE",
     });
-    const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+    const payload = (await response.json().catch(() => null)) as {
+      error?: string;
+    } | null;
 
     if (!response.ok) {
       setError(payload?.error || "Could not delete the selected note.");
@@ -260,13 +295,14 @@ export function NotesWorkspace({
       return;
     }
 
-    setNotes((current) => current.filter((note) => note.id !== selectedNote.id));
+    setNotes((current) =>
+      current.filter((note) => note.id !== selectedNote.id),
+    );
     setStatus("Note deleted.");
   }
 
   async function handleUploadFile(file: File, classId?: string | null) {
     setError(null);
-    setGenerationResult(null);
     setStatus(`Generating notes from ${file.name}...`);
 
     const formData = new FormData();
@@ -281,42 +317,32 @@ export function NotesWorkspace({
       body: formData,
     });
 
-    const payload = (await response.json().catch(() => null)) as
-      | {
-          notes?: NoteRecord[];
-          parsedTextLength?: number;
-          topics?: Array<{
-            noteId?: string;
-            title?: string;
-            markdown?: string;
-            embedding?: number[];
-          }>;
-          error?: string;
-        }
-      | null;
+    const payload = (await response.json().catch(() => null)) as {
+      notes?: NoteRecord[];
+      parsedTextLength?: number;
+      error?: string;
+    } | null;
 
     if (!response.ok) {
-      throw new Error(payload?.error || "Could not generate notes from the uploaded file.");
+      throw new Error(
+        payload?.error || "Could not generate notes from the uploaded file.",
+      );
     }
 
-    const createdNotes = (payload?.notes ?? []).map((record) => noteRecordToWorkspaceNote(record));
+    const createdNotes = (payload?.notes ?? []).map((record) =>
+      noteRecordToWorkspaceNote(record),
+    );
     if (createdNotes.length === 0) {
-      throw new Error("The note generation pipeline completed without returning notes.");
+      throw new Error(
+        "The note generation pipeline completed without returning notes.",
+      );
     }
 
     mergeNotes(createdNotes);
     setSelectedId(createdNotes[0].id);
-    setGenerationResult({
-      fileName: file.name,
-      parsedTextLength: payload?.parsedTextLength ?? 0,
-      topics: (payload?.topics ?? []).map((topic, index) => ({
-        noteId: topic.noteId || createdNotes[index]?.id || "",
-        title: topic.title || createdNotes[index]?.title || "Generated Topic",
-        markdown: topic.markdown || createdNotes[index]?.content.markdown || "",
-        embedding: Array.isArray(topic.embedding) ? topic.embedding : [],
-      })),
-    });
-    setStatus(`Generated ${createdNotes.length} topic note${createdNotes.length === 1 ? "" : "s"} from ${file.name}.`);
+    setStatus(
+      `Generated ${createdNotes.length} topic note${createdNotes.length === 1 ? "" : "s"} from ${file.name}.`,
+    );
   }
 
   async function handleTitleCommit() {
@@ -335,284 +361,297 @@ export function NotesWorkspace({
     try {
       await saveNote(selectedNote.id, { title: nextTitle });
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : "Could not update the note title.");
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : "Could not update the note title.",
+      );
       setStatus(null);
     }
   }
 
+  const renderNoteItem = (
+    note: WorkspaceNote,
+    options?: { compact?: boolean },
+  ) => {
+    const isSelected = note.id === selectedNote?.id;
+    const linkedClass = note.classId
+      ? (classesById.get(note.classId) ?? null)
+      : null;
+
+    return (
+      <button
+        key={note.id}
+        type="button"
+        onClick={() => selectNote(note)}
+        className={cx(
+          "group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition",
+          isSelected
+            ? "bg-surface-elevated text-foreground"
+            : "text-muted-foreground hover:bg-surface hover:text-foreground",
+        )}
+      >
+        <FileText className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+        <span className="min-w-0 flex-1 truncate font-medium">
+          {getRenderableTitle(note.title)}
+        </span>
+        {options?.compact ? null : (
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            {formatTimestamp(note.updatedAt)}
+          </span>
+        )}
+        {options?.compact && linkedClass ? (
+          <span className="max-w-20 shrink-0 truncate text-[11px] text-muted-foreground">
+            {getClassLabel(linkedClass)}
+          </span>
+        ) : null}
+      </button>
+    );
+  };
+
   return (
-    <div className="space-y-6">
-      <PageHeader
-        eyebrow="Connected workspace"
-        title="Notes"
-        description="Notes stay fully functional, but now they can be filed under classes created by syllabus parsing."
-        actions={
-          <>
-            <Button
-              type="button"
-              onClick={() => startTransition(() => void handleCreateNote(getClassFilterId(selectedFilter)))}
-              disabled={isPending}
-            >
-              New note
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isPending}
-            >
-              Generate from file
-            </Button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".pdf,image/png,image/jpeg,image/webp,image/gif"
-              className="hidden"
-              onChange={(event) => {
-                const file = event.currentTarget.files?.[0];
-                event.currentTarget.value = "";
-                if (!file) {
-                  return;
-                }
-                startTransition(() => {
-                  void handleUploadFile(file, getClassFilterId(selectedFilter)).catch((uploadError) => {
-                    setError(
-                      uploadError instanceof Error
-                        ? uploadError.message
-                        : "Could not generate notes from the uploaded file.",
-                    );
-                    setStatus(null);
-                  });
-                });
-              }}
-            />
-          </>
-        }
+    <div className="h-full min-h-0 overflow-hidden bg-surface">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".pdf,image/png,image/jpeg,image/webp,image/gif"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          event.currentTarget.value = "";
+          if (!file) {
+            return;
+          }
+          startTransition(() => {
+            void handleUploadFile(
+              file,
+              selectedNote?.classId ?? fallbackClassId,
+            ).catch((uploadError) => {
+              setError(
+                uploadError instanceof Error
+                  ? uploadError.message
+                  : "Could not generate notes from the uploaded file.",
+              );
+              setStatus(null);
+            });
+          });
+        }}
       />
 
-      {status || error ? (
-        <div className="flex flex-wrap items-center gap-3 text-sm">
-          {status ? <p className="text-muted-foreground">{status}</p> : null}
-          {error ? <p className="text-danger">{error}</p> : null}
-        </div>
-      ) : null}
-
-      <div className="grid gap-6 xl:grid-cols-[340px_minmax(0,1fr)]">
-        <Card className="p-4">
-          <div className="mb-4 flex items-center justify-between">
-            <div>
-              <h2 className="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                Your notes
-              </h2>
-              <p className="mt-1 text-sm text-muted-foreground">{filteredNotes.length} in view</p>
-            </div>
-          </div>
-
-          <div className="mb-4 flex flex-wrap gap-2">
+      <div className="grid h-full min-h-0 lg:grid-cols-[292px_minmax(0,1fr)]">
+        <aside className="flex h-full min-h-0 flex-col border-b border-border bg-surface-muted/70 lg:border-b-0 lg:border-r">
+          <div className="flex h-12 items-center gap-2 border-b border-border px-3">
             <button
               type="button"
-              onClick={() => setSelectedFilter("all")}
-              className={cx(
-                "rounded-full px-3 py-1.5 text-xs font-medium transition",
-                selectedFilter === "all" ? "bg-accent text-accent-foreground" : "bg-surface-muted text-muted-foreground",
-              )}
+              onClick={() =>
+                startTransition(() => void handleCreateNote(fallbackClassId))
+              }
+              disabled={isPending}
+              className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-sm font-medium text-foreground hover:bg-surface disabled:opacity-60"
             >
-              All
+              <Plus className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span className="truncate">New page</span>
             </button>
-            <button
-              type="button"
-              onClick={() => setSelectedFilter("unfiled")}
-              className={cx(
-                "rounded-full px-3 py-1.5 text-xs font-medium transition",
-                selectedFilter === "unfiled"
-                  ? "bg-accent text-accent-foreground"
-                  : "bg-surface-muted text-muted-foreground",
-              )}
-            >
-              Unfiled
-            </button>
-            {classes.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => setSelectedFilter(item.id)}
-                className={cx(
-                  "rounded-full px-3 py-1.5 text-xs font-medium transition",
-                  selectedFilter === item.id
-                    ? "bg-accent text-accent-foreground"
-                    : "bg-surface-muted text-muted-foreground",
-                )}
-              >
-                {item.courseCode ? `${item.courseCode} - ` : ""}
-                {item.title}
-              </button>
-            ))}
           </div>
 
-          {filteredNotes.length === 0 ? (
-            <EmptyState
-              title="No notes here yet"
-              description={
-                selectedFilter === "all"
-                  ? "Create a note or generate notes from a file to start building your notes library."
-                  : "Create or move a note into this class to start building its study context."
-              }
-              eyebrow="Notes"
-              action={
-                <Button
-                  type="button"
-                  onClick={() => startTransition(() => void handleCreateNote(getClassFilterId(selectedFilter)))}
-                  disabled={isPending}
-                >
-                  Create note
-                </Button>
-              }
-            />
-          ) : (
-            <div className="space-y-2">
-              {filteredNotes.map((note) => {
-                const isSelected = note.id === selectedNote?.id;
-                const linkedClass = note.classId ? classesById.get(note.classId) ?? null : null;
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 py-3">
+            {recentNotes.length > 0 ? (
+              <section className="mb-5">
+                <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">
+                  Recents
+                </div>
+                <div className="space-y-0.5">
+                  {recentNotes.map((note) =>
+                    renderNoteItem(note, { compact: true }),
+                  )}
+                </div>
+              </section>
+            ) : null}
 
+            <section className="space-y-1">
+              <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">
+                Private
+              </div>
+              {groupedNotes.map((group) => {
+                const isCollapsed = collapsedGroups.has(group.id);
                 return (
-                  <button
-                    key={note.id}
-                    type="button"
-                    onClick={() => {
-                      setError(null);
-                      setStatus(null);
-                      setSelectedId(note.id);
-                    }}
-                    className={cx(
-                      "w-full rounded-[var(--radius-lg)] border px-4 py-3 text-left transition",
-                      isSelected
-                        ? "border-accent bg-accent-soft"
-                        : "border-border bg-surface-muted hover:border-border-strong hover:bg-surface",
-                    )}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="line-clamp-2 text-sm font-medium text-foreground">
-                          {getRenderableTitle(note.title)}
-                        </p>
-                        <div className="mt-2 flex flex-wrap items-center gap-2">
-                          <Badge variant="outline">
-                            {note.sourceType === "upload" ? "Imported file" : "Manual note"}
-                          </Badge>
-                          {linkedClass ? <Badge variant="accent">{linkedClass.title}</Badge> : null}
-                        </div>
-                        {note.generation ? (
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            Topic {note.generation.topicIndex + 1}/{note.generation.topicCount}
-                          </p>
-                        ) : null}
-                      </div>
-                      {note.fileName ? (
-                        <Badge variant="neutral">
-                          {note.fileName.split(".").pop()?.toUpperCase() || "FILE"}
-                        </Badge>
-                      ) : null}
+                  <div key={group.id}>
+                    <div className="group flex items-center gap-1 rounded-md text-muted-foreground hover:bg-surface hover:text-foreground">
+                      <button
+                        type="button"
+                        onClick={() => toggleGroup(group.id)}
+                        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+                        aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group.title}`}
+                      >
+                        {isCollapsed ? (
+                          <ChevronRight
+                            className="h-3.5 w-3.5"
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <ChevronDown
+                            className="h-3.5 w-3.5"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => toggleGroup(group.id)}
+                        className="flex min-w-0 flex-1 items-center gap-2 py-1.5 text-left text-sm font-medium"
+                      >
+                        <Folder
+                          className="h-4 w-4 shrink-0 opacity-70"
+                          aria-hidden="true"
+                        />
+                        <span className="truncate">{group.title}</span>
+                        <span className="ml-auto pr-1 text-[11px] text-muted-foreground">
+                          {group.notes.length}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          startTransition(
+                            () => void handleCreateNote(group.classId),
+                          )
+                        }
+                        disabled={isPending}
+                        className="mr-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md opacity-0 hover:bg-surface-elevated group-hover:opacity-100 disabled:opacity-40"
+                        aria-label={`New note in ${group.title}`}
+                      >
+                        <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+                      </button>
                     </div>
-                    <p className="mt-3 text-xs text-muted-foreground">
-                      Updated {formatTimestamp(note.updatedAt)}
-                    </p>
-                  </button>
+                    {!isCollapsed && group.notes.length > 0 ? (
+                      <div className="ml-5 space-y-0.5 border-l border-border/70 pl-1.5">
+                        {group.notes.map((note) => renderNoteItem(note))}
+                      </div>
+                    ) : null}
+                  </div>
                 );
               })}
-            </div>
-          )}
-        </Card>
+            </section>
+          </div>
+        </aside>
 
-        <Card className="overflow-hidden">
+        <section className="h-full min-h-0 bg-background">
           {selectedNote ? (
-            <>
-              <div className="border-b border-border px-6 py-5">
-                <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-                  <div className="min-w-0 flex-1">
-                    <input
-                      value={draftTitle}
-                      onChange={(event) => {
-                        const nextTitle = event.currentTarget.value;
-                        setTitleDraftState({
-                          noteId: selectedNote.id,
-                          value: nextTitle,
-                        });
-                        setNotes((current) =>
-                          current.map((note) =>
-                            note.id === selectedNote.id ? { ...note, title: nextTitle } : note,
-                          ),
-                        );
-                      }}
-                      onBlur={() => void handleTitleCommit()}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter") {
-                          event.currentTarget.blur();
-                        }
-                      }}
-                      className="w-full border-none bg-transparent p-0 text-2xl font-semibold tracking-tight text-foreground outline-none placeholder:text-muted-foreground"
-                      placeholder="Untitled"
-                    />
-                    <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px]">
-                      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                        <Badge variant="outline">
-                          {selectedNote.sourceType === "upload" ? "Imported note" : "Manual note"}
-                        </Badge>
-                        <Badge variant="outline">Created {formatTimestamp(selectedNote.createdAt)}</Badge>
-                        <Badge variant="outline">Last saved {formatTimestamp(selectedNote.updatedAt)}</Badge>
-                        {selectedNote.fileName ? (
-                          <Badge variant="outline">
-                            {selectedNote.fileName}
-                            {selectedNote.fileSize ? ` - ${formatFileSize(selectedNote.fileSize)}` : ""}
-                          </Badge>
-                        ) : null}
-                        {selectedNote.generation ? (
-                          <Badge variant="outline">
-                            {selectedNote.generation.embeddingDimensions}D embedding
-                          </Badge>
-                        ) : null}
-                      </div>
-                      <Select
-                        aria-label="Select class"
-                        value={selectedNote.classId ?? ""}
-                        onChange={(event) => {
-                          const nextClassId = event.currentTarget.value || null;
-                          setNotes((current) =>
-                            current.map((note) =>
-                              note.id === selectedNote.id ? { ...note, classId: nextClassId } : note,
-                            ),
-                          );
-                          startTransition(() => void saveNote(selectedNote.id, { classId: nextClassId }));
-                        }}
-                      >
-                        <option value="">No class</option>
-                        {classes.map((item) => (
-                          <option key={item.id} value={item.id}>
-                            {item.courseCode ? `${item.courseCode} - ` : ""}
-                            {item.title}
-                          </option>
-                        ))}
-                      </Select>
-                    </div>
+            <div className="flex h-full min-h-0 flex-col">
+              <div className="flex min-h-12 items-center justify-between gap-3 border-b border-border px-4">
+                <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+                  <FileText className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span className="truncate text-foreground">
+                    {getRenderableTitle(draftTitle)}
+                  </span>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <div className="pr-1">
+                    {status ? (
+                      <span className="hidden text-xs text-muted-foreground md:inline">
+                        {status}
+                      </span>
+                    ) : null}
+                    {error ? (
+                      <span className="hidden text-xs text-danger md:inline">
+                        {error}
+                      </span>
+                    ) : null}
                   </div>
 
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    onClick={() => startTransition(() => void handleDeleteNote())}
-                    disabled={isPending}
+                  <Select
+                    aria-label="Select class"
+                    value={selectedNote.classId ?? ""}
+                    onChange={(event) => {
+                      const nextClassId = event.currentTarget.value || null;
+                      setNotes((current) =>
+                        current.map((note) =>
+                          note.id === selectedNote.id
+                            ? { ...note, classId: nextClassId }
+                            : note,
+                        ),
+                      );
+                      startTransition(
+                        () =>
+                          void saveNote(selectedNote.id, {
+                            classId: nextClassId,
+                          }),
+                      );
+                    }}
+                    className="h-8 w-36 border-transparent bg-transparent px-2 py-1 text-xs text-muted-foreground shadow-none hover:bg-surface-muted focus:border-border focus-visible:ring-0 md:w-44"
                   >
-                    Delete note
-                  </Button>
+                    <option value="">No class</option>
+                    {classes.map((item) => (
+                      <option key={item.id} value={item.id}>
+                        {getClassLabel(item)}
+                      </option>
+                    ))}
+                  </Select>
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isPending}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-surface-muted hover:text-foreground disabled:opacity-60"
+                    aria-label="Import file"
+                  >
+                    <Upload className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      startTransition(() => void handleDeleteNote())
+                    }
+                    disabled={isPending}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-danger-soft hover:text-danger disabled:opacity-60"
+                    aria-label="Delete note"
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                  </button>
                 </div>
               </div>
 
-              <div className="px-3 pb-3 pt-1 md:px-4 md:pb-4">
-                {selectedNote.generation ? (
-                  <GeneratedNoteVectorPanel generation={selectedNote.generation} />
-                ) : null}
+              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pt-0">
                 <NoteSurface
                   initialDocument={selectedNote.content.document}
                   keepEditingWhenEmpty
+                  selectionPrelude={
+                    <div className="mx-auto w-full px-4 pt-7 md:px-10 md:pt-10">
+                      <input
+                        data-note-selection-region
+                        value={draftTitle}
+                        onChange={(event) => {
+                          const nextTitle = event.currentTarget.value;
+                          setTitleDraftState({
+                            noteId: selectedNote.id,
+                            value: nextTitle,
+                          });
+                          setNotes((current) =>
+                            current.map((note) =>
+                              note.id === selectedNote.id
+                                ? { ...note, title: nextTitle }
+                                : note,
+                            ),
+                          );
+                        }}
+                        onBlur={() => void handleTitleCommit()}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.currentTarget.blur();
+                          }
+                        }}
+                        className="w-full border-none bg-transparent p-0 text-4xl font-semibold tracking-tight text-foreground outline-none placeholder:text-muted-foreground/50"
+                        placeholder="Untitled"
+                      />
+                      <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <span>{formatTimestamp(selectedNote.updatedAt)}</span>
+                        {selectedNote.fileName ? (
+                          <span className="truncate">
+                            {selectedNote.fileName}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                  }
                   onSave={async (nextContent) => {
                     try {
                       await saveNote(selectedNote.id, {
@@ -621,130 +660,43 @@ export function NotesWorkspace({
                       });
                     } catch (saveError) {
                       setError(
-                        saveError instanceof Error ? saveError.message : "Could not save note changes.",
+                        saveError instanceof Error
+                          ? saveError.message
+                          : "Could not save note changes.",
                       );
                       setStatus(null);
                     }
                   }}
                 />
               </div>
-            </>
+            </div>
           ) : (
-            <div className="p-6">
-              <EmptyState
-                title="No note selected"
-                description="Pick a note from the left or create one directly inside the current class filter."
-                eyebrow="Editor"
-                action={
-                  <div className="flex flex-wrap gap-3">
-                    <Button
-                      type="button"
-                      onClick={() => startTransition(() => void handleCreateNote(getClassFilterId(selectedFilter)))}
-                      disabled={isPending}
-                    >
-                      Create note
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={isPending}
-                    >
-                      Generate from file
-                    </Button>
-                  </div>
-                }
-              />
+            <div className="flex h-full min-h-0 items-center justify-center p-6">
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  onClick={() =>
+                    startTransition(
+                      () => void handleCreateNote(fallbackClassId),
+                    )
+                  }
+                  disabled={isPending}
+                >
+                  New page
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isPending}
+                >
+                  Import
+                </Button>
+              </div>
             </div>
           )}
-        </Card>
+        </section>
       </div>
-
-      {selectedFilter !== "all" && getClassFilterId(selectedFilter) ? (
-        <div className="text-sm text-muted-foreground">
-          Working inside{" "}
-          <Link
-            href={`/classes/${classesById.get(getClassFilterId(selectedFilter) ?? "")?.runId ?? ""}?tab=notes`}
-            className="font-medium text-accent underline-offset-4 hover:underline"
-          >
-            {classesById.get(getClassFilterId(selectedFilter) ?? "")?.title}
-          </Link>
-          . New notes and imports will link to this class by default.
-        </div>
-      ) : null}
-
-      {generationResult ? <GenerationResultPanel result={generationResult} /> : null}
     </div>
-  );
-}
-
-function GeneratedNoteVectorPanel({ generation }: { generation: NoteGenerationMetadata }) {
-  return (
-    <div className="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-950 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-100">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <p className="font-medium">
-          Generated topic {generation.topicIndex + 1}/{generation.topicCount}: {generation.topicTitle}
-        </p>
-        <p className="text-xs text-emerald-700 dark:text-emerald-300">
-          L2 {getVectorMagnitude(generation.embedding).toFixed(4)} · {generation.embedding.length} values
-        </p>
-      </div>
-      <p className="mt-2 break-all font-mono text-xs text-emerald-800 dark:text-emerald-200">
-        [{formatVectorPreview(generation.embedding)}
-        {generation.embedding.length > 8 ? ", ..." : ""}]
-      </p>
-      <details className="mt-3">
-        <summary className="cursor-pointer text-xs font-medium text-emerald-800 dark:text-emerald-200">
-          Full vector
-        </summary>
-        <pre className="mt-2 max-h-52 overflow-auto whitespace-pre-wrap rounded-xl bg-white/70 p-3 text-xs text-emerald-950 dark:bg-zinc-950/70 dark:text-emerald-100">
-          {formatFullVector(generation.embedding)}
-        </pre>
-      </details>
-    </div>
-  );
-}
-
-function GenerationResultPanel({ result }: { result: GenerationResult }) {
-  return (
-    <section className="rounded-3xl border border-border bg-surface-muted p-5 shadow-sm">
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-semibold tracking-tight text-foreground">Generated notes</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {result.fileName} · {result.parsedTextLength.toLocaleString()} parsed characters ·{" "}
-            {result.topics.length} topic notes
-          </p>
-        </div>
-      </div>
-      <div className="mt-4 grid gap-3 lg:grid-cols-2">
-        {result.topics.map((topic, index) => (
-          <article key={`${topic.noteId}-${index}`} className="rounded-2xl border border-border bg-surface p-4">
-            <h3 className="line-clamp-2 text-sm font-semibold text-foreground">{topic.title}</h3>
-            <p className="mt-2 line-clamp-6 whitespace-pre-wrap text-sm leading-6 text-muted-foreground">
-              {topic.markdown}
-            </p>
-            <div className="mt-3 rounded-xl bg-surface-muted p-3">
-              <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
-                <span>{topic.embedding.length}D L2-normalized vector</span>
-                <span>magnitude {getVectorMagnitude(topic.embedding).toFixed(4)}</span>
-              </div>
-              <p className="mt-2 break-all font-mono text-xs text-foreground">
-                [{formatVectorPreview(topic.embedding)}
-                {topic.embedding.length > 8 ? ", ..." : ""}]
-              </p>
-              <details className="mt-3">
-                <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
-                  Full vector
-                </summary>
-                <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded-lg bg-surface p-2 text-xs text-foreground">
-                  {formatFullVector(topic.embedding)}
-                </pre>
-              </details>
-            </div>
-          </article>
-        ))}
-      </div>
-    </section>
   );
 }

--- a/app/quizzes/quizzes-client.tsx
+++ b/app/quizzes/quizzes-client.tsx
@@ -356,14 +356,6 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
 
   return (
     <main className="flex h-full flex-col gap-4">
-      <div className="shrink-0 flex items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold tracking-tight text-foreground">Quizzes</h1>
-        {started ? (
-          <Button type="button" variant="outline" leadingIcon={<RotateCcw className="size-4" />} onClick={resetQuiz}>
-            Reset
-          </Button>
-        ) : null}
-      </div>
       {error ? (
         <div className="shrink-0 rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
           {error}
@@ -802,6 +794,19 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
               </div>
             ) : null}
           </CardContent>
+
+          <div className="shrink-0 flex items-center justify-between gap-3">
+            {started ? (
+              <Button
+                type="button"
+                variant="outline"
+                leadingIcon={<RotateCcw className="size-4" />}
+                onClick={resetQuiz}
+              >
+                Reset
+              </Button>
+            ) : null}
+          </div>
         </Card>
       </div>
     </main>

--- a/app/quizzes/quizzes-client.tsx
+++ b/app/quizzes/quizzes-client.tsx
@@ -17,11 +17,20 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input, Textarea } from "@/components/ui/input";
-import { PageHeader } from "@/components/ui/page-header";
 import { cx } from "@/lib/utils";
-import type { QuizDifficulty, QuizQuestion, QuizQuestionType } from "@/lib/quizzes/gemini";
+import type {
+  QuizDifficulty,
+  QuizQuestion,
+  QuizQuestionType,
+} from "@/lib/quizzes/gemini";
 
 type QuizMode = "infinite" | "exam";
 
@@ -67,7 +76,9 @@ function formatTimer(seconds: number) {
 }
 
 async function readJsonResponse<T>(response: Response): Promise<T> {
-  const payload = (await response.json().catch(() => null)) as T & { error?: string };
+  const payload = (await response.json().catch(() => null)) as T & {
+    error?: string;
+  };
   if (!response.ok) {
     throw new Error(payload?.error || "Request failed");
   }
@@ -89,10 +100,18 @@ function MarkdownText({
         remarkPlugins={[remarkGfm, remarkMath]}
         components={{
           p: ({ children }) => <p>{children}</p>,
-          ul: ({ children }) => <ul className="ml-5 list-disc space-y-1">{children}</ul>,
-          ol: ({ children }) => <ol className="ml-5 list-decimal space-y-1">{children}</ol>,
+          ul: ({ children }) => (
+            <ul className="ml-5 list-disc space-y-1">{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="ml-5 list-decimal space-y-1">{children}</ol>
+          ),
           li: ({ children }) => <li>{children}</li>,
-          strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
+          strong: ({ children }) => (
+            <strong className="font-semibold text-foreground">
+              {children}
+            </strong>
+          ),
           em: ({ children }) => <em className="italic">{children}</em>,
           code: ({ children, className: codeClassName }) => (
             <code
@@ -110,17 +129,25 @@ function MarkdownText({
             </pre>
           ),
           blockquote: ({ children }) => (
-            <blockquote className="border-l-4 border-border pl-3 text-muted-foreground">{children}</blockquote>
+            <blockquote className="border-l-4 border-border pl-3 text-muted-foreground">
+              {children}
+            </blockquote>
           ),
           table: ({ children }) => (
             <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-sm">{children}</table>
+              <table className="w-full border-collapse text-sm">
+                {children}
+              </table>
             </div>
           ),
           th: ({ children }) => (
-            <th className="border border-border bg-surface-muted px-2 py-1 text-left font-semibold">{children}</th>
+            <th className="border border-border bg-surface-muted px-2 py-1 text-left font-semibold">
+              {children}
+            </th>
           ),
-          td: ({ children }) => <td className="border border-border px-2 py-1">{children}</td>,
+          td: ({ children }) => (
+            <td className="border border-border px-2 py-1">{children}</td>
+          ),
         }}
       >
         {markdown}
@@ -130,12 +157,17 @@ function MarkdownText({
 }
 
 export function QuizzesClient({ notes }: QuizzesClientProps) {
-  const embeddedNotes = useMemo(() => notes.filter((note) => note.hasEmbedding), [notes]);
+  const embeddedNotes = useMemo(
+    () => notes.filter((note) => note.hasEmbedding),
+    [notes],
+  );
   const [selectedNoteIds, setSelectedNoteIds] = useState<string[]>([]);
   const [mode, setMode] = useState<QuizMode>("infinite");
   const [timeMinutes, setTimeMinutes] = useState(20);
   const [questionCount, setQuestionCount] = useState(10);
-  const [questionTypes, setQuestionTypes] = useState<QuizQuestionType[]>(["multiple_choice"]);
+  const [questionTypes, setQuestionTypes] = useState<QuizQuestionType[]>([
+    "multiple_choice",
+  ]);
   const [difficulty, setDifficulty] = useState<QuizDifficulty>("medium");
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
   const [answers, setAnswers] = useState<Record<string, AnswerState>>({});
@@ -148,12 +180,23 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
   const [error, setError] = useState<string | null>(null);
 
   const currentQuestion = questions[currentIndex];
-  const currentAnswer = currentQuestion ? answers[currentQuestion.id]?.answer ?? "" : "";
-  const currentEvaluation = currentQuestion ? answers[currentQuestion.id]?.evaluation : undefined;
+  const currentAnswer = currentQuestion
+    ? (answers[currentQuestion.id]?.answer ?? "")
+    : "";
+  const currentEvaluation = currentQuestion
+    ? answers[currentQuestion.id]?.evaluation
+    : undefined;
   const examExpired = mode === "exam" && started && remainingSeconds <= 0;
-  const canStart = selectedNoteIds.length > 0 && questionTypes.length > 0 && embeddedNotes.length > 0;
-  const answeredCount = Object.values(answers).filter((answer) => answer.evaluation).length;
-  const correctCount = Object.values(answers).filter((answer) => answer.evaluation?.correct).length;
+  const canStart =
+    selectedNoteIds.length > 0 &&
+    questionTypes.length > 0 &&
+    embeddedNotes.length > 0;
+  const answeredCount = Object.values(answers).filter(
+    (answer) => answer.evaluation,
+  ).length;
+  const correctCount = Object.values(answers).filter(
+    (answer) => answer.evaluation?.correct,
+  ).length;
 
   useEffect(() => {
     if (!started || finished || mode !== "exam" || remainingSeconds <= 0) {
@@ -207,13 +250,19 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
         }),
       );
 
-      setQuestions((current) => (append ? [...current, ...payload.questions] : payload.questions));
+      setQuestions((current) =>
+        append ? [...current, ...payload.questions] : payload.questions,
+      );
       if (!append) {
         setCurrentIndex(0);
       }
       return true;
     } catch (generationError) {
-      setError(generationError instanceof Error ? generationError.message : "Quiz generation failed");
+      setError(
+        generationError instanceof Error
+          ? generationError.message
+          : "Quiz generation failed",
+      );
       return false;
     } finally {
       setIsGenerating(false);
@@ -226,7 +275,9 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
     setQuestions([]);
     setCurrentIndex(0);
     setRemainingSeconds(Math.max(1, timeMinutes) * 60);
-    const generated = await generateQuestions(mode === "exam" ? questionCount : 1);
+    const generated = await generateQuestions(
+      mode === "exam" ? questionCount : 1,
+    );
     setStarted(generated);
   }
 
@@ -257,7 +308,11 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
         },
       }));
     } catch (evaluationError) {
-      setError(evaluationError instanceof Error ? evaluationError.message : "Answer evaluation failed");
+      setError(
+        evaluationError instanceof Error
+          ? evaluationError.message
+          : "Answer evaluation failed",
+      );
     } finally {
       setIsEvaluating(false);
     }
@@ -300,37 +355,36 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
-      <PageHeader
-        eyebrow="Quizzing"
-        title="Quizzes"
-        description="Create note-driven quizzes from stored note embeddings and content, then have Gemini evaluate each answer."
-        actions={
-          started ? (
-            <Button type="button" variant="outline" leadingIcon={<RotateCcw className="size-4" />} onClick={resetQuiz}>
-              Reset
-            </Button>
-          ) : null
-        }
-      />
-
+    <main className="flex h-full flex-col gap-4">
+      <div className="shrink-0 flex items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">Quizzes</h1>
+        {started ? (
+          <Button type="button" variant="outline" leadingIcon={<RotateCcw className="size-4" />} onClick={resetQuiz}>
+            Reset
+          </Button>
+        ) : null}
+      </div>
       {error ? (
-        <div className="rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
+        <div className="shrink-0 rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
           {error}
         </div>
       ) : null}
 
-      <div className="grid gap-6 lg:grid-cols-[380px_minmax(0,1fr)]">
-        <Card>
-          <CardHeader>
+      <div className="grid min-h-0 flex-1 gap-6 lg:grid-cols-[380px_minmax(0,1fr)]">
+        <Card className="flex min-h-0 flex-col overflow-hidden">
+          <CardHeader className="shrink-0">
             <CardTitle>Quiz setup</CardTitle>
-            <CardDescription>Select notes, question format, difficulty, and quiz mode.</CardDescription>
+            <CardDescription>
+              Select notes, question format, difficulty, and quiz mode.
+            </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-6">
+          <CardContent className="min-h-0 flex-1 space-y-6 overflow-y-auto">
             <section className="space-y-3">
               <div className="flex items-center justify-between gap-3">
                 <h2 className="text-sm font-medium text-foreground">Notes</h2>
-                <Badge variant="outline">{selectedNoteIds.length} selected</Badge>
+                <Badge variant="outline">
+                  {selectedNoteIds.length} selected
+                </Badge>
               </div>
               <div className="max-h-72 space-y-2 overflow-auto pr-1">
                 {notes.length === 0 ? (
@@ -356,9 +410,13 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                         onChange={() => toggleNote(note.id)}
                       />
                       <span className="min-w-0 flex-1">
-                        <span className="block truncate font-medium text-foreground">{note.title}</span>
+                        <span className="block truncate font-medium text-foreground">
+                          {note.title}
+                        </span>
                         <span className="text-xs text-muted-foreground">
-                          {note.hasEmbedding ? "Embedding ready" : "No embedding stored"}
+                          {note.hasEmbedding
+                            ? "Embedding ready"
+                            : "No embedding stored"}
                         </span>
                       </span>
                     </label>
@@ -411,7 +469,9 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                     max={240}
                     value={timeMinutes}
                     disabled={started}
-                    onChange={(event) => setTimeMinutes(Number(event.target.value))}
+                    onChange={(event) =>
+                      setTimeMinutes(Number(event.target.value))
+                    }
                   />
                 </label>
                 <label className="space-y-2 text-sm font-medium text-foreground">
@@ -422,17 +482,24 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                     max={25}
                     value={questionCount}
                     disabled={started}
-                    onChange={(event) => setQuestionCount(Number(event.target.value))}
+                    onChange={(event) =>
+                      setQuestionCount(Number(event.target.value))
+                    }
                   />
                 </label>
               </section>
             ) : null}
 
             <section className="space-y-3">
-              <h2 className="text-sm font-medium text-foreground">Question types</h2>
+              <h2 className="text-sm font-medium text-foreground">
+                Question types
+              </h2>
               <div className="space-y-2">
                 {questionTypeOptions.map((option) => (
-                  <label key={option.value} className="flex items-center gap-3 text-sm text-foreground">
+                  <label
+                    key={option.value}
+                    className="flex items-center gap-3 text-sm text-foreground"
+                  >
                     <input
                       type="checkbox"
                       className="size-4 accent-[var(--accent)]"
@@ -447,7 +514,9 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
             </section>
 
             <section className="space-y-3">
-              <h2 className="text-sm font-medium text-foreground">Difficulty</h2>
+              <h2 className="text-sm font-medium text-foreground">
+                Difficulty
+              </h2>
               <div className="grid grid-cols-3 gap-2">
                 {difficultyOptions.map((option) => (
                   <button
@@ -472,7 +541,13 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
               type="button"
               className="w-full"
               disabled={!canStart || started || isGenerating}
-              leadingIcon={isGenerating ? <Loader2 className="size-4 animate-spin" /> : <Play className="size-4" />}
+              leadingIcon={
+                isGenerating ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Play className="size-4" />
+                )
+              }
               onClick={startQuiz}
             >
               Start quiz
@@ -480,8 +555,8 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <Card className="flex min-h-0 flex-col overflow-hidden">
+          <CardHeader className="shrink-0 gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-2">
               <CardTitle>Question workspace</CardTitle>
               <CardDescription>
@@ -509,14 +584,17 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
               </div>
             ) : null}
           </CardHeader>
-          <CardContent>
+          <CardContent className="min-h-0 flex-1 overflow-y-auto">
             {!started ? (
               <div className="flex min-h-96 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-surface-muted px-6 text-center">
                 <Brain className="size-10 text-muted-foreground" />
                 <div className="space-y-1">
-                  <h2 className="text-base font-semibold text-foreground">Ready when your notes are selected</h2>
+                  <h2 className="text-base font-semibold text-foreground">
+                    Ready when your notes are selected
+                  </h2>
                   <p className="max-w-md text-sm leading-6 text-muted-foreground">
-                    Generated questions use the embeddings stored on the selected note rows, plus their readable note content.
+                    Generated questions use the embeddings stored on the
+                    selected note rows, plus their readable note content.
                   </p>
                 </div>
               </div>
@@ -528,9 +606,12 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
             ) : finished ? (
               <div className="flex min-h-96 flex-col justify-center gap-5">
                 <div className="space-y-2 text-center">
-                  <h2 className="text-xl font-semibold text-foreground">Exam complete</h2>
+                  <h2 className="text-xl font-semibold text-foreground">
+                    Exam complete
+                  </h2>
                   <p className="text-sm text-muted-foreground">
-                    Score: {correctCount}/{answeredCount || questions.length} correct
+                    Score: {correctCount}/{answeredCount || questions.length}{" "}
+                    correct
                   </p>
                 </div>
                 <div className="grid gap-2">
@@ -546,7 +627,10 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                           setCurrentIndex(index);
                         }}
                       >
-                        <MarkdownText markdown={question.prompt} className="truncate text-sm" />
+                        <MarkdownText
+                          markdown={question.prompt}
+                          className="truncate text-sm"
+                        />
                         {evaluation ? (
                           evaluation.correct ? (
                             <CheckCircle2 className="size-4 shrink-0 text-green-600" />
@@ -565,7 +649,9 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
               <div className="space-y-6">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant="accent">Question {currentIndex + 1}</Badge>
-                  <Badge variant="outline">{currentQuestion.type.replace("_", " ")}</Badge>
+                  <Badge variant="outline">
+                    {currentQuestion.type.replace("_", " ")}
+                  </Badge>
                   {currentQuestion.sourceNoteTitles.map((title) => (
                     <Badge key={title} variant="neutral">
                       {title}
@@ -578,14 +664,17 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                     markdown={currentQuestion.prompt}
                     className="space-y-3 text-xl font-semibold leading-8"
                   />
-                  {currentQuestion.type === "multiple_choice" || currentQuestion.type === "true_false" ? (
+                  {currentQuestion.type === "multiple_choice" ||
+                  currentQuestion.type === "true_false" ? (
                     <div className="grid gap-2">
                       {(currentQuestion.choices ?? []).map((choice) => (
                         <label
                           key={choice}
                           className={cx(
                             "flex cursor-pointer items-center gap-3 rounded-lg border border-border px-3 py-3 text-sm transition hover:bg-surface-muted",
-                            currentAnswer === choice ? "border-accent bg-accent-soft text-accent" : "text-foreground",
+                            currentAnswer === choice
+                              ? "border-accent bg-accent-soft text-accent"
+                              : "text-foreground",
                           )}
                         >
                           <input
@@ -621,13 +710,19 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                     )}
                   >
                     <div className="font-medium">
-                      {currentEvaluation.correct ? "Correct" : "Needs work"} · Score{" "}
-                      {Math.round(currentEvaluation.score * 100)}%
+                      {currentEvaluation.correct ? "Correct" : "Needs work"} ·
+                      Score {Math.round(currentEvaluation.score * 100)}%
                     </div>
-                    <MarkdownText markdown={currentEvaluation.feedback} className="mt-1 space-y-2" />
+                    <MarkdownText
+                      markdown={currentEvaluation.feedback}
+                      className="mt-1 space-y-2"
+                    />
                     <div className="mt-2 space-y-1">
                       <div className="font-medium">Ideal answer:</div>
-                      <MarkdownText markdown={currentEvaluation.idealAnswer} className="space-y-2" />
+                      <MarkdownText
+                        markdown={currentEvaluation.idealAnswer}
+                        className="space-y-2"
+                      />
                     </div>
                   </div>
                 ) : examExpired ? (
@@ -644,7 +739,9 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                           type="button"
                           variant="outline"
                           disabled={currentIndex === 0}
-                          onClick={() => setCurrentIndex((index) => Math.max(0, index - 1))}
+                          onClick={() =>
+                            setCurrentIndex((index) => Math.max(0, index - 1))
+                          }
                         >
                           Previous
                         </Button>
@@ -652,7 +749,11 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                           type="button"
                           variant="outline"
                           disabled={currentIndex >= questions.length - 1}
-                          onClick={() => setCurrentIndex((index) => Math.min(questions.length - 1, index + 1))}
+                          onClick={() =>
+                            setCurrentIndex((index) =>
+                              Math.min(questions.length - 1, index + 1),
+                            )
+                          }
                         >
                           Next
                         </Button>
@@ -663,8 +764,17 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                     <Button
                       type="button"
                       variant="outline"
-                      disabled={!currentAnswer.trim() || Boolean(currentEvaluation) || isEvaluating || examExpired}
-                      leadingIcon={isEvaluating ? <Loader2 className="size-4 animate-spin" /> : undefined}
+                      disabled={
+                        !currentAnswer.trim() ||
+                        Boolean(currentEvaluation) ||
+                        isEvaluating ||
+                        examExpired
+                      }
+                      leadingIcon={
+                        isEvaluating ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : undefined
+                      }
                       onClick={evaluateCurrentAnswer}
                     >
                       Check answer
@@ -673,7 +783,11 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                       <Button
                         type="button"
                         disabled={!currentEvaluation || isGenerating}
-                        leadingIcon={isGenerating ? <Loader2 className="size-4 animate-spin" /> : undefined}
+                        leadingIcon={
+                          isGenerating ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : undefined
+                        }
                         onClick={nextInfiniteQuestion}
                       >
                         Next question

--- a/components/auth/sign-out-button.tsx
+++ b/components/auth/sign-out-button.tsx
@@ -9,9 +9,11 @@ import { cx } from "@/lib/utils";
 type SignOutButtonProps = {
   compact?: boolean;
   className?: string;
+  onMouseEnter?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onMouseLeave?: () => void;
 };
 
-export function SignOutButton({ compact = false, className }: SignOutButtonProps) {
+export function SignOutButton({ compact = false, className, onMouseEnter, onMouseLeave }: SignOutButtonProps) {
   const router = useRouter();
   const [isPending, setIsPending] = useState(false);
 
@@ -27,6 +29,40 @@ export function SignOutButton({ compact = false, className }: SignOutButtonProps
     }
   }
 
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={handleSignOut}
+        disabled={isPending}
+        aria-label="Sign out"
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        className={cx(
+          "flex h-10 w-full items-center justify-center rounded-lg text-muted-foreground transition hover:bg-surface-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 disabled:opacity-50",
+          className,
+        )}
+      >
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-4 w-4"
+            aria-hidden
+          >
+            <path d="M10 6H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h4" />
+            <path d="M14 8l4 4-4 4" />
+            <path d="M18 12H9" />
+          </svg>
+        </span>
+      </button>
+    );
+  }
+
   return (
     <Button
       type="button"
@@ -34,33 +70,11 @@ export function SignOutButton({ compact = false, className }: SignOutButtonProps
       disabled={isPending}
       variant="outline"
       size="sm"
-      className={cx(
-        compact ? "h-8 w-8 px-0" : "w-full justify-center",
-        className,
-      )}
+      className={cx("w-full justify-center", className)}
       title="Sign out"
       aria-label="Sign out"
     >
-      {compact ? (
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-4 w-4"
-          aria-hidden
-        >
-          <path d="M10 6H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h4" />
-          <path d="M14 8l4 4-4 4" />
-          <path d="M18 12H9" />
-        </svg>
-      ) : isPending ? (
-        "Signing out..."
-      ) : (
-        "Sign out"
-      )}
+      {isPending ? "Signing out..." : "Sign out"}
     </Button>
   );
 }

--- a/components/dashboard/event-countdown.tsx
+++ b/components/dashboard/event-countdown.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cx } from "@/lib/utils";
+
+export type DashboardEvent = {
+  id: string;
+  title: string;
+  category: string;
+  courseTitle: string;
+  courseCode: string | null;
+  dueAt: string | null;
+  timeText: string | null;
+};
+
+function getCountdown(dueAt: string | null): string {
+  if (!dueAt) return "";
+  const diff = new Date(dueAt).getTime() - Date.now();
+  if (diff <= 0) return "Now";
+  const totalMins = Math.floor(diff / 60000);
+  if (totalMins < 60) return `in ${totalMins}m`;
+  const hours = Math.floor(totalMins / 60);
+  const mins = totalMins % 60;
+  if (hours < 24) return mins > 0 ? `in ${hours}h ${mins}m` : `in ${hours}h`;
+  return "Today";
+}
+
+function CategoryIcon({ category }: { category: string }) {
+  const cat = category.toLowerCase();
+  if (cat.includes("lecture") || cat.includes("class")) {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <path d="M3 9h18M9 21V9" />
+      </svg>
+    );
+  }
+  if (cat.includes("office") || cat.includes("hour")) {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+      </svg>
+    );
+  }
+  if (cat.includes("lab")) {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+        <path d="M9 3h6M9 3v7l-4 9h14L15 10V3" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" />
+    </svg>
+  );
+}
+
+function EventRow({ event }: { event: DashboardEvent }) {
+  const [countdown, setCountdown] = useState(() => getCountdown(event.dueAt));
+
+  useEffect(() => {
+    if (!event.dueAt) return;
+    const id = setInterval(() => setCountdown(getCountdown(event.dueAt)), 30000);
+    return () => clearInterval(id);
+  }, [event.dueAt]);
+
+  const isPast = event.dueAt ? new Date(event.dueAt).getTime() < Date.now() : false;
+  const isDue = event.category.toLowerCase().includes("assign") || event.category.toLowerCase().includes("due") || event.category.toLowerCase().includes("exam") || event.category.toLowerCase().includes("quiz");
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg px-3 py-2.5 transition hover:bg-surface-muted">
+      <div className="flex w-16 shrink-0 flex-col text-right text-[0.7rem] leading-tight text-muted-foreground">
+        {event.timeText ? (
+          event.timeText.split(/[-–]/).map((t, i) => <span key={i}>{t.trim()}</span>)
+        ) : (
+          <span>All day</span>
+        )}
+      </div>
+
+      <span className={cx(
+        "flex h-7 w-7 shrink-0 items-center justify-center rounded-md",
+        isDue
+          ? "bg-danger/10 text-danger"
+          : "bg-surface-elevated text-muted-foreground",
+      )}>
+        <CategoryIcon category={event.category} />
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">{event.title}</p>
+        <p className="truncate text-xs text-muted-foreground">
+          {event.category}
+          {event.courseCode ? ` · ${event.courseCode}` : ""}
+        </p>
+      </div>
+
+      <span className={cx(
+        "shrink-0 rounded-full px-2.5 py-0.5 text-[0.68rem] font-medium",
+        isPast
+          ? "bg-surface-elevated text-muted-foreground"
+          : isDue
+          ? "bg-danger/10 text-danger"
+          : "bg-accent-soft text-accent",
+      )}>
+        {isPast ? "Past" : isDue ? "Due today" : countdown}
+      </span>
+    </div>
+  );
+}
+
+export function TodayEventsList({ events }: { events: DashboardEvent[] }) {
+  if (events.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-muted-foreground">
+        No events scheduled for today.
+      </p>
+    );
+  }
+
+  return (
+    <div className="-mx-1 space-y-0.5">
+      {events.map((event) => (
+        <EventRow key={event.id} event={event} />
+      ))}
+    </div>
+  );
+}

--- a/components/dashboard/event-countdown.tsx
+++ b/components/dashboard/event-countdown.tsx
@@ -13,9 +13,8 @@ export type DashboardEvent = {
   timeText: string | null;
 };
 
-function getCountdown(dueAt: string | null): string {
-  if (!dueAt) return "";
-  const diff = new Date(dueAt).getTime() - Date.now();
+function getCountdown(dueTime: number, nowTime: number): string {
+  const diff = dueTime - nowTime;
   if (diff <= 0) return "Now";
   const totalMins = Math.floor(diff / 60000);
   if (totalMins < 60) return `in ${totalMins}m`;
@@ -60,15 +59,22 @@ function CategoryIcon({ category }: { category: string }) {
 }
 
 function EventRow({ event }: { event: DashboardEvent }) {
-  const [countdown, setCountdown] = useState(() => getCountdown(event.dueAt));
+  const [nowTime, setNowTime] = useState<number | null>(null);
 
   useEffect(() => {
     if (!event.dueAt) return;
-    const id = setInterval(() => setCountdown(getCountdown(event.dueAt)), 30000);
-    return () => clearInterval(id);
+    const updateNow = () => setNowTime(Date.now());
+    const timeoutId = window.setTimeout(updateNow, 0);
+    const intervalId = window.setInterval(updateNow, 30000);
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.clearInterval(intervalId);
+    };
   }, [event.dueAt]);
 
-  const isPast = event.dueAt ? new Date(event.dueAt).getTime() < Date.now() : false;
+  const dueTime = event.dueAt ? new Date(event.dueAt).getTime() : null;
+  const countdown = dueTime !== null && nowTime !== null ? getCountdown(dueTime, nowTime) : "";
+  const isPast = dueTime !== null && nowTime !== null ? dueTime < nowTime : false;
   const isDue = event.category.toLowerCase().includes("assign") || event.category.toLowerCase().includes("due") || event.category.toLowerCase().includes("exam") || event.category.toLowerCase().includes("quiz");
 
   return (

--- a/components/dashboard/live-clock.tsx
+++ b/components/dashboard/live-clock.tsx
@@ -61,9 +61,13 @@ export function LiveClock() {
   const [now, setNow] = useState<Date | null>(null);
 
   useEffect(() => {
-    setNow(new Date());
-    const id = setInterval(() => setNow(new Date()), 1000);
-    return () => clearInterval(id);
+    const updateNow = () => setNow(new Date());
+    const timeoutId = window.setTimeout(updateNow, 0);
+    const intervalId = window.setInterval(updateNow, 1000);
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.clearInterval(intervalId);
+    };
   }, []);
 
   if (!now) {

--- a/components/dashboard/live-clock.tsx
+++ b/components/dashboard/live-clock.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+function ClockFace({ now }: { now: Date }) {
+  const h = now.getHours() % 12;
+  const m = now.getMinutes();
+  const s = now.getSeconds();
+
+  const secondDeg = s * 6;
+  const minuteDeg = m * 6 + s * 0.1;
+  const hourDeg = h * 30 + m * 0.5;
+
+  const handX = (angle: number, len: number) =>
+    50 + len * Math.sin((angle * Math.PI) / 180);
+  const handY = (angle: number, len: number) =>
+    50 - len * Math.cos((angle * Math.PI) / 180);
+
+  return (
+    <svg viewBox="0 0 100 100" className="h-28 w-28 shrink-0" aria-hidden>
+      <circle
+        cx="50" cy="50" r="46"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        className="text-border"
+        strokeDasharray="2 5"
+      />
+      {[...Array(12)].map((_, i) => {
+        const a = i * 30;
+        const ox = 50 + 38 * Math.sin((a * Math.PI) / 180);
+        const oy = 50 - 38 * Math.cos((a * Math.PI) / 180);
+        return (
+          <circle key={i} cx={ox} cy={oy} r="1.5" className="fill-border" />
+        );
+      })}
+      <line
+        x1="50" y1="50"
+        x2={handX(hourDeg, 24)} y2={handY(hourDeg, 24)}
+        className="stroke-foreground"
+        strokeWidth="3.5" strokeLinecap="round"
+      />
+      <line
+        x1="50" y1="50"
+        x2={handX(minuteDeg, 34)} y2={handY(minuteDeg, 34)}
+        className="stroke-foreground"
+        strokeWidth="2.5" strokeLinecap="round"
+      />
+      <line
+        x1="50" y1="50"
+        x2={handX(secondDeg, 36)} y2={handY(secondDeg, 36)}
+        className="stroke-accent"
+        strokeWidth="1.5" strokeLinecap="round"
+      />
+      <circle cx="50" cy="50" r="2.5" className="fill-foreground" />
+    </svg>
+  );
+}
+
+export function LiveClock() {
+  const [now, setNow] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setNow(new Date());
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!now) {
+    return (
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <div className="h-14 w-40 animate-pulse rounded-lg bg-surface-elevated" />
+          <div className="mt-2 h-4 w-48 animate-pulse rounded bg-surface-elevated" />
+        </div>
+        <div className="h-28 w-28 animate-pulse rounded-full bg-surface-elevated" />
+      </div>
+    );
+  }
+
+  const hours = now.getHours();
+  const minutes = now.getMinutes().toString().padStart(2, "0");
+  const ampm = hours >= 12 ? "PM" : "AM";
+  const displayHour = hours % 12 || 12;
+  const dateStr = now.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div>
+        <div className="flex items-baseline gap-2">
+          <span className="text-6xl font-bold tabular-nums tracking-tight text-foreground">
+            {displayHour}:{minutes}
+          </span>
+          <span className="text-2xl font-medium text-muted-foreground">{ampm}</span>
+        </div>
+        <p className="mt-1.5 text-sm text-muted-foreground">{dateStr}</p>
+      </div>
+      <ClockFace now={now} />
+    </div>
+  );
+}

--- a/components/note-editor/code-block-tool.ts
+++ b/components/note-editor/code-block-tool.ts
@@ -31,6 +31,7 @@ export class CodeBlockTool implements BlockTool {
   private textarea: HTMLTextAreaElement | null = null;
   private highlightSurface: HTMLPreElement | null = null;
   private highlightCodeNode: HTMLElement | null = null;
+  private langLabelNode: HTMLSpanElement | null = null;
   private layoutFrameId: number | null = null;
 
   private readonly handleTextareaInput = () => {
@@ -91,6 +92,7 @@ export class CodeBlockTool implements BlockTool {
     this.readOnly = readOnly;
     this.data = {
       code: data.code ?? "",
+      language: data.language,
     };
   }
 
@@ -98,6 +100,18 @@ export class CodeBlockTool implements BlockTool {
     const wrapper = document.createElement("div");
     wrapper.className = "note-code-block";
 
+    // ---- Header row: language label ----
+    const header = document.createElement("div");
+    header.className = "note-code-block__header";
+
+    const langLabel = document.createElement("span");
+    langLabel.className = "note-code-block__lang";
+    this.langLabelNode = langLabel;
+    header.append(langLabel);
+
+    wrapper.append(header);
+
+    // ---- Editor area ----
     const editorSurface = document.createElement("div");
     editorSurface.className = "note-code-block__editor";
 
@@ -157,6 +171,7 @@ export class CodeBlockTool implements BlockTool {
     this.textarea = null;
     this.highlightSurface = null;
     this.highlightCodeNode = null;
+    this.langLabelNode = null;
   }
 
   private scheduleLayoutSync() {
@@ -173,9 +188,6 @@ export class CodeBlockTool implements BlockTool {
       window.cancelAnimationFrame(this.layoutFrameId);
     }
 
-    // Re-measure after the block is attached and painted. The immediate call in
-    // render() can happen before Editor.js finalizes layout, which makes the
-    // initial code block appear too short until the user edits it.
     this.layoutFrameId = window.requestAnimationFrame(() => {
       runLayoutSync();
       this.layoutFrameId = window.requestAnimationFrame(() => {
@@ -188,6 +200,7 @@ export class CodeBlockTool implements BlockTool {
   private syncData() {
     this.data = {
       code: this.textarea?.value ?? this.data.code,
+      language: this.data.language,
     };
   }
 
@@ -200,12 +213,22 @@ export class CodeBlockTool implements BlockTool {
       this.highlightCodeNode.innerHTML = this.readOnly
         ? "<span class=\"note-code-block__placeholder\">No code content.</span>"
         : "";
+      this.updateLangLabel(null);
       return;
     }
 
-    this.highlightCodeNode.innerHTML = `${highlightCode(this.data.code)}${
+    const result = highlightCode(this.data.code, this.data.language);
+    this.highlightCodeNode.innerHTML = `${result.html}${
       this.data.code.endsWith("\n") ? "\n " : ""
     }`;
+    this.updateLangLabel(result.language);
+  }
+
+  private updateLangLabel(detected: string | null) {
+    if (!this.langLabelNode) return;
+    const lang = this.data.language ?? detected;
+    this.langLabelNode.textContent = lang ?? "";
+    this.langLabelNode.style.display = lang ? "" : "none";
   }
 
   private syncTextareaHeight() {

--- a/components/note-editor/code-block-tool.ts
+++ b/components/note-editor/code-block-tool.ts
@@ -141,7 +141,7 @@ export class CodeBlockTool implements BlockTool {
   }
 
   public validate(blockData: NoteCodeBlockData) {
-    return blockData.code.trim().length > 0;
+    return typeof blockData.code === "string";
   }
 
   public destroy() {

--- a/components/note-editor/math-block-tool.test.ts
+++ b/components/note-editor/math-block-tool.test.ts
@@ -61,7 +61,7 @@ describe("MathBlockTool", () => {
     expect(pointerListener).not.toHaveBeenCalled();
   });
 
-  it("inserts a paragraph block after the math block on plain enter", () => {
+  it("keeps plain enter inside the math block", () => {
     const { tool, insert, getBlockIndex } = createTool();
     const rendered = tool.render();
     const mathField = rendered.querySelector("math-field");
@@ -76,8 +76,28 @@ describe("MathBlockTool", () => {
 
     mathField?.dispatchEvent(enterEvent);
 
+    expect(getBlockIndex).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("inserts a paragraph block after the math block on shift enter", () => {
+    const { tool, insert, getBlockIndex } = createTool();
+    const rendered = tool.render();
+    const mathField = rendered.querySelector("math-field");
+
+    expect(mathField).not.toBeNull();
+
+    const enterEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Enter",
+      shiftKey: true,
+    });
+
+    mathField?.dispatchEvent(enterEvent);
+
     expect(getBlockIndex).toHaveBeenCalledWith("math-block");
-    expect(insert).toHaveBeenCalledWith("paragraph", {}, undefined, 4, true);
+    expect(insert).toHaveBeenCalledWith("paragraph", { text: "<br>" }, undefined, 4, true);
     expect(enterEvent.defaultPrevented).toBe(true);
   });
 });

--- a/components/note-editor/math-block-tool.ts
+++ b/components/note-editor/math-block-tool.ts
@@ -31,13 +31,14 @@ export class MathBlockTool implements BlockTool {
     event.stopPropagation();
   };
   private readonly handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Enter" && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+    if (event.key === "Enter" && event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
       event.preventDefault();
       event.stopPropagation();
       this.handleInput();
 
       const currentBlockIndex = this.api.blocks.getBlockIndex(this.block.id);
-      this.api.blocks.insert("paragraph", {}, undefined, currentBlockIndex + 1, true);
+      this.api.blocks.insert("paragraph", { text: "<br>" }, undefined, currentBlockIndex + 1, true);
+      this.focusNextBlock();
       return;
     }
 
@@ -109,7 +110,7 @@ export class MathBlockTool implements BlockTool {
   }
 
   public validate(blockData: NoteMathBlockData) {
-    return blockData.latex.trim().length > 0;
+    return typeof blockData.latex === "string";
   }
 
   public destroy() {
@@ -125,5 +126,42 @@ export class MathBlockTool implements BlockTool {
 
     this.mathField = null;
     this.wrapper = null;
+  }
+
+  private focusNextBlock() {
+    const focus = () => {
+      if (typeof document === "undefined") {
+        return;
+      }
+
+      const nextBlock = this.wrapper?.closest(".ce-block")?.nextElementSibling;
+      const focusTarget = nextBlock?.querySelector<HTMLElement>(
+        '[contenteditable="true"], textarea, input, math-field',
+      );
+
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+
+      focusTarget?.focus({ preventScroll: true });
+
+      if (focusTarget?.isContentEditable) {
+        const range = document.createRange();
+        range.selectNodeContents(focusTarget);
+        range.collapse(false);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+    };
+
+    window.requestAnimationFrame(() => {
+      focus();
+      window.setTimeout(focus, 0);
+      window.setTimeout(focus, 50);
+      window.setTimeout(focus, 150);
+      window.setTimeout(focus, 350);
+      window.setTimeout(focus, 650);
+    });
   }
 }

--- a/components/note-editor/note-editor.tsx
+++ b/components/note-editor/note-editor.tsx
@@ -32,12 +32,6 @@ export type NoteEditorProps = {
 };
 
 const MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024;
-const EMPTY_PARAGRAPH_BLOCK: NoteBlock = {
-  type: "paragraph",
-  data: {
-    text: "<br>",
-  },
-};
 const NOTE_BLOCKS_CLIPBOARD_TYPE = "application/x-taskmaster-note-blocks";
 
 type BlockContextMenuState = {
@@ -777,27 +771,6 @@ export function NoteEditor({
       blocks: document.blocks.map((block, index) =>
         targetIndexSet.has(index) ? convertBlock(block, target) : block,
       ) as NoteBlock[],
-    }));
-  };
-
-  const handleMoveBlock = (direction: -1 | 1) => {
-    moveBlocksAtIndexes(getContextTargetIndexes(), direction);
-  };
-
-  const handleInsertBlockBelow = () => {
-    const targetIndexes = getContextTargetIndexes();
-    if (targetIndexes.length === 0) {
-      return;
-    }
-
-    const targetIndex = Math.max(...targetIndexes);
-    void applyDocumentMutation((document) => ({
-      ...document,
-      blocks: [
-        ...document.blocks.slice(0, targetIndex + 1),
-        { ...EMPTY_PARAGRAPH_BLOCK, data: { ...EMPTY_PARAGRAPH_BLOCK.data } },
-        ...document.blocks.slice(targetIndex + 1),
-      ] as NoteBlock[],
     }));
   };
 

--- a/components/note-editor/note-editor.tsx
+++ b/components/note-editor/note-editor.tsx
@@ -1069,13 +1069,31 @@ export function NoteEditor({
     };
 
     const finishDrag = async () => {
+      if (!isDraggingBlocks) return;
+
+      // Stop live pointer tracking immediately so concurrent move events
+      // cannot restart a new drag or render stale previews.
+      isDraggingBlocks = false;
+      candidateBlock = null;
+      pointerMode = null;
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+      removeDragPreview();
+      // Capture dropIndex before clearDropIndicator() zeroes it out.
+      const targetDropIndex = dropIndex;
+      clearDropIndicator();
+      clearReflowTransforms();
+      syncSelectionClasses();
+
       const blocks = getBlocks();
       const selectedIndexes = blocks
         .map((block, index) => (selectedBlocks.has(block) ? index : -1))
         .filter((index) => index >= 0);
 
-      if (dropIndex !== null && selectedIndexes.length > 0) {
-        const targetDropIndex = dropIndex;
+      if (targetDropIndex !== null && selectedIndexes.length > 0) {
         const firstSelectedIndex = selectedIndexes[0];
         const lastSelectedIndex = selectedIndexes[selectedIndexes.length - 1];
 
@@ -1205,8 +1223,14 @@ export function NoteEditor({
     };
 
     const startDrag = (clientY: number) => {
-      if (!candidateBlock || !selectedBlocks.has(candidateBlock)) {
+      if (!candidateBlock) {
         return;
+      }
+
+      // Auto-select the candidate block if it isn't already part of the
+      // selection (enables drag-to-reorder without a prior rubber-band select).
+      if (!selectedBlocks.has(candidateBlock)) {
+        setSelectedBlocks([candidateBlock]);
       }
 
       isDraggingBlocks = true;
@@ -1304,19 +1328,32 @@ export function NoteEditor({
         event.target instanceof Element
           ? event.target.closest<HTMLElement>(".ce-block")
           : null;
-      const shouldPrepareDrag = block && selectedBlocks.has(block);
+      const isBlockSelected = block && selectedBlocks.has(block);
 
-      if (block && !shouldPrepareDrag) {
+      if (block && !isBlockSelected) {
+        // Block is not selected — clear any prior selection. We still set up
+        // pointer tracking so a drag gesture will work without a prior
+        // rubber-band select. If the user just clicks (no drag), pointerup
+        // calls clearSelection and allows native focus/cursor to work.
         clearSelection();
+        pointerMode = "pointer";
+        pressedBlock = block;
+        candidateBlock = block; // allow immediate drag
+        startX = event.clientX;
+        startY = event.clientY;
+        // No preventDefault — let the click focus the block for text editing.
+        window.addEventListener("pointermove", handlePointerMove);
+        window.addEventListener("pointerup", handlePointerUp);
+        window.addEventListener("pointercancel", handlePointerUp);
         return;
       }
 
       pointerMode = "pointer";
       pressedBlock = block;
-      candidateBlock = shouldPrepareDrag ? block : null;
+      candidateBlock = isBlockSelected ? block : null;
       startX = event.clientX;
       startY = event.clientY;
-      if (shouldPrepareDrag) {
+      if (isBlockSelected) {
         event.preventDefault();
       }
       window.addEventListener("pointermove", handlePointerMove);
@@ -1396,19 +1433,26 @@ export function NoteEditor({
         event.target instanceof Element
           ? event.target.closest<HTMLElement>(".ce-block")
           : null;
-      const shouldPrepareDrag = block && selectedBlocks.has(block);
+      const isBlockSelected = block && selectedBlocks.has(block);
 
-      if (block && !shouldPrepareDrag) {
+      if (block && !isBlockSelected) {
         clearSelection();
+        pointerMode = "mouse";
+        pressedBlock = block;
+        candidateBlock = block;
+        startX = event.clientX;
+        startY = event.clientY;
+        window.addEventListener("mousemove", handleMouseMove);
+        window.addEventListener("mouseup", handleMouseUp);
         return;
       }
 
       pointerMode = "mouse";
       pressedBlock = block;
-      candidateBlock = shouldPrepareDrag ? block : null;
+      candidateBlock = isBlockSelected ? block : null;
       startX = event.clientX;
       startY = event.clientY;
-      if (shouldPrepareDrag) {
+      if (isBlockSelected) {
         event.preventDefault();
       }
       window.addEventListener("mousemove", handleMouseMove);
@@ -1446,9 +1490,12 @@ export function NoteEditor({
             return;
           }
 
+          // 220px wide menu, 320px max height — clamp so it never clips viewport.
+          const menuW = 220;
+          const menuH = 320;
           setBlockContextMenu({
-            x: event.clientX,
-            y: event.clientY,
+            x: Math.min(event.clientX, window.innerWidth - menuW - 8),
+            y: Math.min(event.clientY, window.innerHeight - menuH - 8),
             blockIndex,
             blockType: noteBlock.type,
           });
@@ -1461,6 +1508,7 @@ export function NoteEditor({
     selectionScope.addEventListener("pointerdown", handlePointerDown, true);
     selectionScope.addEventListener("mousedown", handleMouseDown, true);
     selectionScope.addEventListener("contextmenu", handleContextMenu, true);
+    window.addEventListener("blur", resetInteractionState);
 
     return () => {
       selectionScope.removeEventListener(
@@ -1474,6 +1522,7 @@ export function NoteEditor({
         handleContextMenu,
         true,
       );
+      window.removeEventListener("blur", resetInteractionState);
       resetInteractionState();
       clearBlockSelectionRef.current = () => undefined;
       selectedBlockIndexesRef.current = [];
@@ -1943,11 +1992,14 @@ export function NoteEditor({
         ? window.getSelection()?.getRangeAt(0).getBoundingClientRect()
         : null;
       const blockRect = block.getBoundingClientRect();
-      const x = selectionRect && selectionRect.left > 0 ? selectionRect.left : blockRect.left + 32;
-      const y =
+      const rawX = selectionRect && selectionRect.left > 0 ? selectionRect.left : blockRect.left + 32;
+      const rawY =
         selectionRect && selectionRect.bottom > 0
           ? selectionRect.bottom + 8
           : blockRect.top + 36;
+      // Clamp so the 288px-wide menu doesn't overflow the viewport.
+      const x = Math.min(rawX, window.innerWidth - 296);
+      const y = rawY;
 
       setSlashCommandMenu((current) => {
         const query = match[1] ?? "";
@@ -2086,8 +2138,8 @@ export function NoteEditor({
           className="note-editor__slash-menu"
           role="menu"
           style={{
-            left: slashCommandMenu.x,
-            top: slashCommandMenu.y,
+            left: `clamp(4px, ${slashCommandMenu.x}px, calc(100vw - 18.5rem))`,
+            top: `clamp(4px, ${slashCommandMenu.y}px, calc(100vh - 24rem))`,
           }}
         >
           {getSlashCommandMatches(slashCommandMenu.query).length > 0 ? (
@@ -2120,8 +2172,8 @@ export function NoteEditor({
           className="note-editor__context-menu"
           role="menu"
           style={{
-            left: blockContextMenu.x,
-            top: blockContextMenu.y,
+            left: `clamp(4px, ${blockContextMenu.x}px, calc(100vw - 14rem))`,
+            top: `clamp(4px, ${blockContextMenu.y}px, calc(100vh - 22rem))`,
           }}
           onContextMenu={(event) => event.preventDefault()}
         >
@@ -2207,28 +2259,6 @@ export function NoteEditor({
               </button>
             </div>
           </div>
-          <div className="note-editor__context-menu-separator" />
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => handleInsertBlockBelow()}
-          >
-            New block below
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => handleMoveBlock(-1)}
-          >
-            Move up
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => handleMoveBlock(1)}
-          >
-            Move down
-          </button>
           <div className="note-editor__context-menu-separator" />
           <button
             type="button"

--- a/components/note-editor/note-editor.tsx
+++ b/components/note-editor/note-editor.tsx
@@ -1,9 +1,22 @@
 "use client";
 
-import { useEffect, useEffectEvent, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import type EditorJS from "@editorjs/editorjs";
 import type { BlockToolConstructable } from "@editorjs/editorjs";
-import type { NoteContent, NoteDocument, NoteImageFileData } from "@/lib/notes/types";
+import type {
+  NoteBlock,
+  NoteBlockType,
+  NoteContent,
+  NoteDocument,
+  NoteImageFileData,
+} from "@/lib/notes/types";
 import { emptyNoteDocument, NoteDocumentSchema } from "@/lib/notes/types";
 import { createNoteContent } from "@/lib/notes/markdown";
 import { CodeBlockTool } from "@/components/note-editor/code-block-tool";
@@ -15,12 +28,304 @@ export type NoteEditorProps = {
   onSave?: (content: NoteContent) => Promise<void>;
   uploadImage?: (file: File) => Promise<NoteImageFileData>;
   readOnly?: boolean;
+  selectionPrelude?: ReactNode;
 };
 
 const MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024;
+const EMPTY_PARAGRAPH_BLOCK: NoteBlock = {
+  type: "paragraph",
+  data: {
+    text: "",
+  },
+};
+
+type BlockContextMenuState = {
+  x: number;
+  y: number;
+  blockIndex: number;
+  blockType: NoteBlockType;
+};
+
+type SlashCommandMenuState = {
+  x: number;
+  y: number;
+  blockIndex: number;
+  query: string;
+};
+
+type BlockConversionTarget =
+  | { type: "paragraph" }
+  | { type: "header"; level: 1 | 2 | 3 | 4 }
+  | { type: "list"; style: "ordered" | "unordered" | "checklist" }
+  | { type: "quote" }
+  | { type: "code" }
+  | { type: "math" };
+
+type SlashCommand = {
+  id: string;
+  label: string;
+  hint: string;
+  keywords: string[];
+  target: BlockConversionTarget;
+};
+
+const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    id: "text",
+    label: "Text",
+    hint: "Plain text block",
+    keywords: ["paragraph", "plain"],
+    target: { type: "paragraph" },
+  },
+  {
+    id: "h1",
+    label: "Heading 1",
+    hint: "Large section heading",
+    keywords: ["heading", "title", "h1"],
+    target: { type: "header", level: 1 },
+  },
+  {
+    id: "h2",
+    label: "Heading 2",
+    hint: "Medium section heading",
+    keywords: ["heading", "subtitle", "h2"],
+    target: { type: "header", level: 2 },
+  },
+  {
+    id: "h3",
+    label: "Heading 3",
+    hint: "Small section heading",
+    keywords: ["heading", "h3"],
+    target: { type: "header", level: 3 },
+  },
+  {
+    id: "bullet",
+    label: "Bulleted list",
+    hint: "Simple unordered list",
+    keywords: ["list", "ul", "bullet"],
+    target: { type: "list", style: "unordered" },
+  },
+  {
+    id: "number",
+    label: "Numbered list",
+    hint: "Ordered list",
+    keywords: ["list", "ol", "number"],
+    target: { type: "list", style: "ordered" },
+  },
+  {
+    id: "todo",
+    label: "Checklist",
+    hint: "Track tasks",
+    keywords: ["todo", "task", "check"],
+    target: { type: "list", style: "checklist" },
+  },
+  {
+    id: "quote",
+    label: "Quote",
+    hint: "Callout text",
+    keywords: ["blockquote", "callout"],
+    target: { type: "quote" },
+  },
+  {
+    id: "code",
+    label: "Code",
+    hint: "Code block",
+    keywords: ["pre", "snippet"],
+    target: { type: "code" },
+  },
+  {
+    id: "math",
+    label: "Math",
+    hint: "Equation block",
+    keywords: ["equation", "latex"],
+    target: { type: "math" },
+  },
+];
 
 function areDocumentsEqual(left: NoteDocument, right: NoteDocument) {
   return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function stripHtml(value: string) {
+  return value
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|li|blockquote|h[1-6])>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function getBlockText(block: NoteBlock, options?: { plain?: boolean }) {
+  const normalize = options?.plain ? stripHtml : (value: string) => value;
+
+  switch (block.type) {
+    case "paragraph":
+    case "header":
+      return normalize(block.data.text);
+    case "quote":
+      return normalize(block.data.text);
+    case "list":
+      return normalize(block.data.items.map((item) => item.content).join("\n"));
+    case "code":
+      return block.data.code;
+    case "math":
+      return block.data.latex;
+    case "image":
+      return normalize(block.data.caption);
+    default:
+      return "";
+  }
+}
+
+function convertBlock(
+  block: NoteBlock,
+  target: BlockConversionTarget,
+): NoteBlock {
+  const richText = getBlockText(block);
+  const plainText = getBlockText(block, { plain: true });
+
+  switch (target.type) {
+    case "paragraph":
+      return {
+        type: "paragraph",
+        data: {
+          text: richText,
+        },
+      };
+    case "header":
+      return {
+        type: "header",
+        data: {
+          text: richText,
+          level: target.level,
+        },
+      };
+    case "list":
+      return {
+        type: "list",
+        data: {
+          style: target.style,
+          items: plainText
+            .split("\n")
+            .map((item) => item.trim())
+            .filter(Boolean)
+            .map((item) => ({
+              content: item,
+              meta: target.style === "checklist" ? { checked: false } : {},
+              items: [],
+            })),
+        },
+      };
+    case "quote":
+      return {
+        type: "quote",
+        data: {
+          text: richText,
+          caption: "",
+          alignment: "left",
+        },
+      };
+    case "code":
+      return {
+        type: "code",
+        data: {
+          code: plainText,
+        },
+      };
+    case "math":
+      return {
+        type: "math",
+        data: {
+          latex: plainText,
+        },
+      };
+    default:
+      return block;
+  }
+}
+
+function createEmptyBlockForTarget(target: BlockConversionTarget): NoteBlock {
+  switch (target.type) {
+    case "paragraph":
+      return {
+        type: "paragraph",
+        data: {
+          text: "",
+        },
+      };
+    case "header":
+      return {
+        type: "header",
+        data: {
+          text: "",
+          level: target.level,
+        },
+      };
+    case "list":
+      return {
+        type: "list",
+        data: {
+          style: target.style,
+          items: [
+            {
+              content: "",
+              meta: target.style === "checklist" ? { checked: false } : {},
+              items: [],
+            },
+          ],
+        },
+      };
+    case "quote":
+      return {
+        type: "quote",
+        data: {
+          text: "",
+          caption: "",
+          alignment: "left",
+        },
+      };
+    case "code":
+      return {
+        type: "code",
+        data: {
+          code: "",
+        },
+      };
+    case "math":
+      return {
+        type: "math",
+        data: {
+          latex: "",
+        },
+      };
+    default:
+      return {
+        type: "paragraph",
+        data: {
+          text: "",
+        },
+      };
+  }
+}
+
+function getSlashCommandMatches(query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return SLASH_COMMANDS;
+  }
+
+  return SLASH_COMMANDS.filter((command) =>
+    [command.label, command.id, ...command.keywords].some((value) =>
+      value.toLowerCase().includes(normalizedQuery),
+    ),
+  );
 }
 
 async function uploadImageToDataUrl(file: File): Promise<NoteImageFileData> {
@@ -67,13 +372,20 @@ export function NoteEditor({
   onSave,
   uploadImage,
   readOnly = false,
+  selectionPrelude,
 }: NoteEditorProps) {
+  const selectionScopeRef = useRef<HTMLElement | null>(null);
   const holderRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<EditorJS | null>(null);
   const changeTimeoutRef = useRef<number | null>(null);
   const renderedDocumentRef = useRef<NoteDocument>(initialDocument);
   const pendingSaveRef = useRef<NoteContent | null>(null);
   const isFlushingSaveRef = useRef(false);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  const [blockContextMenu, setBlockContextMenu] =
+    useState<BlockContextMenuState | null>(null);
+  const [slashCommandMenu, setSlashCommandMenu] =
+    useState<SlashCommandMenuState | null>(null);
 
   const flushPendingSaves = useEffectEvent(async () => {
     if (!onSave || isFlushingSaveRef.current) {
@@ -120,6 +432,52 @@ export function NoteEditor({
     }
   });
 
+  const applyDocumentMutation = useCallback(
+    async (mutate: (document: NoteDocument) => NoteDocument) => {
+      const editor = editorRef.current;
+      if (!editor) {
+        return;
+      }
+
+      try {
+        const saved = NoteDocumentSchema.parse(await editor.save());
+        const nextDocument = NoteDocumentSchema.parse(mutate(saved));
+        renderedDocumentRef.current = nextDocument;
+        await editor.render(
+          nextDocument.blocks.length > 0
+            ? nextDocument
+            : { ...emptyNoteDocument },
+        );
+        const content = createNoteContent(nextDocument);
+        onContentChange?.(content);
+
+        if (onSave) {
+          pendingSaveRef.current = content;
+
+          if (!isFlushingSaveRef.current) {
+            isFlushingSaveRef.current = true;
+
+            try {
+              while (pendingSaveRef.current) {
+                const nextContent = pendingSaveRef.current;
+                pendingSaveRef.current = null;
+                await onSave(nextContent);
+              }
+            } finally {
+              isFlushingSaveRef.current = false;
+            }
+          }
+        }
+      } catch (error) {
+        console.error("Failed to update note block.", error);
+      } finally {
+        setBlockContextMenu(null);
+        setSlashCommandMenu(null);
+      }
+    },
+    [onContentChange, onSave],
+  );
+
   const resolveImageUpload = useEffectEvent(async (file: File) => {
     const resolvedFile = uploadImage
       ? await uploadImage(file)
@@ -128,6 +486,743 @@ export function NoteEditor({
     return {
       success: 1 as const,
       file: resolvedFile,
+    };
+  });
+
+  const handleConvertBlock = (target: BlockConversionTarget) => {
+    if (!blockContextMenu) {
+      return;
+    }
+
+    const targetIndex = blockContextMenu.blockIndex;
+    void applyDocumentMutation((document) => ({
+      ...document,
+      blocks: document.blocks.map((block, index) =>
+        index === targetIndex ? convertBlock(block, target) : block,
+      ) as NoteBlock[],
+    }));
+  };
+
+  const handleMoveBlock = (direction: -1 | 1) => {
+    if (!blockContextMenu) {
+      return;
+    }
+
+    const targetIndex = blockContextMenu.blockIndex;
+    void applyDocumentMutation((document) => {
+      const blocks = [...document.blocks];
+      const nextIndex = targetIndex + direction;
+
+      if (nextIndex < 0 || nextIndex >= blocks.length) {
+        return document;
+      }
+
+      const currentBlock = blocks[targetIndex];
+      const nextBlock = blocks[nextIndex];
+      if (!currentBlock || !nextBlock) {
+        return document;
+      }
+
+      blocks[targetIndex] = nextBlock;
+      blocks[nextIndex] = currentBlock;
+
+      return {
+        ...document,
+        blocks,
+      };
+    });
+  };
+
+  const handleInsertBlockBelow = () => {
+    if (!blockContextMenu) {
+      return;
+    }
+
+    const targetIndex = blockContextMenu.blockIndex;
+    void applyDocumentMutation((document) => ({
+      ...document,
+      blocks: [
+        ...document.blocks.slice(0, targetIndex + 1),
+        { ...EMPTY_PARAGRAPH_BLOCK, data: { ...EMPTY_PARAGRAPH_BLOCK.data } },
+        ...document.blocks.slice(targetIndex + 1),
+      ] as NoteBlock[],
+    }));
+  };
+
+  const handleDeleteBlock = () => {
+    if (!blockContextMenu) {
+      return;
+    }
+
+    const targetIndex = blockContextMenu.blockIndex;
+    void applyDocumentMutation((document) => ({
+      ...document,
+      blocks: document.blocks.filter(
+        (_, index) => index !== targetIndex,
+      ) as NoteBlock[],
+    }));
+  };
+
+  const handleSlashCommand = useCallback((command: SlashCommand) => {
+    if (!slashCommandMenu) {
+      return;
+    }
+
+    const targetIndex = slashCommandMenu.blockIndex;
+    void applyDocumentMutation((document) => ({
+      ...document,
+      blocks: document.blocks.map((block, index) =>
+        index === targetIndex
+          ? getBlockText(block, { plain: true }).startsWith("/")
+            ? createEmptyBlockForTarget(command.target)
+            : convertBlock(block, command.target)
+          : block,
+      ) as NoteBlock[],
+    }));
+  }, [applyDocumentMutation, slashCommandMenu]);
+
+  const installBlockSurfaceDragging = useEffectEvent((editor: EditorJS) => {
+    if (readOnly || !holderRef.current || !selectionScopeRef.current) {
+      return () => undefined;
+    }
+
+    const holder = holderRef.current;
+    const selectionScope = selectionScopeRef.current;
+    const dragThreshold = 8;
+    let candidateBlock: HTMLElement | null = null;
+    let pressedBlock: HTMLElement | null = null;
+    let isDraggingBlocks = false;
+    let isSelectingBlocks = false;
+    let dropIndex: number | null = null;
+    let selectedBlocks = new Set<HTMLElement>();
+    let pointerMode: "pointer" | "mouse" | null = null;
+    let selectionBox: HTMLDivElement | null = null;
+    let dropIndicator: HTMLDivElement | null = null;
+    let dragPreview: HTMLDivElement | null = null;
+    let dragPreviewPointerOffsetX = 0;
+    let dragPreviewPointerOffsetY = 0;
+    let selectedGroupHeight = 0;
+    let dragLayout: Array<{
+      block: HTMLElement;
+      height: number;
+      index: number;
+      top: number;
+    }> = [];
+    let startX = 0;
+    let startY = 0;
+
+    const getBlocks = () =>
+      Array.from(holder.querySelectorAll<HTMLElement>(".ce-block"));
+    const clearDropIndicator = () => {
+      dropIndex = null;
+      dropIndicator?.remove();
+      dropIndicator = null;
+    };
+
+    const removeDragPreview = () => {
+      dragPreview?.remove();
+      dragPreview = null;
+    };
+
+    const clearReflowTransforms = () => {
+      getBlocks().forEach((block) => {
+        block.style.removeProperty("transform");
+      });
+    };
+
+    const syncSelectionClasses = () => {
+      getBlocks().forEach((block) => {
+        block.classList.toggle(
+          "note-editor__block-selected",
+          selectedBlocks.has(block),
+        );
+        block.classList.toggle(
+          "note-editor__block-dragging",
+          isDraggingBlocks && selectedBlocks.has(block),
+        );
+      });
+    };
+
+    const setSelectedBlocks = (blocks: HTMLElement[]) => {
+      window.getSelection()?.removeAllRanges();
+      selectedBlocks = new Set(blocks);
+      syncSelectionClasses();
+    };
+
+    const clearSelection = () => {
+      selectedBlocks = new Set();
+      syncSelectionClasses();
+    };
+
+    const removeSelectionBox = () => {
+      selectionBox?.remove();
+      selectionBox = null;
+    };
+
+    const isEditorControlTarget = (target: EventTarget | null) =>
+      target instanceof Element &&
+      !target.closest("[data-note-selection-region]") &&
+      Boolean(
+        target.closest(
+          [
+            "button",
+            "input",
+            "textarea",
+            "select",
+            "math-field",
+            ".ce-toolbar",
+            ".ce-popover",
+            ".ce-inline-toolbar",
+            ".ce-conversion-toolbar",
+            ".ce-settings",
+            ".ce-toolbox",
+            ".ML__keyboard",
+            ".MLK__backdrop",
+            ".MLK__plate",
+            ".MLK__layer",
+          ].join(", "),
+        ),
+      );
+
+    const isContextMenuControlTarget = (target: EventTarget | null) =>
+      target instanceof Element &&
+      Boolean(
+        target.closest(
+          [
+            ".ce-toolbar",
+            ".ce-popover",
+            ".ce-inline-toolbar",
+            ".ce-conversion-toolbar",
+            ".ce-settings",
+            ".ce-toolbox",
+            ".ML__keyboard",
+            ".MLK__backdrop",
+            ".MLK__plate",
+            ".MLK__layer",
+          ].join(", "),
+        ),
+      );
+
+    const getDropIndexFromPoint = (clientY: number) => {
+      if (dragLayout.length === 0) {
+        return null;
+      }
+
+      let nextDropIndex = dragLayout.length;
+      for (const item of dragLayout) {
+        if (clientY < item.top + item.height / 2) {
+          nextDropIndex = item.index;
+          break;
+        }
+      }
+
+      return nextDropIndex;
+    };
+
+    const setDropPlaceholderTop = (top: number) => {
+      dropIndicator ??= document.createElement("div");
+      dropIndicator.className = "note-editor__drop-placeholder";
+
+      if (!dropIndicator.parentElement) {
+        holder.append(dropIndicator);
+      }
+
+      const holderRect = holder.getBoundingClientRect();
+      dropIndicator.style.top = `${top - holderRect.top + holder.scrollTop}px`;
+      dropIndicator.style.height = `${Math.max(selectedGroupHeight, 36)}px`;
+    };
+
+    const applyDynamicReflow = (clientY: number) => {
+      const nextDropIndex = getDropIndexFromPoint(clientY);
+      if (nextDropIndex === null) {
+        clearDropIndicator();
+        return;
+      }
+
+      dropIndex = nextDropIndex;
+      const selectedIndexes = dragLayout
+        .filter((item) => selectedBlocks.has(item.block))
+        .map((item) => item.index);
+
+      if (selectedIndexes.length === 0) {
+        clearDropIndicator();
+        return;
+      }
+
+      const selectedIndexSet = new Set(selectedIndexes);
+      const removedBeforeDrop = selectedIndexes.filter(
+        (index) => index < nextDropIndex,
+      ).length;
+      const adjustedDropIndex = Math.max(0, nextDropIndex - removedBeforeDrop);
+      const remaining = dragLayout.filter(
+        (item) => !selectedIndexSet.has(item.index),
+      );
+      const selected = dragLayout.filter((item) =>
+        selectedIndexSet.has(item.index),
+      );
+      const visualOrder = [
+        ...remaining.slice(0, adjustedDropIndex),
+        ...selected,
+        ...remaining.slice(adjustedDropIndex),
+      ];
+
+      let nextTop = dragLayout[0]?.top ?? 0;
+      let placeholderTop = nextTop;
+      const firstSelected = selected[0];
+      const visualTops = new Map<HTMLElement, number>();
+
+      for (const item of visualOrder) {
+        if (firstSelected && item.block === firstSelected.block) {
+          placeholderTop = nextTop;
+        }
+
+        visualTops.set(item.block, nextTop);
+        nextTop += item.height;
+      }
+
+      dragLayout.forEach((item) => {
+        if (selectedIndexSet.has(item.index)) {
+          item.block.style.removeProperty("transform");
+          return;
+        }
+
+        const visualTop = visualTops.get(item.block);
+        if (visualTop === undefined) {
+          return;
+        }
+
+        item.block.style.transform = `translateY(${visualTop - item.top}px)`;
+      });
+
+      setDropPlaceholderTop(placeholderTop);
+    };
+
+    const resetInteractionState = () => {
+      candidateBlock = null;
+      pressedBlock = null;
+      isDraggingBlocks = false;
+      isSelectingBlocks = false;
+      pointerMode = null;
+      removeSelectionBox();
+      clearDropIndicator();
+      removeDragPreview();
+      clearReflowTransforms();
+      dragLayout = [];
+      syncSelectionClasses();
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+
+    const finishDrag = async () => {
+      const blocks = getBlocks();
+      const selectedIndexes = blocks
+        .map((block, index) => (selectedBlocks.has(block) ? index : -1))
+        .filter((index) => index >= 0);
+
+      if (dropIndex !== null && selectedIndexes.length > 0) {
+        const targetDropIndex = dropIndex;
+        const firstSelectedIndex = selectedIndexes[0];
+        const lastSelectedIndex = selectedIndexes[selectedIndexes.length - 1];
+
+        if (
+          targetDropIndex < firstSelectedIndex ||
+          targetDropIndex > lastSelectedIndex + 1
+        ) {
+          const saved = NoteDocumentSchema.parse(await editor.save());
+          const selectedIndexSet = new Set(selectedIndexes);
+          const movedBlocks = saved.blocks.filter((_, index) =>
+            selectedIndexSet.has(index),
+          );
+          const remainingBlocks = saved.blocks.filter(
+            (_, index) => !selectedIndexSet.has(index),
+          );
+          const removedBeforeDrop = selectedIndexes.filter(
+            (index) => index < targetDropIndex,
+          ).length;
+          const adjustedDropIndex = Math.max(
+            0,
+            targetDropIndex - removedBeforeDrop,
+          );
+          const nextDocument = {
+            ...saved,
+            blocks: [
+              ...remainingBlocks.slice(0, adjustedDropIndex),
+              ...movedBlocks,
+              ...remainingBlocks.slice(adjustedDropIndex),
+            ],
+          };
+
+          renderedDocumentRef.current = nextDocument;
+          await editor.render(nextDocument);
+          window.setTimeout(() => {
+            const nextBlocks = getBlocks();
+            setSelectedBlocks(
+              nextBlocks.slice(
+                adjustedDropIndex,
+                adjustedDropIndex + movedBlocks.length,
+              ),
+            );
+            void emitContentChange();
+          }, 0);
+        }
+      }
+
+      resetInteractionState();
+    };
+
+    const getSelectedBlocksInDocumentOrder = () =>
+      getBlocks().filter((block) => selectedBlocks.has(block));
+
+    const createDragPreview = () => {
+      const selected = getSelectedBlocksInDocumentOrder();
+      if (selected.length === 0) {
+        return;
+      }
+
+      const firstRect = selected[0].getBoundingClientRect();
+      const lastRect = selected[selected.length - 1].getBoundingClientRect();
+      const widestRect = selected.reduce((widest, block) => {
+        const rect = block.getBoundingClientRect();
+        return rect.width > widest.width ? rect : widest;
+      }, firstRect);
+
+      selectedGroupHeight = lastRect.bottom - firstRect.top;
+      dragPreviewPointerOffsetX = startX - widestRect.left;
+      dragPreviewPointerOffsetY = startY - firstRect.top;
+      dragPreview = document.createElement("div");
+      dragPreview.className = "note-editor__drag-preview";
+      dragPreview.style.left = `${startX - dragPreviewPointerOffsetX}px`;
+      dragPreview.style.top = `${startY - dragPreviewPointerOffsetY}px`;
+      dragPreview.style.width = `${widestRect.width}px`;
+
+      selected.forEach((block) => {
+        const clone = block.cloneNode(true);
+        if (clone instanceof HTMLElement) {
+          clone.classList.remove(
+            "note-editor__block-selected",
+            "note-editor__block-dragging",
+          );
+          clone.classList.add("note-editor__drag-preview-block");
+          dragPreview?.append(clone);
+        }
+      });
+
+      document.body.append(dragPreview);
+    };
+
+    const updateDragPreview = (clientX: number, clientY: number) => {
+      if (!dragPreview) {
+        return;
+      }
+
+      dragPreview.style.left = `${clientX - dragPreviewPointerOffsetX}px`;
+      dragPreview.style.top = `${clientY - dragPreviewPointerOffsetY}px`;
+    };
+
+    const updateSelectionBox = (clientX: number, clientY: number) => {
+      if (!selectionBox) {
+        selectionBox = document.createElement("div");
+        selectionBox.className = "note-editor__selection-box";
+        document.body.append(selectionBox);
+      }
+
+      const left = Math.min(startX, clientX);
+      const top = Math.min(startY, clientY);
+      const width = Math.abs(clientX - startX);
+      const height = Math.abs(clientY - startY);
+      selectionBox.style.left = `${left}px`;
+      selectionBox.style.top = `${top}px`;
+      selectionBox.style.width = `${width}px`;
+      selectionBox.style.height = `${height}px`;
+
+      const selectionRect = new DOMRect(left, top, width, height);
+      setSelectedBlocks(
+        getBlocks().filter((block) => {
+          const rect = block.getBoundingClientRect();
+          return (
+            rect.left < selectionRect.right &&
+            rect.right > selectionRect.left &&
+            rect.top < selectionRect.bottom &&
+            rect.bottom > selectionRect.top
+          );
+        }),
+      );
+    };
+
+    const startDrag = (clientY: number) => {
+      if (!candidateBlock || !selectedBlocks.has(candidateBlock)) {
+        return;
+      }
+
+      isDraggingBlocks = true;
+      window.getSelection()?.removeAllRanges();
+      dragLayout = getBlocks().map((block, index) => {
+        const rect = block.getBoundingClientRect();
+        return {
+          block,
+          height: rect.height,
+          index,
+          top: rect.top,
+        };
+      });
+      syncSelectionClasses();
+      createDragPreview();
+      updateDragPreview(startX, startY);
+      applyDynamicReflow(clientY);
+    };
+
+    const startSelectionBox = () => {
+      isSelectingBlocks = true;
+      clearSelection();
+      window.getSelection()?.removeAllRanges();
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (pointerMode !== "pointer") {
+        return;
+      }
+
+      const distance = Math.hypot(
+        event.clientX - startX,
+        event.clientY - startY,
+      );
+      if (!isDraggingBlocks && !isSelectingBlocks && distance < dragThreshold) {
+        return;
+      }
+
+      event.preventDefault();
+      if (!candidateBlock && !isSelectingBlocks) {
+        startSelectionBox();
+      }
+
+      if (isSelectingBlocks) {
+        updateSelectionBox(event.clientX, event.clientY);
+        return;
+      }
+
+      if (!isDraggingBlocks) {
+        startDrag(event.clientY);
+        return;
+      }
+
+      updateDragPreview(event.clientX, event.clientY);
+      applyDynamicReflow(event.clientY);
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      if (pointerMode !== "pointer") {
+        return;
+      }
+
+      if (isDraggingBlocks) {
+        event.preventDefault();
+        void finishDrag();
+        return;
+      }
+
+      if (isSelectingBlocks) {
+        event.preventDefault();
+      } else if (pressedBlock) {
+        if (selectedBlocks.has(pressedBlock)) {
+          event.preventDefault();
+          clearSelection();
+        } else {
+          clearSelection();
+        }
+      } else {
+        clearSelection();
+      }
+
+      resetInteractionState();
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        pointerMode ||
+        event.button !== 0 ||
+        isEditorControlTarget(event.target)
+      ) {
+        return;
+      }
+
+      const block =
+        event.target instanceof Element
+          ? event.target.closest<HTMLElement>(".ce-block")
+          : null;
+      const shouldPrepareDrag = block && selectedBlocks.has(block);
+
+      if (block && !shouldPrepareDrag) {
+        clearSelection();
+        return;
+      }
+
+      pointerMode = "pointer";
+      pressedBlock = block;
+      candidateBlock = shouldPrepareDrag ? block : null;
+      startX = event.clientX;
+      startY = event.clientY;
+      if (shouldPrepareDrag) {
+        event.preventDefault();
+      }
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+      window.addEventListener("pointercancel", handlePointerUp);
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      if (pointerMode !== "mouse") {
+        return;
+      }
+
+      const distance = Math.hypot(
+        event.clientX - startX,
+        event.clientY - startY,
+      );
+      if (!isDraggingBlocks && !isSelectingBlocks && distance < dragThreshold) {
+        return;
+      }
+
+      event.preventDefault();
+      if (!candidateBlock && !isSelectingBlocks) {
+        startSelectionBox();
+      }
+
+      if (isSelectingBlocks) {
+        updateSelectionBox(event.clientX, event.clientY);
+        return;
+      }
+
+      if (!isDraggingBlocks) {
+        startDrag(event.clientY);
+        return;
+      }
+
+      updateDragPreview(event.clientX, event.clientY);
+      applyDynamicReflow(event.clientY);
+    };
+
+    const handleMouseUp = (event: MouseEvent) => {
+      if (pointerMode !== "mouse") {
+        return;
+      }
+
+      if (isDraggingBlocks) {
+        event.preventDefault();
+        void finishDrag();
+        return;
+      }
+
+      if (isSelectingBlocks) {
+        event.preventDefault();
+      } else if (pressedBlock) {
+        if (selectedBlocks.has(pressedBlock)) {
+          event.preventDefault();
+          clearSelection();
+        } else {
+          clearSelection();
+        }
+      } else {
+        clearSelection();
+      }
+
+      resetInteractionState();
+    };
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (
+        pointerMode ||
+        event.button !== 0 ||
+        isEditorControlTarget(event.target)
+      ) {
+        return;
+      }
+
+      const block =
+        event.target instanceof Element
+          ? event.target.closest<HTMLElement>(".ce-block")
+          : null;
+      const shouldPrepareDrag = block && selectedBlocks.has(block);
+
+      if (block && !shouldPrepareDrag) {
+        clearSelection();
+        return;
+      }
+
+      pointerMode = "mouse";
+      pressedBlock = block;
+      candidateBlock = shouldPrepareDrag ? block : null;
+      startX = event.clientX;
+      startY = event.clientY;
+      if (shouldPrepareDrag) {
+        event.preventDefault();
+      }
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    };
+
+    const handleContextMenu = (event: MouseEvent) => {
+      if (isContextMenuControlTarget(event.target)) {
+        return;
+      }
+
+      const block =
+        event.target instanceof Element
+          ? event.target.closest<HTMLElement>(".ce-block")
+          : null;
+
+      if (!block) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      resetInteractionState();
+
+      void (async () => {
+        try {
+          const blockIndex = getBlocks().indexOf(block);
+          if (blockIndex < 0) {
+            return;
+          }
+
+          const saved = NoteDocumentSchema.parse(await editor.save());
+          const noteBlock = saved.blocks[blockIndex];
+          if (!noteBlock) {
+            return;
+          }
+
+          setBlockContextMenu({
+            x: event.clientX,
+            y: event.clientY,
+            blockIndex,
+            blockType: noteBlock.type,
+          });
+        } catch (error) {
+          console.error("Failed to open note block menu.", error);
+        }
+      })();
+    };
+
+    selectionScope.addEventListener("pointerdown", handlePointerDown, true);
+    selectionScope.addEventListener("mousedown", handleMouseDown, true);
+    selectionScope.addEventListener("contextmenu", handleContextMenu, true);
+
+    return () => {
+      selectionScope.removeEventListener(
+        "pointerdown",
+        handlePointerDown,
+        true,
+      );
+      selectionScope.removeEventListener("mousedown", handleMouseDown, true);
+      selectionScope.removeEventListener(
+        "contextmenu",
+        handleContextMenu,
+        true,
+      );
+      resetInteractionState();
     };
   });
 
@@ -180,7 +1275,7 @@ export function NoteEditor({
             class: paragraphTool,
             inlineToolbar: true,
             config: {
-              placeholder: "press '/' for commands",
+              placeholder: "Type '/' for commands",
             },
           },
           header: {
@@ -244,6 +1339,10 @@ export function NoteEditor({
 
       try {
         await editor.isReady;
+        if (!disposed) {
+          dragCleanupRef.current?.();
+          dragCleanupRef.current = installBlockSurfaceDragging(editor);
+        }
       } catch (error) {
         if (!disposed) {
           console.error("Failed to initialize the editor.", error);
@@ -267,6 +1366,8 @@ export function NoteEditor({
 
       const editor = editorRef.current;
       editorRef.current = null;
+      dragCleanupRef.current?.();
+      dragCleanupRef.current = null;
 
       if (editor) {
         void editor.isReady.then(() => editor.destroy()).catch(() => undefined);
@@ -291,7 +1392,9 @@ export function NoteEditor({
     void editor.isReady
       .then(() =>
         editor.render(
-          initialDocument.blocks.length > 0 ? initialDocument : { ...emptyNoteDocument },
+          initialDocument.blocks.length > 0
+            ? initialDocument
+            : { ...emptyNoteDocument },
         ),
       )
       .catch((error) => {
@@ -299,12 +1402,309 @@ export function NoteEditor({
       });
   }, [initialDocument]);
 
+  useEffect(() => {
+    if (readOnly || !holderRef.current) {
+      return;
+    }
+
+    const holder = holderRef.current;
+
+    const getFocusedBlock = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) {
+        return null;
+      }
+
+      if (
+        !target.closest(
+          '[contenteditable="true"], textarea, input, math-field',
+        )
+      ) {
+        return null;
+      }
+
+      return target.closest<HTMLElement>(".ce-block");
+    };
+
+    const updateSlashMenu = () => {
+      const activeElement = document.activeElement;
+      const block = getFocusedBlock(activeElement);
+
+      if (!block) {
+        setSlashCommandMenu(null);
+        return;
+      }
+
+      const blockIndex = Array.from(
+        holder.querySelectorAll<HTMLElement>(".ce-block"),
+      ).indexOf(block);
+
+      if (blockIndex < 0) {
+        setSlashCommandMenu(null);
+        return;
+      }
+
+      const text = stripHtml(block.textContent ?? "");
+      const match = text.match(/^\/([^\s]*)?$/);
+
+      if (!match) {
+        setSlashCommandMenu(null);
+        return;
+      }
+
+      const selectionRect = window.getSelection()?.rangeCount
+        ? window.getSelection()?.getRangeAt(0).getBoundingClientRect()
+        : null;
+      const blockRect = block.getBoundingClientRect();
+      const x = selectionRect && selectionRect.left > 0 ? selectionRect.left : blockRect.left + 32;
+      const y =
+        selectionRect && selectionRect.bottom > 0
+          ? selectionRect.bottom + 8
+          : blockRect.top + 36;
+
+      setSlashCommandMenu({
+        x,
+        y,
+        blockIndex,
+        query: match[1] ?? "",
+      });
+    };
+
+    const handleInput = () => {
+      window.requestAnimationFrame(updateSlashMenu);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSlashCommandMenu(null);
+        return;
+      }
+
+      if (!slashCommandMenu) {
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const firstCommand = getSlashCommandMatches(slashCommandMenu.query)[0];
+        if (firstCommand) {
+          event.preventDefault();
+          handleSlashCommand(firstCommand);
+        }
+      }
+    };
+
+    holder.addEventListener("input", handleInput, true);
+    holder.addEventListener("keyup", handleInput, true);
+    holder.addEventListener("focusin", handleInput, true);
+    holder.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      holder.removeEventListener("input", handleInput, true);
+      holder.removeEventListener("keyup", handleInput, true);
+      holder.removeEventListener("focusin", handleInput, true);
+      holder.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [handleSlashCommand, readOnly, slashCommandMenu]);
+
+  useEffect(() => {
+    if (!blockContextMenu) {
+      return;
+    }
+
+    const closeMenu = (event: Event) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest("[data-note-block-context-menu]")
+      ) {
+        return;
+      }
+
+      setBlockContextMenu(null);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setBlockContextMenu(null);
+      }
+    };
+
+    window.addEventListener("pointerdown", closeMenu, true);
+    window.addEventListener("scroll", closeMenu, true);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", closeMenu, true);
+      window.removeEventListener("scroll", closeMenu, true);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [blockContextMenu]);
+
   return (
-    <section className="note-editor relative min-h-[78vh]">
+    <section
+      ref={selectionScopeRef}
+      className="note-editor relative flex flex-1 flex-col"
+    >
+      {selectionPrelude}
       <div
         ref={holderRef}
-        className="mx-auto min-h-[72vh] w-full max-w-4xl px-2 pb-24 pt-8 md:px-8 md:pb-32 md:pt-12"
+        className="note-editor__canvas flex-1 w-full px-4 pb-28 pt-6 md:px-10 md:pb-36 md:pt-8"
       />
+      {slashCommandMenu ? (
+        <div
+          data-note-slash-command-menu
+          className="note-editor__slash-menu"
+          role="menu"
+          style={{
+            left: slashCommandMenu.x,
+            top: slashCommandMenu.y,
+          }}
+        >
+          {getSlashCommandMatches(slashCommandMenu.query).length > 0 ? (
+            getSlashCommandMatches(slashCommandMenu.query).map((command) => (
+              <button
+                key={command.id}
+                type="button"
+                role="menuitem"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => handleSlashCommand(command)}
+              >
+                <span>{command.label}</span>
+                <span>{command.hint}</span>
+              </button>
+            ))
+          ) : (
+            <div className="note-editor__slash-menu-empty">No commands</div>
+          )}
+        </div>
+      ) : null}
+      {blockContextMenu ? (
+        <div
+          data-note-block-context-menu
+          className="note-editor__context-menu"
+          role="menu"
+          style={{
+            left: blockContextMenu.x,
+            top: blockContextMenu.y,
+          }}
+          onContextMenu={(event) => event.preventDefault()}
+        >
+          <div className="note-editor__context-menu-item note-editor__context-menu-item--submenu">
+            <span>Turn into</span>
+            <span aria-hidden="true">›</span>
+            <div className="note-editor__context-submenu" role="menu">
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => handleConvertBlock({ type: "paragraph" })}
+              >
+                Text
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => handleConvertBlock({ type: "header", level: 1 })}
+              >
+                Heading 1
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => handleConvertBlock({ type: "header", level: 2 })}
+              >
+                Heading 2
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => handleConvertBlock({ type: "header", level: 3 })}
+              >
+                Heading 3
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() =>
+                  handleConvertBlock({ type: "list", style: "unordered" })
+                }
+              >
+                Bulleted list
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() =>
+                  handleConvertBlock({ type: "list", style: "ordered" })
+                }
+              >
+                Numbered list
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() =>
+                  handleConvertBlock({ type: "list", style: "checklist" })
+                }
+              >
+                Checklist
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => handleConvertBlock({ type: "quote" })}
+              >
+                Quote
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => handleConvertBlock({ type: "code" })}
+              >
+                Code
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => handleConvertBlock({ type: "math" })}
+              >
+                Math
+              </button>
+            </div>
+          </div>
+          <div className="note-editor__context-menu-separator" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => handleInsertBlockBelow()}
+          >
+            New block below
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => handleMoveBlock(-1)}
+          >
+            Move up
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => handleMoveBlock(1)}
+          >
+            Move down
+          </button>
+          <div className="note-editor__context-menu-separator" />
+          <button
+            type="button"
+            role="menuitem"
+            className="note-editor__context-menu-danger"
+            onClick={() => handleDeleteBlock()}
+          >
+            Delete block
+          </button>
+          <div className="note-editor__context-menu-meta">
+            {blockContextMenu.blockType}
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/components/note-editor/note-editor.tsx
+++ b/components/note-editor/note-editor.tsx
@@ -35,9 +35,10 @@ const MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024;
 const EMPTY_PARAGRAPH_BLOCK: NoteBlock = {
   type: "paragraph",
   data: {
-    text: "",
+    text: "<br>",
   },
 };
+const NOTE_BLOCKS_CLIPBOARD_TYPE = "application/x-taskmaster-note-blocks";
 
 type BlockContextMenuState = {
   x: number;
@@ -51,6 +52,7 @@ type SlashCommandMenuState = {
   y: number;
   blockIndex: number;
   query: string;
+  activeIndex: number;
 };
 
 type BlockConversionTarget =
@@ -382,6 +384,11 @@ export function NoteEditor({
   const pendingSaveRef = useRef<NoteContent | null>(null);
   const isFlushingSaveRef = useRef(false);
   const dragCleanupRef = useRef<(() => void) | null>(null);
+  const selectedBlockIndexesRef = useRef<number[]>([]);
+  const clearBlockSelectionRef = useRef<() => void>(() => undefined);
+  const pendingBlockFocusTimersRef = useRef<number[]>([]);
+  const shiftEnterInsertIndexRef = useRef<number | null>(null);
+  const shiftEnterChainTimerRef = useRef<number | null>(null);
   const [blockContextMenu, setBlockContextMenu] =
     useState<BlockContextMenuState | null>(null);
   const [slashCommandMenu, setSlashCommandMenu] =
@@ -417,14 +424,84 @@ export function NoteEditor({
     await flushPendingSaves();
   });
 
+  const saveEditorDocument = useCallback(async (editor: EditorJS) => {
+    const saved = NoteDocumentSchema.parse(await editor.save());
+    const holder = holderRef.current;
+    if (!holder) {
+      return saved;
+    }
+
+    const domBlocks = Array.from(holder.querySelectorAll<HTMLElement>(".ce-block"));
+    if (domBlocks.length === 0) {
+      return saved;
+    }
+
+    const savedBlocksById = new Map(
+      saved.blocks
+        .map((block, index) => [block.id, { block, index }] as const)
+        .filter((entry): entry is readonly [string, { block: NoteBlock; index: number }] =>
+          Boolean(entry[0]),
+        ),
+    );
+    const usedSavedIndexes = new Set<number>();
+    let nextSavedIndex = 0;
+
+    const takeNextSavedBlock = () => {
+      while (usedSavedIndexes.has(nextSavedIndex)) {
+        nextSavedIndex += 1;
+      }
+
+      const block = saved.blocks[nextSavedIndex];
+      if (block) {
+        usedSavedIndexes.add(nextSavedIndex);
+        nextSavedIndex += 1;
+      }
+
+      return block;
+    };
+
+    const blocks = domBlocks
+      .map((domBlock) => {
+        const id = domBlock.dataset.id;
+        const savedEntry = id ? savedBlocksById.get(id) : undefined;
+        if (savedEntry) {
+          usedSavedIndexes.add(savedEntry.index);
+          return savedEntry.block;
+        }
+
+        const paragraph = domBlock.querySelector<HTMLElement>(".ce-paragraph");
+        const isEmptyParagraph =
+          paragraph &&
+          paragraph.getAttribute("contenteditable") === "true" &&
+          stripHtml(paragraph.innerHTML).length === 0;
+
+        if (isEmptyParagraph) {
+          return {
+            id,
+            type: "paragraph",
+            data: {
+              text: "<br>",
+            },
+          } satisfies NoteBlock;
+        }
+
+        return takeNextSavedBlock();
+      })
+      .filter((block): block is NoteBlock => Boolean(block));
+
+    return NoteDocumentSchema.parse({
+      ...saved,
+      blocks,
+    });
+  }, []);
+
   const emitContentChange = useEffectEvent(async () => {
     if (!editorRef.current) {
       return;
     }
 
     try {
-      const saved = await editorRef.current.save();
-      const document = NoteDocumentSchema.parse(saved);
+      const document = await saveEditorDocument(editorRef.current);
       const content = createNoteContent(document);
       await publishContent(content);
     } catch (error) {
@@ -440,7 +517,7 @@ export function NoteEditor({
       }
 
       try {
-        const saved = NoteDocumentSchema.parse(await editor.save());
+        const saved = await saveEditorDocument(editor);
         const nextDocument = NoteDocumentSchema.parse(mutate(saved));
         renderedDocumentRef.current = nextDocument;
         await editor.render(
@@ -475,7 +552,7 @@ export function NoteEditor({
         setSlashCommandMenu(null);
       }
     },
-    [onContentChange, onSave],
+    [onContentChange, onSave, saveEditorDocument],
   );
 
   const resolveImageUpload = useEffectEvent(async (file: File) => {
@@ -489,56 +566,231 @@ export function NoteEditor({
     };
   });
 
-  const handleConvertBlock = (target: BlockConversionTarget) => {
+  const getContextTargetIndexes = useCallback(() => {
     if (!blockContextMenu) {
+      return [];
+    }
+
+    const selectedIndexes = selectedBlockIndexesRef.current;
+    return selectedIndexes.includes(blockContextMenu.blockIndex)
+      ? selectedIndexes
+      : [blockContextMenu.blockIndex];
+  }, [blockContextMenu]);
+
+  const cloneBlocksForInsert = useCallback((blocks: NoteBlock[]) => {
+    return blocks.map((block) => {
+      const cloned = structuredClone(block);
+      delete cloned.id;
+      return cloned;
+    }) as NoteBlock[];
+  }, []);
+
+  const getBlocksAtIndexes = useCallback(
+    (document: NoteDocument, indexes: number[]) => {
+      const indexSet = new Set(indexes);
+      return document.blocks.filter((_, index) => indexSet.has(index));
+    },
+    [],
+  );
+
+  const deleteBlocksAtIndexes = useCallback(
+    (indexes: number[]) => {
+      if (indexes.length === 0) {
+        return;
+      }
+
+      const indexSet = new Set(indexes);
+      void applyDocumentMutation((document) => ({
+        ...document,
+        blocks: document.blocks.filter(
+          (_, index) => !indexSet.has(index),
+        ) as NoteBlock[],
+      }));
+      clearBlockSelectionRef.current();
+    },
+    [applyDocumentMutation],
+  );
+
+  const moveBlocksAtIndexes = useCallback(
+    (indexes: number[], direction: -1 | 1) => {
+      if (indexes.length === 0) {
+        return;
+      }
+
+      void applyDocumentMutation((document) => {
+        const blocks = [...document.blocks];
+        const sortedIndexes = [...new Set(indexes)].sort((a, b) => a - b);
+        const indexSet = new Set(sortedIndexes);
+
+        if (direction === -1) {
+          if (sortedIndexes[0] <= 0) {
+            return document;
+          }
+
+          for (const index of sortedIndexes) {
+            const previousIndex = index - 1;
+            if (indexSet.has(previousIndex)) {
+              continue;
+            }
+
+            const currentBlock = blocks[index];
+            const previousBlock = blocks[previousIndex];
+            if (!currentBlock || !previousBlock) {
+              continue;
+            }
+
+            blocks[previousIndex] = currentBlock;
+            blocks[index] = previousBlock;
+          }
+        } else {
+          if (sortedIndexes[sortedIndexes.length - 1] >= blocks.length - 1) {
+            return document;
+          }
+
+          for (const index of [...sortedIndexes].reverse()) {
+            const nextIndex = index + 1;
+            if (indexSet.has(nextIndex)) {
+              continue;
+            }
+
+            const currentBlock = blocks[index];
+            const nextBlock = blocks[nextIndex];
+            if (!currentBlock || !nextBlock) {
+              continue;
+            }
+
+            blocks[nextIndex] = currentBlock;
+            blocks[index] = nextBlock;
+          }
+        }
+
+        return {
+          ...document,
+          blocks,
+        };
+      });
+    },
+    [applyDocumentMutation],
+  );
+
+  const insertBlocksAfterIndex = useCallback(
+    (targetIndex: number, blocksToInsert: NoteBlock[]) => {
+      if (blocksToInsert.length === 0) {
+        return;
+      }
+
+      const nextBlocks = cloneBlocksForInsert(blocksToInsert);
+      void applyDocumentMutation((document) => {
+        const boundedIndex = Math.min(
+          Math.max(targetIndex, -1),
+          document.blocks.length - 1,
+        );
+
+        return {
+          ...document,
+          blocks: [
+            ...document.blocks.slice(0, boundedIndex + 1),
+            ...nextBlocks,
+            ...document.blocks.slice(boundedIndex + 1),
+          ] as NoteBlock[],
+        };
+      });
+      clearBlockSelectionRef.current();
+    },
+    [applyDocumentMutation, cloneBlocksForInsert],
+  );
+
+  const insertEmptyParagraphAfterIndex = useCallback(
+    (blockIndex: number) => {
+      const editor = editorRef.current;
+      if (!editor) {
+        return;
+      }
+
+      const boundedIndex = Math.max(-1, blockIndex);
+      editor.blocks.insert(
+        "paragraph",
+        { text: "<br>" },
+        undefined,
+        boundedIndex + 1,
+        true,
+      );
+      clearBlockSelectionRef.current();
+      setSlashCommandMenu(null);
+      shiftEnterInsertIndexRef.current = boundedIndex + 1;
+      if (shiftEnterChainTimerRef.current !== null) {
+        window.clearTimeout(shiftEnterChainTimerRef.current);
+      }
+      shiftEnterChainTimerRef.current = window.setTimeout(() => {
+        shiftEnterInsertIndexRef.current = null;
+        shiftEnterChainTimerRef.current = null;
+      }, 1200);
+
+      pendingBlockFocusTimersRef.current.forEach((timer) => {
+        window.clearTimeout(timer);
+      });
+      pendingBlockFocusTimersRef.current = [];
+
+      const focusInsertedBlock = () => {
+        const holder = holderRef.current;
+        const nextBlock = holder?.querySelectorAll<HTMLElement>(".ce-block")[
+          boundedIndex + 1
+        ];
+        const focusTarget = nextBlock?.querySelector<HTMLElement>(
+          '[contenteditable="true"], textarea, input, math-field',
+        );
+        if (document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur();
+        }
+
+        focusTarget?.focus({ preventScroll: true });
+
+        if (focusTarget?.isContentEditable) {
+          const range = document.createRange();
+          range.selectNodeContents(focusTarget);
+          range.collapse(false);
+          const selection = window.getSelection();
+          selection?.removeAllRanges();
+          selection?.addRange(range);
+        }
+      };
+
+      window.requestAnimationFrame(() => {
+        focusInsertedBlock();
+        pendingBlockFocusTimersRef.current = [0, 50, 150, 350, 650].map((delay) =>
+          window.setTimeout(focusInsertedBlock, delay),
+        );
+      });
+    },
+    [],
+  );
+
+  const handleConvertBlock = (target: BlockConversionTarget) => {
+    const targetIndexes = getContextTargetIndexes();
+    if (targetIndexes.length === 0) {
       return;
     }
 
-    const targetIndex = blockContextMenu.blockIndex;
+    const targetIndexSet = new Set(targetIndexes);
     void applyDocumentMutation((document) => ({
       ...document,
       blocks: document.blocks.map((block, index) =>
-        index === targetIndex ? convertBlock(block, target) : block,
+        targetIndexSet.has(index) ? convertBlock(block, target) : block,
       ) as NoteBlock[],
     }));
   };
 
   const handleMoveBlock = (direction: -1 | 1) => {
-    if (!blockContextMenu) {
-      return;
-    }
-
-    const targetIndex = blockContextMenu.blockIndex;
-    void applyDocumentMutation((document) => {
-      const blocks = [...document.blocks];
-      const nextIndex = targetIndex + direction;
-
-      if (nextIndex < 0 || nextIndex >= blocks.length) {
-        return document;
-      }
-
-      const currentBlock = blocks[targetIndex];
-      const nextBlock = blocks[nextIndex];
-      if (!currentBlock || !nextBlock) {
-        return document;
-      }
-
-      blocks[targetIndex] = nextBlock;
-      blocks[nextIndex] = currentBlock;
-
-      return {
-        ...document,
-        blocks,
-      };
-    });
+    moveBlocksAtIndexes(getContextTargetIndexes(), direction);
   };
 
   const handleInsertBlockBelow = () => {
-    if (!blockContextMenu) {
+    const targetIndexes = getContextTargetIndexes();
+    if (targetIndexes.length === 0) {
       return;
     }
 
-    const targetIndex = blockContextMenu.blockIndex;
+    const targetIndex = Math.max(...targetIndexes);
     void applyDocumentMutation((document) => ({
       ...document,
       blocks: [
@@ -550,17 +802,7 @@ export function NoteEditor({
   };
 
   const handleDeleteBlock = () => {
-    if (!blockContextMenu) {
-      return;
-    }
-
-    const targetIndex = blockContextMenu.blockIndex;
-    void applyDocumentMutation((document) => ({
-      ...document,
-      blocks: document.blocks.filter(
-        (_, index) => index !== targetIndex,
-      ) as NoteBlock[],
-    }));
+    deleteBlocksAtIndexes(getContextTargetIndexes());
   };
 
   const handleSlashCommand = useCallback((command: SlashCommand) => {
@@ -631,7 +873,12 @@ export function NoteEditor({
     };
 
     const syncSelectionClasses = () => {
-      getBlocks().forEach((block) => {
+      const blocks = getBlocks();
+      selectedBlockIndexesRef.current = blocks
+        .map((block, index) => (selectedBlocks.has(block) ? index : -1))
+        .filter((index) => index >= 0);
+
+      blocks.forEach((block) => {
         block.classList.toggle(
           "note-editor__block-selected",
           selectedBlocks.has(block),
@@ -645,6 +892,9 @@ export function NoteEditor({
 
     const setSelectedBlocks = (blocks: HTMLElement[]) => {
       window.getSelection()?.removeAllRanges();
+      if (blocks.length > 0 && document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
       selectedBlocks = new Set(blocks);
       syncSelectionClasses();
     };
@@ -653,6 +903,8 @@ export function NoteEditor({
       selectedBlocks = new Set();
       syncSelectionClasses();
     };
+
+    clearBlockSelectionRef.current = clearSelection;
 
     const removeSelectionBox = () => {
       selectionBox?.remove();
@@ -831,7 +1083,7 @@ export function NoteEditor({
           targetDropIndex < firstSelectedIndex ||
           targetDropIndex > lastSelectedIndex + 1
         ) {
-          const saved = NoteDocumentSchema.parse(await editor.save());
+          const saved = await saveEditorDocument(editor);
           const selectedIndexSet = new Set(selectedIndexes);
           const movedBlocks = saved.blocks.filter((_, index) =>
             selectedIndexSet.has(index),
@@ -1188,7 +1440,7 @@ export function NoteEditor({
             return;
           }
 
-          const saved = NoteDocumentSchema.parse(await editor.save());
+          const saved = await saveEditorDocument(editor);
           const noteBlock = saved.blocks[blockIndex];
           if (!noteBlock) {
             return;
@@ -1223,6 +1475,8 @@ export function NoteEditor({
         true,
       );
       resetInteractionState();
+      clearBlockSelectionRef.current = () => undefined;
+      selectedBlockIndexesRef.current = [];
     };
   });
 
@@ -1366,6 +1620,15 @@ export function NoteEditor({
 
       const editor = editorRef.current;
       editorRef.current = null;
+      pendingBlockFocusTimersRef.current.forEach((timer) => {
+        window.clearTimeout(timer);
+      });
+      pendingBlockFocusTimersRef.current = [];
+      if (shiftEnterChainTimerRef.current !== null) {
+        window.clearTimeout(shiftEnterChainTimerRef.current);
+        shiftEnterChainTimerRef.current = null;
+      }
+      shiftEnterInsertIndexRef.current = null;
       dragCleanupRef.current?.();
       dragCleanupRef.current = null;
 
@@ -1401,6 +1664,231 @@ export function NoteEditor({
         console.error("Failed to sync note document.", error);
       });
   }, [initialDocument]);
+
+  useEffect(() => {
+    if (readOnly || !selectionScopeRef.current || !holderRef.current) {
+      return;
+    }
+
+    const selectionScope = selectionScopeRef.current;
+    const holder = holderRef.current;
+
+    const isInsideScope = (target: EventTarget | null) =>
+      target instanceof Node && selectionScope.contains(target);
+
+    const isTypingTarget = (target: EventTarget | null) =>
+      target instanceof Element &&
+      Boolean(
+        target.closest(
+          '[contenteditable="true"], textarea, input, select, math-field',
+        ),
+      );
+
+    const hasTextSelection = () =>
+      Boolean(window.getSelection()?.toString().trim());
+
+    const getTargetBlockIndex = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) {
+        return renderedDocumentRef.current.blocks.length - 1;
+      }
+
+      const block = target.closest<HTMLElement>(".ce-block");
+      if (!block) {
+        return renderedDocumentRef.current.blocks.length - 1;
+      }
+
+      return Array.from(holder.querySelectorAll<HTMLElement>(".ce-block")).indexOf(
+        block,
+      );
+    };
+
+    const getEventBlockIndex = (target: EventTarget | null) => {
+      const blockIndex = getTargetBlockIndex(target);
+      return blockIndex >= 0 ? blockIndex : renderedDocumentRef.current.blocks.length - 1;
+    };
+
+    const writeBlocksToClipboard = (
+      clipboardData: DataTransfer,
+      blocks: NoteBlock[],
+    ) => {
+      const document = {
+        time: Date.now(),
+        blocks,
+      };
+      const payload = JSON.stringify({
+        type: "taskmaster.noteBlocks",
+        version: 1,
+        blocks: cloneBlocksForInsert(blocks),
+      });
+
+      clipboardData.setData(NOTE_BLOCKS_CLIPBOARD_TYPE, payload);
+      clipboardData.setData("text/plain", createNoteContent(document).markdown);
+    };
+
+    const readBlocksFromClipboard = (clipboardData: DataTransfer) => {
+      const raw =
+        clipboardData.getData(NOTE_BLOCKS_CLIPBOARD_TYPE) ||
+        clipboardData.getData("text/plain");
+      if (!raw) {
+        return [];
+      }
+
+      try {
+        const payload = JSON.parse(raw) as {
+          type?: string;
+          blocks?: unknown;
+        };
+        if (
+          payload.type !== "taskmaster.noteBlocks" ||
+          !Array.isArray(payload.blocks)
+        ) {
+          return [];
+        }
+
+        return NoteDocumentSchema.parse({
+          time: Date.now(),
+          blocks: payload.blocks,
+        }).blocks;
+      } catch {
+        return [];
+      }
+    };
+
+    const getSelectedBlocks = () => {
+      const indexes = selectedBlockIndexesRef.current;
+      if (indexes.length === 0) {
+        return [];
+      }
+
+      return getBlocksAtIndexes(renderedDocumentRef.current, indexes);
+    };
+
+    const handleCopy = (event: ClipboardEvent) => {
+      if (hasTextSelection() || !event.clipboardData) {
+        return;
+      }
+
+      const blocks = getSelectedBlocks();
+      if (blocks.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+      writeBlocksToClipboard(event.clipboardData, blocks);
+    };
+
+    const handleCut = (event: ClipboardEvent) => {
+      if (hasTextSelection() || !event.clipboardData) {
+        return;
+      }
+
+      const selectedIndexes = selectedBlockIndexesRef.current;
+      const blocks = getSelectedBlocks();
+      if (blocks.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+      writeBlocksToClipboard(event.clipboardData, blocks);
+      deleteBlocksAtIndexes(selectedIndexes);
+    };
+
+    const handlePaste = (event: ClipboardEvent) => {
+      const selectedIndexes = selectedBlockIndexesRef.current;
+      if (
+        !event.clipboardData ||
+        (selectedIndexes.length === 0 && !isInsideScope(event.target))
+      ) {
+        return;
+      }
+
+      if (selectedIndexes.length === 0 && isTypingTarget(event.target)) {
+        return;
+      }
+
+      const blocks = readBlocksFromClipboard(event.clipboardData);
+      if (blocks.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+      const targetIndex =
+        selectedIndexes.length > 0
+          ? Math.max(...selectedIndexes)
+          : getTargetBlockIndex(event.target);
+      insertBlocksAfterIndex(targetIndex, blocks);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const selectedIndexes = selectedBlockIndexesRef.current;
+      const hasSelectedBlocks = selectedIndexes.length > 0;
+      if (!hasSelectedBlocks && !isInsideScope(event.target)) {
+        return;
+      }
+
+      if (event.key === "Enter" && event.shiftKey && isInsideScope(event.target)) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        insertEmptyParagraphAfterIndex(
+          shiftEnterInsertIndexRef.current ?? getEventBlockIndex(event.target),
+        );
+        return;
+      }
+
+      if (event.key !== "Shift") {
+        shiftEnterInsertIndexRef.current = null;
+      }
+
+      if (event.key === "Escape") {
+        if (hasSelectedBlocks) {
+          event.preventDefault();
+          clearBlockSelectionRef.current();
+        }
+        return;
+      }
+
+      if (!hasSelectedBlocks || hasTextSelection()) {
+        return;
+      }
+
+      if (event.key === "Delete" || event.key === "Backspace") {
+        event.preventDefault();
+        deleteBlocksAtIndexes(selectedIndexes);
+        return;
+      }
+
+      if (event.altKey && event.key === "ArrowUp") {
+        event.preventDefault();
+        moveBlocksAtIndexes(selectedIndexes, -1);
+        return;
+      }
+
+      if (event.altKey && event.key === "ArrowDown") {
+        event.preventDefault();
+        moveBlocksAtIndexes(selectedIndexes, 1);
+      }
+    };
+
+    window.addEventListener("copy", handleCopy, true);
+    window.addEventListener("cut", handleCut, true);
+    window.addEventListener("paste", handlePaste, true);
+    window.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      window.removeEventListener("copy", handleCopy, true);
+      window.removeEventListener("cut", handleCut, true);
+      window.removeEventListener("paste", handlePaste, true);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [
+    cloneBlocksForInsert,
+    deleteBlocksAtIndexes,
+    getBlocksAtIndexes,
+    insertEmptyParagraphAfterIndex,
+    insertBlocksAfterIndex,
+    moveBlocksAtIndexes,
+    readOnly,
+  ]);
 
   useEffect(() => {
     if (readOnly || !holderRef.current) {
@@ -1461,11 +1949,21 @@ export function NoteEditor({
           ? selectionRect.bottom + 8
           : blockRect.top + 36;
 
-      setSlashCommandMenu({
-        x,
-        y,
-        blockIndex,
-        query: match[1] ?? "",
+      setSlashCommandMenu((current) => {
+        const query = match[1] ?? "";
+        const matches = getSlashCommandMatches(query);
+        const activeIndex =
+          current?.blockIndex === blockIndex && current.query === query
+            ? current.activeIndex
+            : 0;
+
+        return {
+          x,
+          y,
+          blockIndex,
+          query,
+          activeIndex: Math.min(activeIndex, Math.max(matches.length - 1, 0)),
+        };
       });
     };
 
@@ -1483,11 +1981,45 @@ export function NoteEditor({
         return;
       }
 
+      const matches = getSlashCommandMatches(slashCommandMenu.query);
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSlashCommandMenu((current) =>
+          current
+            ? {
+                ...current,
+                activeIndex:
+                  matches.length > 0
+                    ? (current.activeIndex + 1) % matches.length
+                    : 0,
+              }
+            : current,
+        );
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSlashCommandMenu((current) =>
+          current
+            ? {
+                ...current,
+                activeIndex:
+                  matches.length > 0
+                    ? (current.activeIndex - 1 + matches.length) % matches.length
+                    : 0,
+              }
+            : current,
+        );
+        return;
+      }
+
       if (event.key === "Enter") {
-        const firstCommand = getSlashCommandMatches(slashCommandMenu.query)[0];
-        if (firstCommand) {
+        const activeCommand = matches[slashCommandMenu.activeIndex] ?? matches[0];
+        if (activeCommand) {
           event.preventDefault();
-          handleSlashCommand(firstCommand);
+          handleSlashCommand(activeCommand);
         }
       }
     };
@@ -1559,11 +2091,17 @@ export function NoteEditor({
           }}
         >
           {getSlashCommandMatches(slashCommandMenu.query).length > 0 ? (
-            getSlashCommandMatches(slashCommandMenu.query).map((command) => (
+            getSlashCommandMatches(slashCommandMenu.query).map((command, index) => (
               <button
                 key={command.id}
                 type="button"
                 role="menuitem"
+                data-active={index === slashCommandMenu.activeIndex ? "true" : undefined}
+                className={
+                  index === slashCommandMenu.activeIndex
+                    ? "note-editor__slash-menu-active"
+                    : undefined
+                }
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => handleSlashCommand(command)}
               >

--- a/components/note-editor/note-surface.test.tsx
+++ b/components/note-editor/note-surface.test.tsx
@@ -110,7 +110,7 @@ describe("NoteSurface", () => {
     cleanup();
   });
 
-  it("renders by default, enters full-note editor mode, and preserves Editor.js-added blocks", async () => {
+  it("opens directly in full-note editor mode and preserves Editor.js-added blocks", async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
 
     render(
@@ -139,11 +139,6 @@ describe("NoteSurface", () => {
       />,
     );
 
-    expect(screen.getByText("Hybrid Notes")).toBeInTheDocument();
-    expect(screen.getByText("Original block")).toBeInTheDocument();
-    expect(screen.queryByTestId("mock-note-editor")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByLabelText("Open note editor"));
     expect(screen.getByTestId("mock-note-editor")).toBeInTheDocument();
     expect(screen.getByText("Mock Editor.js UI")).toBeInTheDocument();
     expect(screen.queryByLabelText("Add block at end")).not.toBeInTheDocument();
@@ -157,12 +152,6 @@ describe("NoteSurface", () => {
     expect(onSave).toHaveBeenCalledTimes(1);
     expect(onSave.mock.calls.at(-1)?.[0]?.markdown).toContain("Updated block");
 
-    fireEvent.pointerDown(document.body);
-
-    expect(screen.queryByTestId("mock-note-editor")).not.toBeInTheDocument();
-    expect(screen.getByText("Updated block")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByLabelText("Open note editor"));
     fireEvent.click(screen.getByLabelText(/Commit paragraph and ordered list/));
 
     await act(async () => {
@@ -170,17 +159,10 @@ describe("NoteSurface", () => {
     });
 
     expect(onSave).toHaveBeenCalledTimes(2);
-
-    fireEvent.pointerDown(document.body);
-
-    expect(screen.queryByTestId("mock-note-editor")).not.toBeInTheDocument();
-    expect(screen.getByText("Updated block")).toBeInTheDocument();
-    expect(screen.getByText("Inserted item")).toBeInTheDocument();
-    expect(document.querySelector("ol")).not.toBeNull();
     expect(onSave.mock.calls.at(-1)?.[0]?.markdown).toContain("1. Inserted item");
   });
 
-  it("resyncs the preview when the parent supplies a different note", () => {
+  it("resyncs the editor when the parent supplies a different note", () => {
     const { rerender } = render(
       <NoteSurface
         initialDocument={{
@@ -198,7 +180,7 @@ describe("NoteSurface", () => {
       />,
     );
 
-    expect(screen.getByText("First note")).toBeInTheDocument();
+    expect(screen.getByLabelText("Commit paragraph note-a")).toBeInTheDocument();
 
     rerender(
       <NoteSurface
@@ -217,8 +199,8 @@ describe("NoteSurface", () => {
       />,
     );
 
-    expect(screen.queryByText("First note")).not.toBeInTheDocument();
-    expect(screen.getByText("Second note")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Commit paragraph note-a")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Commit paragraph note-b")).toBeInTheDocument();
   });
 
   it("does not double-fire onContentChange when a save completes", async () => {
@@ -243,7 +225,6 @@ describe("NoteSurface", () => {
       />,
     );
 
-    fireEvent.click(screen.getByLabelText("Open note editor"));
     fireEvent.click(screen.getByLabelText("Commit paragraph header-1"));
 
     await act(async () => {
@@ -253,7 +234,7 @@ describe("NoteSurface", () => {
     expect(onContentChange).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps rendered links clickable and does not force editor mode", () => {
+  it("renders markdown in read-only mode", () => {
     render(
       <NoteSurface
         initialDocument={{
@@ -268,35 +249,31 @@ describe("NoteSurface", () => {
             },
           ],
         }}
+        readOnly
       />,
     );
-
-    fireEvent.click(screen.getByRole("link", { name: "Open link" }));
 
     expect(screen.queryByTestId("mock-note-editor")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open link" })).toBeInTheDocument();
   });
 
-  it("stays in editor mode when configured to keep editing while empty", () => {
+  it("stays in editor mode for empty notes", () => {
     render(
       <NoteSurface
         initialDocument={{
           time: 1,
           blocks: [],
         }}
-        keepEditingWhenEmpty
       />,
     );
 
     expect(screen.getByTestId("mock-note-editor")).toBeInTheDocument();
     expect(screen.queryByText("No note content yet.")).not.toBeInTheDocument();
 
-    fireEvent.pointerDown(document.body);
-
     expect(screen.getByTestId("mock-note-editor")).toBeInTheDocument();
   });
 
-  it("does not close the editor when interacting with MathLive chrome", () => {
+  it("keeps the editor open when interacting outside the editor", () => {
     render(
       <NoteSurface
         initialDocument={{
@@ -314,37 +291,8 @@ describe("NoteSurface", () => {
       />,
     );
 
-    fireEvent.click(screen.getByLabelText("Open note editor"));
     expect(screen.getByTestId("mock-note-editor")).toBeInTheDocument();
-
-    const virtualKeyboard = document.createElement("div");
-    virtualKeyboard.className = "MLK__plate";
-    document.body.append(virtualKeyboard);
-
-    fireEvent.pointerDown(virtualKeyboard);
-
-    expect(screen.getByTestId("mock-note-editor")).toBeInTheDocument();
-  });
-
-  it("opens the editor when clicking non-interactive preview content", () => {
-    render(
-      <NoteSurface
-        initialDocument={{
-          time: 1,
-          blocks: [
-            {
-              id: "paragraph-1",
-              type: "paragraph",
-              data: {
-                text: "Clickable preview",
-              },
-            },
-          ],
-        }}
-      />,
-    );
-
-    fireEvent.click(screen.getByText("Clickable preview"));
+    fireEvent.pointerDown(document.body);
 
     expect(screen.getByTestId("mock-note-editor")).toBeInTheDocument();
   });

--- a/components/note-editor/note-surface.tsx
+++ b/components/note-editor/note-surface.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { MouseEvent } from "react";
+import { useState, type ReactNode } from "react";
 import { NoteEditor } from "@/components/note-editor/note-editor";
 import { NoteRenderer } from "@/components/note-editor/note-renderer";
 import { createNoteContent } from "@/lib/notes/markdown";
@@ -14,45 +13,8 @@ export type NoteSurfaceProps = {
   uploadImage?: (file: File) => Promise<NoteImageFileData>;
   readOnly?: boolean;
   keepEditingWhenEmpty?: boolean;
+  selectionPrelude?: ReactNode;
 };
-
-function isEditorChromeTarget(target: EventTarget | null) {
-  if (!(target instanceof Element)) {
-    return false;
-  }
-
-  return Boolean(
-    target.closest(
-      [
-        ".ce-toolbar",
-        ".ce-popover",
-        ".ce-inline-toolbar",
-        ".ce-conversion-toolbar",
-        ".ce-toolbox",
-        ".ce-settings",
-        ".ML__keyboard",
-        ".MLK__backdrop",
-        ".MLK__plate",
-        ".MLK__layer",
-        ".ML__virtual-keyboard-toggle",
-        ".ML__menu-toggle",
-        ".ML__tooltip-container",
-      ].join(", "),
-    ),
-  );
-}
-
-function isInteractivePreviewTarget(target: EventTarget | null, container: HTMLElement) {
-  if (!(target instanceof Element)) {
-    return false;
-  }
-
-  const interactiveTarget = target.closest(
-    "a, button, input, textarea, select, summary, [role='button'], [role='link'], [data-note-surface-ignore-click]",
-  );
-
-  return interactiveTarget !== null && interactiveTarget !== container;
-}
 
 function areDocumentsEqual(left: NoteDocument, right: NoteDocument) {
   return JSON.stringify(left) === JSON.stringify(right);
@@ -64,57 +26,15 @@ export function NoteSurface({
   onSave,
   uploadImage,
   readOnly = false,
-  keepEditingWhenEmpty = false,
+  selectionPrelude,
 }: NoteSurfaceProps) {
   const [draftState, setDraftState] = useState(() => ({
     sourceDocument: initialDocument,
     content: createNoteContent(initialDocument),
   }));
-  const [isEditing, setIsEditing] = useState(
-    () =>
-      !readOnly &&
-      keepEditingWhenEmpty &&
-      createNoteContent(initialDocument).markdown.trim().length === 0,
-  );
-  const editorRootRef = useRef<HTMLDivElement | null>(null);
   const content = areDocumentsEqual(draftState.sourceDocument, initialDocument)
     ? draftState.content
     : createNoteContent(initialDocument);
-  const renderedMarkdown = useMemo(() => content.markdown, [content.markdown]);
-  const shouldKeepEditorOpen =
-    !readOnly && keepEditingWhenEmpty && renderedMarkdown.trim().length === 0;
-  const isEditorOpen = isEditing || shouldKeepEditorOpen;
-
-  useEffect(() => {
-    if (!isEditorOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (isEditorChromeTarget(event.target)) {
-        return;
-      }
-
-      if (shouldKeepEditorOpen) {
-        return;
-      }
-
-      if (!editorRootRef.current?.contains(event.target as Node)) {
-        setIsEditing(false);
-      }
-    };
-
-    window.document.addEventListener("pointerdown", handlePointerDown, true);
-    return () => {
-      window.document.removeEventListener("pointerdown", handlePointerDown, true);
-    };
-  }, [isEditorOpen, shouldKeepEditorOpen]);
-
-  const openEditor = () => {
-    if (!readOnly) {
-      setIsEditing(true);
-    }
-  };
 
   const updateContent = (nextContent: NoteContent) => {
     setDraftState({
@@ -123,17 +43,9 @@ export function NoteSurface({
     });
   };
 
-  const handlePreviewClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (readOnly || isInteractivePreviewTarget(event.target, event.currentTarget)) {
-      return;
-    }
-
-    openEditor();
-  };
-
-  if (isEditorOpen && !readOnly) {
+  if (!readOnly) {
     return (
-      <div ref={editorRootRef} className="note-surface">
+      <div className="note-surface note-surface--editing flex flex-1 flex-col">
         <NoteEditor
           initialDocument={content.document}
           onContentChange={(nextContent) => {
@@ -145,21 +57,16 @@ export function NoteSurface({
             await onSave?.(nextContent);
           }}
           uploadImage={uploadImage}
+          selectionPrelude={selectionPrelude}
         />
       </div>
     );
   }
 
   return (
-    <div
-      aria-label={readOnly || shouldKeepEditorOpen ? undefined : "Open note editor"}
-      className="note-surface"
-      onClick={handlePreviewClick}
-      role={readOnly || shouldKeepEditorOpen ? undefined : "button"}
-      tabIndex={readOnly || shouldKeepEditorOpen ? undefined : 0}
-    >
+    <div className="note-surface">
       <div className="note-surface__content">
-        <NoteRenderer markdown={renderedMarkdown} />
+        <NoteRenderer markdown={content.markdown} />
       </div>
     </div>
   );

--- a/components/shell/app-shell.tsx
+++ b/components/shell/app-shell.tsx
@@ -3,8 +3,8 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { usePathname } from "next/navigation";
+import { cx } from "@/lib/utils";
 import { AppSidebar } from "./app-sidebar";
-import { AppTopbar } from "./app-topbar";
 import { useSidebarBehavior } from "./sidebar-preference";
 
 type AppShellProps = {
@@ -14,14 +14,20 @@ type AppShellProps = {
 
 export function AppShell({ children, displayName }: AppShellProps) {
   const pathname = usePathname();
+  const isNotesRoute = pathname.startsWith("/notes");
   const sidebarBehavior = useSidebarBehavior();
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(true);
   const [hoverExpanded, setHoverExpanded] = useState(false);
   const hoverMode = sidebarBehavior === "hover";
   const sidebarCollapsed = hoverMode ? !hoverExpanded : collapsed;
 
   return (
-    <div className="flex min-h-screen bg-background text-foreground">
+    <div
+      className={cx(
+        "flex min-h-screen bg-background text-foreground",
+        isNotesRoute && "h-screen overflow-hidden",
+      )}
+    >
       <AppSidebar
         pathname={pathname}
         displayName={displayName}
@@ -30,9 +36,16 @@ export function AppShell({ children, displayName }: AppShellProps) {
         onToggleCollapsed={() => setCollapsed((current) => !current)}
         onHoverChange={setHoverExpanded}
       />
-      <div className="min-w-0 flex-1">
-        <AppTopbar pathname={pathname} />
-        <main className="mx-auto w-full max-w-[1600px] px-5 py-5 lg:px-6 lg:py-6">
+      <div className="min-h-0 min-w-0 flex-1">
+        {/* <AppTopbar pathname={pathname} /> */}
+        <main
+          className={cx(
+            "w-full",
+            isNotesRoute
+              ? "h-full max-w-none overflow-hidden p-0"
+              : "mx-auto max-w-[1600px] px-5 py-5 lg:px-6 lg:py-6",
+          )}
+        >
           {children}
         </main>
       </div>

--- a/components/shell/app-shell.tsx
+++ b/components/shell/app-shell.tsx
@@ -15,6 +15,7 @@ type AppShellProps = {
 export function AppShell({ children, displayName }: AppShellProps) {
   const pathname = usePathname();
   const isNotesRoute = pathname.startsWith("/notes");
+  const isDashboard = pathname === "/";
   const sidebarBehavior = useSidebarBehavior();
   const [collapsed, setCollapsed] = useState(true);
   const [hoverExpanded, setHoverExpanded] = useState(false);
@@ -22,12 +23,7 @@ export function AppShell({ children, displayName }: AppShellProps) {
   const sidebarCollapsed = hoverMode ? !hoverExpanded : collapsed;
 
   return (
-    <div
-      className={cx(
-        "flex min-h-screen bg-background text-foreground",
-        isNotesRoute && "h-screen overflow-hidden",
-      )}
-    >
+    <div className="flex h-screen overflow-hidden bg-background text-foreground">
       <AppSidebar
         pathname={pathname}
         displayName={displayName}
@@ -37,13 +33,14 @@ export function AppShell({ children, displayName }: AppShellProps) {
         onHoverChange={setHoverExpanded}
       />
       <div className="min-h-0 min-w-0 flex-1">
-        {/* <AppTopbar pathname={pathname} /> */}
         <main
           className={cx(
-            "w-full",
+            "h-full w-full",
             isNotesRoute
-              ? "h-full max-w-none overflow-hidden p-0"
-              : "mx-auto max-w-[1600px] px-5 py-5 lg:px-6 lg:py-6",
+              ? "overflow-hidden p-0"
+              : isDashboard
+              ? "flex flex-col p-3"
+              : "p-3",
           )}
         >
           {children}

--- a/components/shell/app-sidebar.tsx
+++ b/components/shell/app-sidebar.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
-import { SignOutButton } from "@/components/auth/sign-out-button";
-import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/auth-client";
 import { cx } from "@/lib/utils";
 import { NavIconGlyph } from "./nav-icon";
 import { isActivePath, primaryNavItems, studyNavItems } from "./navigation";
 import type { SidebarBehavior } from "./sidebar-preference";
+
+type TooltipState = { label: string; y: number } | null;
+type MenuPos = { bottom: number; left: number } | null;
 
 type AppSidebarProps = {
   pathname: string;
@@ -18,7 +21,11 @@ type AppSidebarProps = {
   onHoverChange: (expanded: boolean) => void;
 };
 
-function Chevron({ direction }: { direction: "left" | "right" | "down" | "up" }) {
+function Chevron({
+  direction,
+}: {
+  direction: "left" | "right" | "down" | "up";
+}) {
   const rotation = {
     left: "rotate(180deg)",
     right: "rotate(0deg)",
@@ -50,7 +57,68 @@ export function AppSidebar({
   onToggleCollapsed,
   onHoverChange,
 }: AppSidebarProps) {
-  const [studyOpen, setStudyOpen] = useState(() => pathname.startsWith("/study"));
+  const [studyOpen, setStudyOpen] = useState(() =>
+    pathname.startsWith("/study"),
+  );
+  const [tooltip, setTooltip] = useState<TooltipState>(null);
+  const [menuPos, setMenuPos] = useState<MenuPos>(null);
+  const profileRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!menuPos) return;
+    function handleClick(e: MouseEvent) {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        profileRef.current &&
+        !profileRef.current.contains(e.target as Node)
+      ) {
+        setMenuPos(null);
+      }
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setMenuPos(null);
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [menuPos]);
+
+  function toggleMenu() {
+    if (menuPos) {
+      setMenuPos(null);
+      return;
+    }
+    const rect = profileRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setMenuPos({
+      bottom: window.innerHeight - rect.bottom,
+      left: rect.right + 8,
+    });
+  }
+
+  async function handleSignOut() {
+    setMenuPos(null);
+    await authClient.signOut();
+    router.replace("/login");
+    router.refresh();
+  }
+
+  function showTooltip(e: React.MouseEvent<HTMLElement>, label: string) {
+    if (!collapsed) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    setTooltip({ label, y: rect.top + rect.height / 2 });
+  }
+
+  function hideTooltip() {
+    setTooltip(null);
+  }
+
   const initials = useMemo(
     () =>
       displayName
@@ -92,6 +160,15 @@ export function AppSidebar({
         collapsed ? "w-16" : "w-56 max-lg:w-16",
       )}
     >
+      {tooltip && collapsed ? (
+        <div
+          className="pointer-events-none fixed z-50 ml-1 -translate-y-1/2 rounded-md bg-foreground px-2.5 py-1.5 text-xs font-medium text-background shadow-md"
+          style={{ top: tooltip.y, left: 64 }}
+          aria-hidden
+        >
+          {tooltip.label}
+        </div>
+      ) : null}
       <div
         className={cx(
           "flex items-center gap-2 pb-3",
@@ -109,7 +186,11 @@ export function AppSidebar({
           aria-label="TaskMaster home"
           title="TaskMaster"
         >
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-foreground font-mono text-[0.45rem] leading-[1.1] tracking-tight text-background" aria-label="TaskMaster" style={{ whiteSpace: "pre" }}>{`/\\_/\\
+          <span
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-black font-mono text-[0.45rem] leading-[1.15] text-white"
+            aria-label="TaskMaster"
+            style={{ whiteSpace: "pre", letterSpacing: 0 }}
+          >{` /\\_/\\
 ( o.o )
  > ^ <`}</span>
           {!collapsed ? (
@@ -117,9 +198,9 @@ export function AppSidebar({
               <p className="truncate text-[0.92rem] font-semibold tracking-tight text-foreground">
                 TaskMaster
               </p>
-              <p className="truncate text-[0.72rem] text-muted-foreground">
+              {/* <p className="truncate text-[0.72rem] text-muted-foreground">
                 Academic workspace
-              </p>
+              </p> */}
             </div>
           ) : null}
         </Link>
@@ -137,7 +218,10 @@ export function AppSidebar({
 
       <nav
         aria-label="Primary navigation"
-        className={cx("flex-1 overflow-y-auto", collapsed ? "space-y-1" : "space-y-0.5")}
+        className={cx(
+          "flex-1 overflow-y-auto",
+          collapsed ? "space-y-1" : "space-y-0.5",
+        )}
       >
         {primaryNavItems.map((item) => {
           const active = isActivePath(pathname, item.href);
@@ -145,9 +229,10 @@ export function AppSidebar({
             <Link
               key={item.href}
               href={item.href}
-              title={item.label}
               aria-label={item.label}
               aria-current={active ? "page" : undefined}
+              onMouseEnter={(e) => showTooltip(e, item.label)}
+              onMouseLeave={hideTooltip}
               className={cx(
                 "group relative flex items-center gap-2.5 rounded-lg text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35",
                 collapsed
@@ -177,7 +262,9 @@ export function AppSidebar({
               >
                 <NavIconGlyph name={item.icon} />
               </span>
-              {!collapsed ? <span className="truncate max-lg:hidden">{item.label}</span> : null}
+              {!collapsed ? (
+                <span className="truncate max-lg:hidden">{item.label}</span>
+              ) : null}
             </Link>
           );
         })}
@@ -187,8 +274,9 @@ export function AppSidebar({
             type="button"
             onClick={() => setStudyOpen((current) => !current)}
             aria-expanded={studyOpen}
-            title="Study"
             aria-label="Study"
+            onMouseEnter={(e) => showTooltip(e, "Study")}
+            onMouseLeave={hideTooltip}
             className={cx(
               "relative flex w-full items-center gap-2.5 rounded-lg text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35",
               collapsed
@@ -252,19 +340,19 @@ export function AppSidebar({
         </div>
       </nav>
 
-      <div
-        className={cx(
-          "mt-3 border-t border-border pt-3",
-          collapsed ? "space-y-2" : "space-y-3",
-        )}
-      >
-        <Link
-          href="/settings"
-          title={displayName}
-          aria-label={`Account settings for ${displayName}`}
+      <div className="mt-3 border-t border-border pt-3">
+        <button
+          ref={profileRef}
+          onClick={toggleMenu}
+          onMouseEnter={(e) => collapsed && showTooltip(e, displayName)}
+          onMouseLeave={() => collapsed && hideTooltip()}
+          aria-label={`Open menu for ${displayName}`}
           className={cx(
-            "flex items-center gap-2.5 rounded-lg transition hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35",
-            collapsed ? "justify-center p-0.5" : "px-2 py-2 max-lg:justify-center max-lg:p-0.5",
+            "flex w-full items-center gap-2.5 rounded-lg transition hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35",
+            menuPos ? "bg-surface-muted" : "",
+            collapsed
+              ? "justify-center p-0.5"
+              : "px-2 py-2 max-lg:justify-center max-lg:p-0.5",
           )}
         >
           <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border bg-surface-muted text-xs font-semibold text-foreground">
@@ -275,24 +363,102 @@ export function AppSidebar({
               <p className="truncate text-[0.83rem] font-medium text-foreground">
                 {displayName}
               </p>
-              <p className="truncate text-[0.7rem] text-muted-foreground">Account</p>
+              <p className="truncate text-[0.7rem] text-muted-foreground">
+                Account
+              </p>
             </div>
           ) : null}
-        </Link>
-        {!collapsed ? (
-          <div className="max-lg:hidden">
-            <ThemeToggle />
-          </div>
-        ) : null}
-        {collapsed ? (
-          <SignOutButton compact />
-        ) : (
-          <>
-            <SignOutButton className="max-lg:hidden" />
-            <SignOutButton compact className="lg:hidden" />
-          </>
-        )}
+        </button>
       </div>
+
+      {menuPos ? (
+        <div
+          ref={menuRef}
+          style={{ bottom: menuPos.bottom, left: menuPos.left }}
+          className="fixed z-50 min-w-[200px] overflow-hidden rounded-xl border border-border bg-surface shadow-xl"
+        >
+          <div className="flex items-center gap-2.5 px-3.5 py-3">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border bg-surface-muted text-xs font-semibold text-foreground">
+              {initials}
+            </span>
+            <div className="min-w-0">
+              <p className="truncate text-[0.83rem] font-semibold text-foreground">
+                {displayName}
+              </p>
+              <p className="truncate text-[0.7rem] text-muted-foreground">
+                Account
+              </p>
+            </div>
+          </div>
+
+          <div className="border-t border-border" />
+
+          <div className="py-1">
+            <Link
+              href="/settings?tab=profile"
+              onClick={() => setMenuPos(null)}
+              className="flex w-full items-center gap-2.5 px-3.5 py-2.5 text-[0.83rem] text-foreground transition hover:bg-surface-muted"
+            >
+              <svg
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="8" r="4" />
+                <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+              </svg>
+              Profile
+            </Link>
+            <Link
+              href="/settings"
+              onClick={() => setMenuPos(null)}
+              className="flex w-full items-center gap-2.5 px-3.5 py-2.5 text-[0.83rem] text-foreground transition hover:bg-surface-muted"
+            >
+              <svg
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path d="M12 2v2M12 20v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M2 12h2M20 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+              </svg>
+              Settings
+            </Link>
+          </div>
+
+          <div className="border-t border-border" />
+
+          <div className="py-1">
+            <button
+              onClick={handleSignOut}
+              className="flex w-full items-center gap-2.5 px-3.5 py-2.5 text-[0.83rem] text-foreground transition hover:bg-surface-muted"
+            >
+              <svg
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+              Log out
+            </button>
+          </div>
+        </div>
+      ) : null}
     </aside>
   );
 }

--- a/components/shell/app-sidebar.tsx
+++ b/components/shell/app-sidebar.tsx
@@ -109,9 +109,9 @@ export function AppSidebar({
           aria-label="TaskMaster home"
           title="TaskMaster"
         >
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-foreground text-[0.8rem] font-semibold tracking-tight text-background">
-            TM
-          </span>
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-foreground font-mono text-[0.45rem] leading-[1.1] tracking-tight text-background" aria-label="TaskMaster" style={{ whiteSpace: "pre" }}>{`/\\_/\\
+( o.o )
+ > ^ <`}</span>
           {!collapsed ? (
             <div className="min-w-0 max-lg:hidden">
               <p className="truncate text-[0.92rem] font-semibold tracking-tight text-foreground">

--- a/components/shell/navigation.ts
+++ b/components/shell/navigation.ts
@@ -22,8 +22,7 @@ export const primaryNavItems: readonly NavItem[] = [
   { href: "/flashcards", label: "Flashcards", icon: "flashcards" },
   { href: "/quizzes", label: "Quizzes", icon: "quizzes" },
   { href: "/calendar", label: "Calendar", icon: "calendar" },
-  { href: "/resources", label: "Resources", icon: "resources" },
-  { href: "/settings", label: "Settings", icon: "settings" },
+  // { href: "/resources", label: "Resources", icon: "resources" },
 ] as const;
 
 export const studyNavItems = [
@@ -52,7 +51,8 @@ export function getPageTitle(pathname: string) {
   }
 
   return (
-    primaryNavItems.find((item) => item.href === pathname)?.label ?? "TaskMaster"
+    primaryNavItems.find((item) => item.href === pathname)?.label ??
+    "TaskMaster"
   );
 }
 

--- a/components/study/study-method-page.tsx
+++ b/components/study/study-method-page.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
-import { PageHeader } from "@/components/ui/page-header";
 
 type StudyMethodPageProps = {
   eyebrow?: string;
@@ -12,18 +11,16 @@ type StudyMethodPageProps = {
 };
 
 export function StudyMethodPage({
-  eyebrow = "Study method",
-  title,
-  description,
   detailTitle,
   detailDescription,
   children,
 }: StudyMethodPageProps) {
   return (
-    <div className="space-y-6">
-      <PageHeader eyebrow={eyebrow} title={title} description={description} />
-      {children}
-      <EmptyState eyebrow="Scaffolded" title={detailTitle} description={detailDescription} />
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto space-y-4">
+        {children}
+        <EmptyState eyebrow="Scaffolded" title={detailTitle} description={detailDescription} />
+      </div>
     </div>
   );
 }

--- a/components/ui/scaffold-page.tsx
+++ b/components/ui/scaffold-page.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
-import { PageHeader } from "@/components/ui/page-header";
 
 type ScaffoldPageProps = {
   eyebrow: string;
@@ -13,19 +12,17 @@ type ScaffoldPageProps = {
 };
 
 export function ScaffoldPage({
-  eyebrow,
-  title,
-  description,
   emptyTitle,
   emptyDescription,
   action,
   children,
 }: ScaffoldPageProps) {
   return (
-    <div className="space-y-6">
-      <PageHeader eyebrow={eyebrow} title={title} description={description} />
-      {children}
-      <EmptyState eyebrow="Scaffolded" title={emptyTitle} description={emptyDescription} action={action} />
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto space-y-4">
+        {children}
+        <EmptyState eyebrow="Scaffolded" title={emptyTitle} description={emptyDescription} action={action} />
+      </div>
     </div>
   );
 }

--- a/drizzle/0010_warm_squirrel_girl.sql
+++ b/drizzle/0010_warm_squirrel_girl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "note" ADD COLUMN "markdown" text DEFAULT '' NOT NULL;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1523 @@
+{
+  "id": "4e40829a-dd3b-42db-af03-b7ef373e1dad",
+  "prevId": "7854ad89-2733-40f5-a2c6-b68f5174221c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flashcards": {
+      "name": "flashcards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_note_ids": {
+          "name": "source_note_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "cards": {
+          "name": "cards",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_count": {
+          "name": "card_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flashcards_user_id_idx": {
+          "name": "flashcards_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flashcards_created_at_idx": {
+          "name": "flashcards_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flashcards_user_id_user_id_fk": {
+          "name": "flashcards_user_id_user_id_fk",
+          "tableFrom": "flashcards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note": {
+      "name": "note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "note_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_userId_idx": {
+          "name": "note_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_class_id_idx": {
+          "name": "note_class_id_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_createdAt_idx": {
+          "name": "note_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_user_id_user_id_fk": {
+          "name": "note_user_id_user_id_fk",
+          "tableFrom": "note",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_class_id_parse_test_course_id_fk": {
+          "name": "note_class_id_parse_test_course_id_fk",
+          "tableFrom": "note",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_assignments": {
+      "name": "parse_test_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_text": {
+          "name": "date_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_text": {
+          "name": "time_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_percent": {
+          "name": "weight_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_assignments_course_id_idx": {
+          "name": "parse_test_assignments_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_assignments_due_at_idx": {
+          "name": "parse_test_assignments_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_assignments_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_assignments_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_assignments",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_concepts": {
+      "name": "parse_test_concepts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_concepts_course_id_idx": {
+          "name": "parse_test_concepts_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_concepts_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_concepts_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_concepts",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_contacts": {
+      "name": "parse_test_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_hours": {
+          "name": "office_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_contacts_course_id_idx": {
+          "name": "parse_test_contacts_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_contacts_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_contacts_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_contacts",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_course": {
+      "name": "parse_test_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_section": {
+          "name": "course_section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructor_name": {
+          "name": "instructor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_days": {
+          "name": "meeting_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_time": {
+          "name": "meeting_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_location": {
+          "name": "meeting_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_materials": {
+          "name": "required_materials",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "homework_tools": {
+          "name": "homework_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "catalog_description": {
+          "name": "catalog_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_summary": {
+          "name": "student_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_course_run_id_idx": {
+          "name": "parse_test_course_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_course_run_id_parse_test_runs_id_fk": {
+          "name": "parse_test_course_run_id_parse_test_runs_id_fk",
+          "tableFrom": "parse_test_course",
+          "tableTo": "parse_test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parse_test_course_run_id_unique": {
+          "name": "parse_test_course_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_events": {
+      "name": "parse_test_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_text": {
+          "name": "date_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_text": {
+          "name": "time_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_events_course_id_idx": {
+          "name": "parse_test_events_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_events_due_at_idx": {
+          "name": "parse_test_events_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_events_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_events_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_events",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_grading_items": {
+      "name": "parse_test_grading_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_percent": {
+          "name": "weight_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_grading_items_course_id_idx": {
+          "name": "parse_test_grading_items_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_grading_items_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_grading_items_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_grading_items",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_runs": {
+      "name": "parse_test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parse_status": {
+          "name": "parse_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "parse_model": {
+          "name": "parse_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gemini_file_uri": {
+          "name": "gemini_file_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_runs_user_id_idx": {
+          "name": "parse_test_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_runs_content_hash_idx": {
+          "name": "parse_test_runs_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_runs_status_idx": {
+          "name": "parse_test_runs_status_idx",
+          "columns": [
+            {
+              "expression": "parse_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_runs_user_id_user_id_fk": {
+          "name": "parse_test_runs_user_id_user_id_fk",
+          "tableFrom": "parse_test_runs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.note_source": {
+      "name": "note_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "upload"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777506289321,
       "tag": "0009_ancient_molten_man",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1779687807311,
+      "tag": "0010_warm_squirrel_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -97,6 +97,7 @@ export const note = pgTable(
       .references(() => user.id, { onDelete: "cascade" }),
     title: text("title").notNull().default("Untitled"),
     content: jsonb("content"),
+    markdown: text("markdown").notNull().default(""),
     sourceType: noteSourceEnum("source_type").notNull().default("manual"),
     fileUrl: text("file_url"),
     fileName: text("file_name"),

--- a/lib/flashcards/context.ts
+++ b/lib/flashcards/context.ts
@@ -1,8 +1,6 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { note } from "@/lib/db/schema";
-import { createNoteContent } from "@/lib/notes/markdown";
-import { normalizeNoteDocument } from "@/lib/notes/records";
 import type { FlashcardContextNote } from "@/lib/flashcards/types";
 
 const MAX_MARKDOWN_CHARS_PER_NOTE = 18_000;
@@ -13,11 +11,6 @@ function normalizeEmbedding(value: unknown) {
   }
 
   return value.filter((item): item is number => typeof item === "number");
-}
-
-function getMarkdownFromContent(value: unknown) {
-  const document = normalizeNoteDocument(value);
-  return createNoteContent(document).markdown.trim();
 }
 
 export async function getFlashcardContextNotes(params: {
@@ -33,7 +26,7 @@ export async function getFlashcardContextNotes(params: {
     .select({
       id: note.id,
       title: note.title,
-      content: note.content,
+      markdown: note.markdown,
       embedding: note.embedding,
     })
     .from(note)
@@ -42,7 +35,7 @@ export async function getFlashcardContextNotes(params: {
   return rows.map((row) => ({
     id: row.id,
     title: row.title,
-    markdown: getMarkdownFromContent(row.content).slice(0, MAX_MARKDOWN_CHARS_PER_NOTE),
+    markdown: row.markdown.trim().slice(0, MAX_MARKDOWN_CHARS_PER_NOTE),
     embedding: normalizeEmbedding(row.embedding),
   }));
 }

--- a/lib/notes/code-highlighter.ts
+++ b/lib/notes/code-highlighter.ts
@@ -9,10 +9,29 @@ function escapeHtml(value: string) {
     .replaceAll("'", "&#39;");
 }
 
-export function highlightCode(code: string) {
+export type HighlightResult = {
+  html: string;
+  /** The language actually used (explicit hint or hljs auto-detected). */
+  language: string | null;
+};
+
+/**
+ * Highlight `code` using highlight.js.
+ *
+ * If an explicit `language` is provided and hljs recognises it, that language
+ * is used directly. Otherwise hljs.highlightAuto() is called and the detected
+ * language is returned alongside the highlighted HTML.
+ */
+export function highlightCode(code: string, language?: string): HighlightResult {
   if (code.trim().length === 0) {
-    return escapeHtml(code);
+    return { html: escapeHtml(code), language: language ?? null };
   }
 
-  return hljs.highlightAuto(code).value;
+  if (language && hljs.getLanguage(language)) {
+    const result = hljs.highlight(code, { language });
+    return { html: result.value, language };
+  }
+
+  const result = hljs.highlightAuto(code);
+  return { html: result.value, language: result.language ?? null };
 }

--- a/lib/notes/generation.ts
+++ b/lib/notes/generation.ts
@@ -1,6 +1,5 @@
 import { GoogleGenAI } from "@google/genai";
 import { z } from "zod";
-import type { NoteDocument } from "@/lib/notes/types";
 import { parseMarkdownToNoteDocument } from "@/lib/notes/parse-markdown";
 
 const AZURE_DOCUMENT_INTELLIGENCE_API_VERSION = "2024-11-30";

--- a/lib/notes/generation.ts
+++ b/lib/notes/generation.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI } from "@google/genai";
 import { z } from "zod";
-import type { NoteBlock, NoteDocument } from "@/lib/notes/types";
+import type { NoteDocument } from "@/lib/notes/types";
+import { parseMarkdownToNoteDocument } from "@/lib/notes/parse-markdown";
 
 const AZURE_DOCUMENT_INTELLIGENCE_API_VERSION = "2024-11-30";
 const EMBEDDING_DIMENSIONS = 768;
@@ -270,66 +271,7 @@ export async function embedGeneratedTopics(topics: Array<{ title: string; markdo
   });
 }
 
-function createBlockId() {
-  return crypto.randomUUID().replace(/-/g, "").slice(0, 10);
-}
-
-function createParagraphBlock(lines: string[]): NoteBlock {
-  return {
-    id: createBlockId(),
-    type: "paragraph",
-    data: {
-      text: lines.join("<br>"),
-    },
-  };
-}
-
-export function markdownToNoteDocument(markdown: string): NoteDocument {
-  const blocks: NoteBlock[] = [];
-  const paragraphLines: string[] = [];
-
-  function flushParagraph() {
-    if (paragraphLines.length === 0) {
-      return;
-    }
-
-    blocks.push(createParagraphBlock([...paragraphLines]));
-    paragraphLines.length = 0;
-  }
-
-  for (const rawLine of markdown.split(/\r?\n/)) {
-    const line = rawLine.trimEnd();
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
-
-    if (headingMatch) {
-      flushParagraph();
-      blocks.push({
-        id: createBlockId(),
-        type: "header",
-        data: {
-          text: headingMatch[2].trim(),
-          level: Math.min(6, headingMatch[1].length) as 1 | 2 | 3 | 4 | 5 | 6,
-        },
-      });
-      continue;
-    }
-
-    if (line.trim().length === 0) {
-      flushParagraph();
-      continue;
-    }
-
-    paragraphLines.push(line);
-  }
-
-  flushParagraph();
-
-  return {
-    time: Date.now(),
-    version: "2.31.5",
-    blocks,
-  };
-}
+export { parseMarkdownToNoteDocument as markdownToNoteDocument };
 
 export async function generateTopicNotesFromFile(params: {
   fileBuffer: Buffer;

--- a/lib/notes/markdown.test.ts
+++ b/lib/notes/markdown.test.ts
@@ -144,4 +144,30 @@ describe("serializeNoteDocumentToMarkdown", () => {
       ].join("\n"),
     );
   });
+
+  it("serializes blocks in the current document order", () => {
+    const document: NoteDocument = {
+      time: 1,
+      blocks: [
+        {
+          id: "second",
+          type: "paragraph",
+          data: {
+            text: "Second block moved first",
+          },
+        },
+        {
+          id: "first",
+          type: "paragraph",
+          data: {
+            text: "First block moved second",
+          },
+        },
+      ],
+    };
+
+    expect(serializeNoteDocumentToMarkdown(document)).toBe(
+      "Second block moved first\n\nFirst block moved second",
+    );
+  });
 });

--- a/lib/notes/markdown.ts
+++ b/lib/notes/markdown.ts
@@ -2,6 +2,13 @@ import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
 import type { NoteBlock, NoteContent, NoteDocument, NoteListBlockData, NoteListItem } from "@/lib/notes/types";
 
+// Re-export the canonical parser from its own module.
+export { parseMarkdownToNoteDocument } from "@/lib/notes/parse-markdown";
+
+// ---------------------------------------------------------------------------
+// NoteDocument → Markdown serializer
+// ---------------------------------------------------------------------------
+
 const turndown = new TurndownService({
   bulletListMarker: "-",
   codeBlockStyle: "fenced",
@@ -50,6 +57,17 @@ function createCodeFence(code: string) {
   return "`".repeat(Math.max(3, longestFence + 1));
 }
 
+/**
+ * Convert <span class="note-inline-math" data-latex="…">…</span> back to $…$
+ * so that the round-trip markdown stays clean.
+ */
+function restoreInlineMath(html: string): string {
+  return html.replace(
+    /<span[^>]*class="note-inline-math"[^>]*data-latex="([^"]*)"[^>]*>[\s\S]*?<\/span>/gi,
+    (_, latex: string) => `$${latex}$`,
+  );
+}
+
 function prefixLines(value: string, prefix: string) {
   return value
     .split("\n")
@@ -85,7 +103,7 @@ function serializeListItems(
 function serializeBlock(block: NoteBlock) {
   switch (block.type) {
     case "paragraph":
-      return htmlToMarkdown(block.data.text);
+      return htmlToMarkdown(restoreInlineMath(block.data.text));
     case "header": {
       const level = Math.min(Math.max(block.data.level, 1), 4);
       const content = htmlToMarkdown(block.data.text);
@@ -96,7 +114,7 @@ function serializeBlock(block: NoteBlock) {
       return serializeListItems(block.data.items, block.data.style, 0, start).join("\n");
     }
     case "quote": {
-      const quoteText = htmlToMarkdown(block.data.text);
+      const quoteText = htmlToMarkdown(restoreInlineMath(block.data.text));
       const caption = htmlToMarkdown(block.data.caption);
       return [quoteText, caption]
         .filter(Boolean)
@@ -105,7 +123,8 @@ function serializeBlock(block: NoteBlock) {
     }
     case "code": {
       const fence = createCodeFence(block.data.code);
-      return `${fence}\n${block.data.code}\n${fence}`;
+      const lang = block.data.language ?? "";
+      return `${fence}${lang}\n${block.data.code}\n${fence}`;
     }
     case "image": {
       const altText = htmlToPlainText(block.data.caption) || "Image";

--- a/lib/notes/parse-markdown.ts
+++ b/lib/notes/parse-markdown.ts
@@ -1,0 +1,208 @@
+/**
+ * Markdown → NoteDocument parser.
+ *
+ * Pure JS, no external dependencies, safe to run on both client and server.
+ *
+ * Handles:
+ *   - ATX headings (#, ##, …)
+ *   - Fenced code blocks (``` or ~~~) with optional language hint
+ *   - Block math ($$…$$)
+ *   - Blockquotes (>)
+ *   - Ordered / unordered / checklist lists
+ *   - Inline math ($…$) inside paragraph text
+ *   - Paragraphs (everything else)
+ */
+
+import type { NoteBlock, NoteDocument, NoteListBlockData, NoteListItem } from "@/lib/notes/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function escapeHtmlAttr(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Detect and replace inline math ($…$) within a single line of text.
+ *
+ * Heuristic: we match $content$ where content is non-empty and contains at
+ * least one LaTeX-typical character (backslash, caret, underscore, or braces)
+ * OR is a short single-token that doesn't look like a shell / currency value.
+ * This avoids false-positives on "$HOME", "$5.99", etc.
+ *
+ * The result is a <span class="note-inline-math" data-latex="…"> element so
+ * the serializer and renderer can round-trip it cleanly.
+ */
+function processInlineMath(line: string): string {
+  // Avoid matching $$ (block math uses doubled dollar signs)
+  // Pattern: $<non-empty, non-newline content>$ — negative lookaround for $
+  const re = /(?<!\$)\$(?!\$)([^$\r\n]+?)(?<!\$)\$(?!\$)/g;
+
+  return line.replace(re, (_match, content: string) => {
+    const trimmed = content.trim();
+    if (!trimmed) return _match;
+
+    // Accept as inline math if content contains any LaTeX-specific char, or
+    // is a multi-character expression that can't be a bare shell identifier.
+    const hasLatexChar = /[\\^_{}]/.test(trimmed);
+    const isBareShellId = /^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed);
+    const isCurrency = /^\d/.test(trimmed);
+
+    if (!hasLatexChar && (isBareShellId || isCurrency)) {
+      return _match; // leave untouched
+    }
+
+    return `<span class="note-inline-math" data-latex="${escapeHtmlAttr(trimmed)}">$${trimmed}$</span>`;
+  });
+}
+
+function isListLine(line: string) {
+  return /^[-*+]\s/.test(line) || /^\d+\.\s/.test(line);
+}
+
+function isBlockStartLine(line: string) {
+  return (
+    line.trim() === "" ||
+    /^#{1,6}\s/.test(line) ||
+    line.startsWith("> ") ||
+    /^(`{3,}|~{3,})/.test(line) ||
+    line.trim() === "$$" ||
+    isListLine(line)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main parser
+// ---------------------------------------------------------------------------
+
+export function parseMarkdownToNoteDocument(markdown: string): NoteDocument {
+  const blocks: NoteBlock[] = [];
+  const lines = markdown.split(/\r?\n/);
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+
+    // ---- Fenced code block (``` or ~~~) with optional language ----
+    const codeFenceMatch = line.match(/^(`{3,}|~{3,})\s*(\S*)/);
+    if (codeFenceMatch) {
+      const fence = codeFenceMatch[1]!;
+      const lang = (codeFenceMatch[2] ?? "").trim() || undefined;
+      i++;
+      const codeLines: string[] = [];
+      while (i < lines.length && !(lines[i] ?? "").startsWith(fence)) {
+        codeLines.push(lines[i] ?? "");
+        i++;
+      }
+      i++; // skip closing fence
+      blocks.push({
+        type: "code",
+        data: {
+          code: codeLines.join("\n"),
+          ...(lang ? { language: lang } : {}),
+        },
+      });
+      continue;
+    }
+
+    // ---- Block math ($$ … $$) ----
+    if (line.trim() === "$$") {
+      i++;
+      const mathLines: string[] = [];
+      while (i < lines.length && (lines[i] ?? "").trim() !== "$$") {
+        mathLines.push(lines[i] ?? "");
+        i++;
+      }
+      i++; // skip closing $$
+      blocks.push({ type: "math", data: { latex: mathLines.join("\n") } });
+      continue;
+    }
+
+    // ---- ATX Heading ----
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
+    if (headingMatch) {
+      const level = Math.min(4, headingMatch[1]!.length) as 1 | 2 | 3 | 4;
+      blocks.push({
+        type: "header",
+        data: { text: (headingMatch[2] ?? "").trim(), level },
+      });
+      i++;
+      continue;
+    }
+
+    // ---- Blockquote ----
+    if (line.startsWith("> ")) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && (lines[i] ?? "").startsWith("> ")) {
+        quoteLines.push((lines[i] ?? "").slice(2));
+        i++;
+      }
+      blocks.push({
+        type: "quote",
+        data: {
+          text: quoteLines.map(processInlineMath).join("<br>"),
+          caption: "",
+          alignment: "left",
+        },
+      });
+      continue;
+    }
+
+    // ---- List (ordered / unordered / checklist) ----
+    if (isListLine(line)) {
+      const isChecklist = /^[-*+]\s+\[[ xX]\]/.test(line);
+      const isOrdered = /^\d+\.\s/.test(line) && !isChecklist;
+      const style: NoteListBlockData["style"] = isChecklist
+        ? "checklist"
+        : isOrdered
+          ? "ordered"
+          : "unordered";
+      const items: NoteListItem[] = [];
+
+      while (i < lines.length && isListLine(lines[i] ?? "")) {
+        const itemLine = lines[i] ?? "";
+        const clMatch = itemLine.match(/^[-*+]\s+\[([ xX])\]\s*(.*)/);
+        const olMatch = itemLine.match(/^\d+\.\s+(.*)/);
+        const ulMatch = itemLine.match(/^[-*+]\s+(.*)/);
+        const rawContent = (clMatch?.[2] ?? olMatch?.[1] ?? ulMatch?.[1] ?? "").trim();
+        const content = processInlineMath(rawContent);
+        const checked = clMatch ? clMatch[1] !== " " : false;
+        items.push({
+          content,
+          meta: style === "checklist" ? { checked } : {},
+          items: [],
+        });
+        i++;
+      }
+
+      if (items.length > 0) {
+        blocks.push({ type: "list", data: { style, items } });
+      }
+      continue;
+    }
+
+    // ---- Empty line ----
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // ---- Paragraph — accumulate until next block-starting line ----
+    const paragraphLines: string[] = [];
+    while (i < lines.length && !isBlockStartLine(lines[i] ?? "")) {
+      paragraphLines.push(lines[i] ?? "");
+      i++;
+    }
+    if (paragraphLines.length > 0) {
+      const text = paragraphLines.map(processInlineMath).join("<br>");
+      blocks.push({ type: "paragraph", data: { text } });
+    }
+  }
+
+  return { time: Date.now(), blocks };
+}

--- a/lib/notes/persistence.test.ts
+++ b/lib/notes/persistence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { normalizeNoteWriteContent } from "@/lib/notes/persistence";
+
+describe("normalizeNoteWriteContent", () => {
+  it("validates note JSON and derives markdown from block content", () => {
+    const content = normalizeNoteWriteContent({
+      time: 1,
+      blocks: [
+        {
+          id: "heading",
+          type: "header",
+          data: {
+            level: 2,
+            text: "Server saved",
+          },
+        },
+        {
+          id: "body",
+          type: "paragraph",
+          data: {
+            text: "Markdown is derived on write",
+          },
+        },
+      ],
+    });
+
+    expect(content.markdown).toBe("## Server saved\n\nMarkdown is derived on write");
+    expect(content.document.blocks).toHaveLength(2);
+  });
+
+  it("rejects invalid note JSON before persistence", () => {
+    expect(() =>
+      normalizeNoteWriteContent({
+        time: 1,
+        blocks: [
+          {
+            type: "unsupported",
+            data: {},
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+});

--- a/lib/notes/persistence.ts
+++ b/lib/notes/persistence.ts
@@ -1,0 +1,16 @@
+import { serializeNoteDocumentToMarkdown } from "@/lib/notes/markdown";
+import { emptyNoteDocument, NoteDocumentSchema, type NoteDocument } from "@/lib/notes/types";
+
+export type NormalizedNoteWriteContent = {
+  document: NoteDocument;
+  markdown: string;
+};
+
+export function normalizeNoteWriteContent(value: unknown = emptyNoteDocument): NormalizedNoteWriteContent {
+  const document = NoteDocumentSchema.parse(value ?? emptyNoteDocument);
+
+  return {
+    document,
+    markdown: serializeNoteDocumentToMarkdown(document),
+  };
+}

--- a/lib/notes/records.ts
+++ b/lib/notes/records.ts
@@ -8,6 +8,7 @@ export type NoteRecord = {
   title: string;
   classId: string | null;
   content: unknown;
+  markdown?: string | null;
   sourceType: NoteSourceType;
   fileName: string | null;
   mimeType: string | null;
@@ -121,6 +122,8 @@ function normalizeNoteGeneration(value: unknown, noteEmbedding: number[] | null)
 export function noteRecordToWorkspaceNote(record: NoteRecord): WorkspaceNote {
   const document = normalizeNoteDocument(record.content);
   const embedding = normalizeEmbedding(record.embedding);
+  const content = createNoteContent(document);
+  const markdown = typeof record.markdown === "string" ? record.markdown : content.markdown;
 
   return {
     id: record.id,
@@ -133,7 +136,10 @@ export function noteRecordToWorkspaceNote(record: NoteRecord): WorkspaceNote {
     embedding,
     createdAt: normalizeDate(record.createdAt),
     updatedAt: normalizeDate(record.updatedAt),
-    content: createNoteContent(document),
+    content: {
+      markdown,
+      document,
+    },
     generation: normalizeNoteGeneration(record.content, embedding),
   };
 }

--- a/lib/notes/types.ts
+++ b/lib/notes/types.ts
@@ -48,6 +48,7 @@ export type NoteQuoteBlockData = {
 
 export type NoteCodeBlockData = {
   code: string;
+  language?: string;
 };
 
 export type NoteImageFileData = {
@@ -208,6 +209,7 @@ export const NoteDocumentSchema: z.ZodType<NoteDocument> = z
             ...block,
             data: {
               code: block.data.code,
+              ...(block.data.language ? { language: block.data.language } : {}),
             },
           }
         : block,

--- a/lib/quizzes/context.ts
+++ b/lib/quizzes/context.ts
@@ -1,8 +1,6 @@
 import { and, inArray, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { note } from "@/lib/db/schema";
-import { createNoteContent } from "@/lib/notes/markdown";
-import { normalizeNoteDocument } from "@/lib/notes/records";
 import type { QuizContextNote } from "@/lib/quizzes/gemini";
 
 const MAX_MARKDOWN_CHARS_PER_NOTE = 18_000;
@@ -13,12 +11,6 @@ function normalizeEmbedding(value: unknown) {
   }
 
   return value.filter((item): item is number => typeof item === "number");
-}
-
-function getMarkdownFromContent(value: unknown) {
-  const document = normalizeNoteDocument(value);
-  const content = createNoteContent(document);
-  return content.markdown.trim();
 }
 
 export async function getQuizContextNotes(params: {
@@ -34,7 +26,7 @@ export async function getQuizContextNotes(params: {
     .select({
       id: note.id,
       title: note.title,
-      content: note.content,
+      markdown: note.markdown,
       embedding: note.embedding,
     })
     .from(note)
@@ -43,7 +35,7 @@ export async function getQuizContextNotes(params: {
   return rows.map((row) => ({
     id: row.id,
     title: row.title,
-    markdown: getMarkdownFromContent(row.content).slice(0, MAX_MARKDOWN_CHARS_PER_NOTE),
+    markdown: row.markdown.trim().slice(0, MAX_MARKDOWN_CHARS_PER_NOTE),
     embedding: normalizeEmbedding(row.embedding),
   }));
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "shadcn": "^4.4.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       shadcn:
         specifier: ^4.4.0
         version: 4.4.0(@types/node@20.19.39)(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -5130,6 +5133,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -11024,6 +11033,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
# Description / Story Summary

Adds more depth to the notes editor by making note blocks easier to select, edit, and move around. The goal is to make the notes page feel closer to a Notion-style editor while keeping the current block JSON structure as the main source of truth.

### What's changed

* Store generated markdown alongside the existing block JSON note content.
* Validate note content on the server before saving.
* Regenerate markdown when note content changes.
* Open notes directly in an editable writing view.
* Add block selection and multi-block selection behavior.
* Add drag-and-drop support for selected note blocks.
* Improve visual feedback for selected blocks, drag previews, and drop positions.
* Remove developer/debug UI from the normal notes view.

### Why

The notes editor needed better block-level interactions. Selecting and moving blocks should feel clear and visual instead of relying on hidden behavior or unclear editor states.

### How

The editor now keeps block JSON as the main editable format while storing markdown as a derived version for search, AI context, and future export use. The notes UI was also updated so block selection and drag behavior are more visible and easier to understand.

## How to Test

```sh
pnpm exec tsc --noEmit
pnpm lint
pnpm test -- components/note-editor lib/notes
```

Manual checks:

* Create or open a note.
* Select one or more blocks.
* Drag selected blocks to a new position.
* Confirm the drag preview and drop location are visible.
* Confirm reordered blocks save correctly.

## Checklist

General

* [ ] My pull request represents one logical piece of work.
* [ ] My commits are related to the pull request and look clean.
* [ ] I have performed a self-review of my code
* [ ] Vercel deployments pass with my changes
* [ ] My code contains no conflicts and is up to date with the latest main branch
