### PR TITLE
Redesign quiz experience and creation flow

### DIFF
--- a/app/(app)/quizzes/page.tsx
+++ b/app/(app)/quizzes/page.tsx
@@ -1,15 +1,17 @@
 import { connection } from "next/server";
 import { desc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { note } from "@/lib/db/schema";
+import { note, quizAttempts, quizzes } from "@/lib/db/schema";
 import { requireServerSession } from "@/lib/auth-session";
 import { QuizzesClient } from "@/app/quizzes/quizzes-client";
+import { rowToQuizAttempt, rowToSavedQuiz } from "@/lib/quizzes/records";
+import { hasQuizStorage } from "@/lib/quizzes/storage";
 
 export default async function QuizzesPage() {
   await connection();
 
   const session = await requireServerSession("/quizzes");
-  const rows = await db
+  const noteRows = await db
     .select({
       id: note.id,
       title: note.title,
@@ -20,14 +22,35 @@ export default async function QuizzesPage() {
     .where(eq(note.userId, session.user.id))
     .orderBy(desc(note.updatedAt));
 
+  const quizStorageReady = await hasQuizStorage();
+  const { quizRows, attemptRows } = quizStorageReady
+    ? await Promise.all([
+        db
+          .select()
+          .from(quizzes)
+          .where(eq(quizzes.userId, session.user.id))
+          .orderBy(desc(quizzes.updatedAt)),
+        db
+          .select()
+          .from(quizAttempts)
+          .where(eq(quizAttempts.userId, session.user.id))
+          .orderBy(desc(quizAttempts.completedAt)),
+      ]).then(([loadedQuizRows, loadedAttemptRows]) => ({
+        quizRows: loadedQuizRows,
+        attemptRows: loadedAttemptRows,
+      }))
+    : { quizRows: [], attemptRows: [] };
+
   return (
     <QuizzesClient
-      notes={rows.map((row) => ({
+      notes={noteRows.map((row) => ({
         id: row.id,
         title: row.title,
         updatedAt: row.updatedAt.toISOString(),
         hasEmbedding: Array.isArray(row.embedding) && row.embedding.length > 0,
       }))}
+      initialQuizzes={quizRows.map(rowToSavedQuiz)}
+      initialAttempts={attemptRows.map(rowToQuizAttempt)}
     />
   );
 }

--- a/app/api/quizzes/[id]/attempts/route.ts
+++ b/app/api/quizzes/[id]/attempts/route.ts
@@ -1,0 +1,91 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { and, desc, eq } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { quizAttempts, quizzes } from "@/lib/db/schema";
+import { rowToQuizAttempt, saveAttemptSchema } from "@/lib/quizzes/records";
+import { hasQuizStorage, quizStorageUnavailableMessage } from "@/lib/quizzes/storage";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+async function getOwnedQuiz(userId: string, quizId: string) {
+  const [found] = await db
+    .select({ id: quizzes.id })
+    .from(quizzes)
+    .where(and(eq(quizzes.id, quizId), eq(quizzes.userId, userId)))
+    .limit(1);
+
+  return found ?? null;
+}
+
+export async function GET(_req: Request, ctx: RouteContext) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await hasQuizStorage())) {
+    return NextResponse.json({ attempts: [] });
+  }
+
+  const { id } = await ctx.params;
+  if (!(await getOwnedQuiz(session.user.id, id))) {
+    return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+  }
+
+  const rows = await db
+    .select()
+    .from(quizAttempts)
+    .where(and(eq(quizAttempts.quizId, id), eq(quizAttempts.userId, session.user.id)))
+    .orderBy(desc(quizAttempts.completedAt));
+
+  return NextResponse.json({ attempts: rows.map(rowToQuizAttempt) });
+}
+
+export async function POST(req: Request, ctx: RouteContext) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await hasQuizStorage())) {
+    return NextResponse.json({ error: quizStorageUnavailableMessage }, { status: 503 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = saveAttemptSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid attempt payload" }, { status: 400 });
+  }
+
+  const { id } = await ctx.params;
+  if (!(await getOwnedQuiz(session.user.id, id))) {
+    return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+  }
+
+  const [created] = await db
+    .insert(quizAttempts)
+    .values({
+      quizId: id,
+      userId: session.user.id,
+      answers: parsed.data.answers,
+      score: parsed.data.score,
+      correctCount: parsed.data.correctCount,
+      answeredCount: parsed.data.answeredCount,
+      questionCount: parsed.data.questionCount,
+      timeSpentSeconds: parsed.data.timeSpentSeconds,
+      mode: parsed.data.mode,
+    })
+    .returning();
+
+  return NextResponse.json({ attempt: rowToQuizAttempt(created) }, { status: 201 });
+}

--- a/app/api/quizzes/[id]/route.ts
+++ b/app/api/quizzes/[id]/route.ts
@@ -1,0 +1,82 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { quizzes } from "@/lib/db/schema";
+import { rowToSavedQuiz, saveQuizSchema } from "@/lib/quizzes/records";
+import { hasQuizStorage, quizStorageUnavailableMessage } from "@/lib/quizzes/storage";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: Request, ctx: RouteContext) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await hasQuizStorage())) {
+    return NextResponse.json({ error: quizStorageUnavailableMessage }, { status: 503 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = saveQuizSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid quiz payload" }, { status: 400 });
+  }
+
+  const { id } = await ctx.params;
+  const [updated] = await db
+    .update(quizzes)
+    .set({
+      title: parsed.data.title.trim(),
+      sourceNoteIds: Array.from(new Set(parsed.data.sourceNoteIds)),
+      sourceNoteTitles: Array.from(new Set(parsed.data.sourceNoteTitles)),
+      questions: parsed.data.questions,
+      questionCount: parsed.data.questions.length,
+      difficulty: parsed.data.difficulty,
+      mode: parsed.data.mode,
+      questionTypes: parsed.data.questionTypes,
+      timeLimitMinutes: parsed.data.mode === "exam" ? parsed.data.timeLimitMinutes : null,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(quizzes.id, id), eq(quizzes.userId, session.user.id)))
+    .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ quiz: rowToSavedQuiz(updated) });
+}
+
+export async function DELETE(_req: Request, ctx: RouteContext) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await hasQuizStorage())) {
+    return NextResponse.json({ error: quizStorageUnavailableMessage }, { status: 503 });
+  }
+
+  const { id } = await ctx.params;
+  const [deleted] = await db
+    .delete(quizzes)
+    .where(and(eq(quizzes.id, id), eq(quizzes.userId, session.user.id)))
+    .returning();
+
+  if (!deleted) {
+    return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/quizzes/route.ts
+++ b/app/api/quizzes/route.ts
@@ -1,0 +1,70 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { desc, eq } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { quizzes } from "@/lib/db/schema";
+import { rowToSavedQuiz, saveQuizSchema } from "@/lib/quizzes/records";
+import { hasQuizStorage, quizStorageUnavailableMessage } from "@/lib/quizzes/storage";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await hasQuizStorage())) {
+    return NextResponse.json({ quizzes: [] });
+  }
+
+  const rows = await db
+    .select()
+    .from(quizzes)
+    .where(eq(quizzes.userId, session.user.id))
+    .orderBy(desc(quizzes.updatedAt));
+
+  return NextResponse.json({ quizzes: rows.map(rowToSavedQuiz) });
+}
+
+export async function POST(req: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await hasQuizStorage())) {
+    return NextResponse.json({ error: quizStorageUnavailableMessage }, { status: 503 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = saveQuizSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid quiz payload" }, { status: 400 });
+  }
+
+  const [created] = await db
+    .insert(quizzes)
+    .values({
+      userId: session.user.id,
+      title: parsed.data.title.trim(),
+      sourceNoteIds: Array.from(new Set(parsed.data.sourceNoteIds)),
+      sourceNoteTitles: Array.from(new Set(parsed.data.sourceNoteTitles)),
+      questions: parsed.data.questions,
+      questionCount: parsed.data.questions.length,
+      difficulty: parsed.data.difficulty,
+      mode: parsed.data.mode,
+      questionTypes: parsed.data.questionTypes,
+      timeLimitMinutes: parsed.data.mode === "exam" ? parsed.data.timeLimitMinutes : null,
+    })
+    .returning();
+
+  return NextResponse.json({ quiz: rowToSavedQuiz(created) }, { status: 201 });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "sonner";
 import "./globals.css";
 import "mathlive/fonts.css";
 import "mathlive/static.css";
-import { THEME_STORAGE_KEY } from "@/lib/theme";
+import { ThemeInitializer } from "@/components/ui/theme-initializer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -22,22 +21,6 @@ export const metadata: Metadata = {
   description: "TaskMaster academic workspace",
 };
 
-const themeInitScript = `
-(() => {
-  try {
-    var saved = window.localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
-    var theme = saved === "light" || saved === "dark" || saved === "system" ? saved : "system";
-    var resolved = theme === "system"
-      ? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
-      : theme;
-    var root = document.documentElement;
-    root.classList.toggle("dark", resolved === "dark");
-    root.classList.toggle("light", resolved === "light");
-    root.dataset.theme = theme;
-  } catch (_) {}
-})();
-`;
-
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -50,11 +33,7 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full bg-background text-foreground">
-        <Script
-          id="taskmaster-theme-init"
-          strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{ __html: themeInitScript }}
-        />
+        <ThemeInitializer />
         {children}
         <Toaster
           position="bottom-right"

--- a/app/quizzes/quizzes-client.test.tsx
+++ b/app/quizzes/quizzes-client.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { QuizzesClient } from "@/app/quizzes/quizzes-client";
+import type { QuizQuestion } from "@/lib/quizzes/gemini";
+import type { SavedQuiz } from "@/lib/quizzes/types";
+
+const notes = [
+  {
+    id: "note-ready",
+    title: "Ready note",
+    updatedAt: "2026-05-29T18:00:00.000Z",
+    hasEmbedding: true,
+  },
+  {
+    id: "note-missing",
+    title: "Missing embedding note",
+    updatedAt: "2026-05-29T18:00:00.000Z",
+    hasEmbedding: false,
+  },
+];
+
+const question: QuizQuestion = {
+  id: "question-1",
+  type: "free_response",
+  prompt: "Explain loop invariants.",
+  correctAnswer: "A loop invariant is true before and after each iteration.",
+  explanation: "Invariants prove loop correctness.",
+  sourceNoteTitles: ["Ready note"],
+};
+
+const savedQuiz: SavedQuiz = {
+  id: "quiz-1",
+  title: "Loop quiz",
+  sourceNoteIds: ["note-ready"],
+  sourceNoteTitles: ["Ready note"],
+  questions: [question],
+  questionCount: 1,
+  difficulty: "medium",
+  mode: "practice",
+  questionTypes: ["free_response"],
+  timeLimitMinutes: null,
+  createdAt: "2026-05-29T18:00:00.000Z",
+  updatedAt: "2026-05-29T18:00:00.000Z",
+};
+
+describe("QuizzesClient", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders library as quiz dashboard with stats and empty state", () => {
+    render(<QuizzesClient notes={notes} initialQuizzes={[]} initialAttempts={[]} />);
+
+    expect(screen.getByRole("heading", { name: "My Quizzes" })).toBeInTheDocument();
+    expect(screen.getByText("0 quizzes")).toBeInTheDocument();
+    expect(screen.getByText("0 questions")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create quiz/i })).toBeInTheDocument();
+    expect(screen.getByText("No saved quizzes")).toBeInTheDocument();
+    expect(screen.getByText("Saved quizzes appear here.")).toBeInTheDocument();
+  });
+
+  it("uses a context-first creation screen with selectable embedding-ready notes", async () => {
+    const user = userEvent.setup();
+    render(<QuizzesClient notes={notes} initialQuizzes={[]} initialAttempts={[]} />);
+
+    await user.click(screen.getByRole("button", { name: /create quiz/i }));
+
+    expect(screen.getByRole("heading", { name: "Quizzes" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Create Quiz" })).toBeInTheDocument();
+    expect(screen.getByText("Context")).toBeInTheDocument();
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(screen.getByText("0 selected")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/Ready note/i));
+
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Missing embedding note/i)).toBeDisabled();
+  });
+
+  it("keeps generated questions editable in preview and supports manual additions", async () => {
+    const user = userEvent.setup();
+    render(<QuizzesClient notes={notes} initialQuizzes={[savedQuiz]} initialAttempts={[]} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(screen.getByRole("heading", { name: "Preview Quiz" })).toBeInTheDocument();
+    expect(screen.getByLabelText(/quiz name/i)).toHaveValue("Loop quiz");
+    expect(screen.getAllByLabelText("Prompt")).toHaveLength(1);
+
+    await user.click(screen.getByRole("button", { name: /add question/i }));
+
+    expect(screen.getAllByLabelText("Prompt")).toHaveLength(2);
+    expect(screen.getByText("Question 2")).toBeInTheDocument();
+  });
+});

--- a/app/quizzes/quizzes-client.test.tsx
+++ b/app/quizzes/quizzes-client.test.tsx
@@ -52,6 +52,7 @@ describe("QuizzesClient", () => {
   it("renders library as quiz dashboard with stats and empty state", () => {
     render(<QuizzesClient notes={notes} initialQuizzes={[]} initialAttempts={[]} />);
 
+    expect(screen.getByTestId("quizzes-one-page")).toHaveClass("h-full", "overflow-hidden");
     expect(screen.getByRole("heading", { name: "My Quizzes" })).toBeInTheDocument();
     expect(screen.getByText("0 quizzes")).toBeInTheDocument();
     expect(screen.getByText("0 questions")).toBeInTheDocument();
@@ -90,7 +91,7 @@ describe("QuizzesClient", () => {
 
     await user.click(screen.getByRole("button", { name: /add question/i }));
 
-    expect(screen.getAllByLabelText("Prompt")).toHaveLength(2);
-    expect(screen.getByText("Question 2")).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Prompt")).toHaveLength(1);
+    expect(screen.getAllByText("Question 2").length).toBeGreaterThan(0);
   });
 });

--- a/app/quizzes/quizzes-client.tsx
+++ b/app/quizzes/quizzes-client.tsx
@@ -2,13 +2,19 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
-  Brain,
+  AlertTriangle,
   CheckCircle2,
   Clock,
-  Infinity,
+  Copy,
+  Edit3,
+  FileQuestion,
   Loader2,
+  Pencil,
   Play,
+  Plus,
   RotateCcw,
+  Save,
+  Trash2,
   XCircle,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -17,22 +23,13 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Input, Textarea } from "@/components/ui/input";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input, Select, Textarea } from "@/components/ui/input";
+import { PageHeader } from "@/components/ui/page-header";
+import { createUnansweredEvaluation, gradeObjectiveAnswer, summarizeAttempt } from "@/lib/quizzes/attempts";
+import type { QuizDifficulty, QuizQuestion, QuizQuestionType } from "@/lib/quizzes/gemini";
+import type { QuizAttempt, QuizAttemptAnswer, QuizEvaluation, QuizMode, SavedQuiz } from "@/lib/quizzes/types";
 import { cx } from "@/lib/utils";
-import type {
-  QuizDifficulty,
-  QuizQuestion,
-  QuizQuestionType,
-} from "@/lib/quizzes/gemini";
-
-type QuizMode = "infinite" | "exam";
 
 type QuizNoteOption = {
   id: string;
@@ -41,21 +38,13 @@ type QuizNoteOption = {
   hasEmbedding: boolean;
 };
 
-type QuizEvaluation = {
-  correct: boolean;
-  score: number;
-  feedback: string;
-  idealAnswer: string;
-};
-
-type AnswerState = {
-  answer: string;
-  evaluation?: QuizEvaluation;
-};
-
 type QuizzesClientProps = {
   notes: QuizNoteOption[];
+  initialQuizzes: SavedQuiz[];
+  initialAttempts: QuizAttempt[];
 };
+
+type View = "library" | "create" | "preview" | "take" | "results";
 
 const questionTypeOptions: Array<{ value: QuizQuestionType; label: string }> = [
   { value: "multiple_choice", label: "Multiple choice" },
@@ -69,16 +58,30 @@ const difficultyOptions: Array<{ value: QuizDifficulty; label: string }> = [
   { value: "hard", label: "Hard" },
 ];
 
+const modeOptions: Array<{ value: QuizMode; label: string; description: string }> = [
+  { value: "practice", label: "Practice", description: "Immediate checking while taking the quiz." },
+  { value: "exam", label: "Exam", description: "Timed attempt with results after finish." },
+];
+
 function formatTimer(seconds: number) {
   const minutes = Math.floor(seconds / 60);
   const remainingSeconds = seconds % 60;
   return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
 }
 
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatPercent(value: number) {
+  return `${Math.round(value * 100)}%`;
+}
+
 async function readJsonResponse<T>(response: Response): Promise<T> {
-  const payload = (await response.json().catch(() => null)) as T & {
-    error?: string;
-  };
+  const payload = (await response.json().catch(() => null)) as T & { error?: string };
   if (!response.ok) {
     throw new Error(payload?.error || "Request failed");
   }
@@ -86,13 +89,7 @@ async function readJsonResponse<T>(response: Response): Promise<T> {
   return payload;
 }
 
-function MarkdownText({
-  markdown,
-  className,
-}: {
-  markdown: string;
-  className?: string;
-}) {
+function MarkdownText({ markdown, className }: { markdown: string; className?: string }) {
   return (
     <div className={cx("quiz-markdown min-w-0 text-foreground", className)}>
       <ReactMarkdown
@@ -100,26 +97,13 @@ function MarkdownText({
         remarkPlugins={[remarkGfm, remarkMath]}
         components={{
           p: ({ children }) => <p>{children}</p>,
-          ul: ({ children }) => (
-            <ul className="ml-5 list-disc space-y-1">{children}</ul>
-          ),
-          ol: ({ children }) => (
-            <ol className="ml-5 list-decimal space-y-1">{children}</ol>
-          ),
+          ul: ({ children }) => <ul className="ml-5 list-disc space-y-1">{children}</ul>,
+          ol: ({ children }) => <ol className="ml-5 list-decimal space-y-1">{children}</ol>,
           li: ({ children }) => <li>{children}</li>,
-          strong: ({ children }) => (
-            <strong className="font-semibold text-foreground">
-              {children}
-            </strong>
-          ),
+          strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
           em: ({ children }) => <em className="italic">{children}</em>,
           code: ({ children, className: codeClassName }) => (
-            <code
-              className={cx(
-                "rounded bg-surface-elevated px-1 py-0.5 font-mono text-[0.92em]",
-                codeClassName,
-              )}
-            >
+            <code className={cx("rounded bg-surface-elevated px-1 py-0.5 font-mono text-[0.92em]", codeClassName)}>
               {children}
             </code>
           ),
@@ -129,24 +113,7 @@ function MarkdownText({
             </pre>
           ),
           blockquote: ({ children }) => (
-            <blockquote className="border-l-4 border-border pl-3 text-muted-foreground">
-              {children}
-            </blockquote>
-          ),
-          table: ({ children }) => (
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-sm">
-                {children}
-              </table>
-            </div>
-          ),
-          th: ({ children }) => (
-            <th className="border border-border bg-surface-muted px-2 py-1 text-left font-semibold">
-              {children}
-            </th>
-          ),
-          td: ({ children }) => (
-            <td className="border border-border px-2 py-1">{children}</td>
+            <blockquote className="border-l-4 border-border pl-3 text-muted-foreground">{children}</blockquote>
           ),
         }}
       >
@@ -156,50 +123,75 @@ function MarkdownText({
   );
 }
 
-export function QuizzesClient({ notes }: QuizzesClientProps) {
-  const embeddedNotes = useMemo(
-    () => notes.filter((note) => note.hasEmbedding),
-    [notes],
-  );
+function getSourceTitles(questions: QuizQuestion[], notes: QuizNoteOption[], selectedNoteIds: string[]) {
+  const titles = questions.flatMap((question) => question.sourceNoteTitles);
+  if (titles.length > 0) {
+    return Array.from(new Set(titles));
+  }
+
+  return notes.filter((note) => selectedNoteIds.includes(note.id)).map((note) => note.title);
+}
+
+function createQuizCopy(quiz: SavedQuiz): Omit<SavedQuiz, "id" | "createdAt" | "updatedAt"> {
+  return {
+    title: `${quiz.title} copy`,
+    sourceNoteIds: quiz.sourceNoteIds,
+    sourceNoteTitles: quiz.sourceNoteTitles,
+    questions: quiz.questions.map((question) => ({ ...question, id: crypto.randomUUID() })),
+    questionCount: quiz.questionCount,
+    difficulty: quiz.difficulty,
+    mode: quiz.mode,
+    questionTypes: quiz.questionTypes,
+    timeLimitMinutes: quiz.timeLimitMinutes,
+  };
+}
+
+export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: QuizzesClientProps) {
+  const embeddedNotes = useMemo(() => notes.filter((note) => note.hasEmbedding), [notes]);
+  const [quizzes, setQuizzes] = useState<SavedQuiz[]>(initialQuizzes);
+  const [attempts, setAttempts] = useState<QuizAttempt[]>(initialAttempts);
+  const [view, setView] = useState<View>("library");
+  const [activeQuizId, setActiveQuizId] = useState(initialQuizzes[0]?.id ?? "");
+  const [selectedAttemptId, setSelectedAttemptId] = useState("");
+
   const [selectedNoteIds, setSelectedNoteIds] = useState<string[]>([]);
-  const [mode, setMode] = useState<QuizMode>("infinite");
+  const [mode, setMode] = useState<QuizMode>("practice");
   const [timeMinutes, setTimeMinutes] = useState(20);
   const [questionCount, setQuestionCount] = useState(10);
-  const [questionTypes, setQuestionTypes] = useState<QuizQuestionType[]>([
-    "multiple_choice",
-  ]);
+  const [questionTypes, setQuestionTypes] = useState<QuizQuestionType[]>(["multiple_choice"]);
   const [difficulty, setDifficulty] = useState<QuizDifficulty>("medium");
-  const [questions, setQuestions] = useState<QuizQuestion[]>([]);
-  const [answers, setAnswers] = useState<Record<string, AnswerState>>({});
+  const [draftTitle, setDraftTitle] = useState("");
+  const [draftQuestions, setDraftQuestions] = useState<QuizQuestion[]>([]);
+  const [editingQuizId, setEditingQuizId] = useState<string | null>(null);
+
+  const [answers, setAnswers] = useState<Record<string, QuizAttemptAnswer>>({});
   const [currentIndex, setCurrentIndex] = useState(0);
   const [remainingSeconds, setRemainingSeconds] = useState(0);
-  const [started, setStarted] = useState(false);
-  const [finished, setFinished] = useState(false);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [latestAttempt, setLatestAttempt] = useState<QuizAttempt | null>(null);
+
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [isEvaluating, setIsEvaluating] = useState(false);
+  const [isFinishing, setIsFinishing] = useState(false);
+  const [deleteQuizId, setDeleteQuizId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const currentQuestion = questions[currentIndex];
-  const currentAnswer = currentQuestion
-    ? (answers[currentQuestion.id]?.answer ?? "")
-    : "";
-  const currentEvaluation = currentQuestion
-    ? answers[currentQuestion.id]?.evaluation
-    : undefined;
-  const examExpired = mode === "exam" && started && remainingSeconds <= 0;
-  const canStart =
-    selectedNoteIds.length > 0 &&
-    questionTypes.length > 0 &&
-    embeddedNotes.length > 0;
-  const answeredCount = Object.values(answers).filter(
-    (answer) => answer.evaluation,
-  ).length;
-  const correctCount = Object.values(answers).filter(
-    (answer) => answer.evaluation?.correct,
-  ).length;
+  const activeQuiz = quizzes.find((quiz) => quiz.id === activeQuizId) ?? quizzes[0] ?? null;
+  const activeAttempts = attempts.filter((attempt) => attempt.quizId === activeQuiz?.id);
+  const selectedAttempt =
+    attempts.find((attempt) => attempt.id === selectedAttemptId) ??
+    latestAttempt ??
+    activeAttempts[0] ??
+    null;
+  const currentQuestion = activeQuiz?.questions[currentIndex] ?? null;
+  const currentAnswer = currentQuestion ? answers[currentQuestion.id]?.answer ?? "" : "";
+  const currentEvaluation = currentQuestion ? answers[currentQuestion.id]?.evaluation : undefined;
+  const canGenerate = selectedNoteIds.length > 0 && questionTypes.length > 0 && embeddedNotes.length > 0 && !isGenerating;
+  const examExpired = activeQuiz?.mode === "exam" && remainingSeconds <= 0;
 
   useEffect(() => {
-    if (!started || finished || mode !== "exam" || remainingSeconds <= 0) {
+    if (view !== "take" || activeQuiz?.mode !== "exam" || remainingSeconds <= 0 || isFinishing) {
       return;
     }
 
@@ -208,31 +200,48 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
     }, 1000);
 
     return () => window.clearInterval(timer);
-  }, [finished, mode, remainingSeconds, started]);
+  }, [activeQuiz?.mode, isFinishing, remainingSeconds, view]);
 
-  useEffect(() => {
-    if (started && mode === "exam" && remainingSeconds === 0) {
-      setFinished(true);
+  function resetCreateForm() {
+    setSelectedNoteIds([]);
+    setMode("practice");
+    setTimeMinutes(20);
+    setQuestionCount(10);
+    setQuestionTypes(["multiple_choice"]);
+    setDifficulty("medium");
+    setDraftTitle("");
+    setDraftQuestions([]);
+    setEditingQuizId(null);
+  }
+
+  function openLibrary(quizId?: string) {
+    setView("library");
+    setError(null);
+    setLatestAttempt(null);
+    if (quizId) {
+      setActiveQuizId(quizId);
     }
-  }, [mode, remainingSeconds, started]);
+  }
+
+  function openCreate() {
+    resetCreateForm();
+    setView("create");
+    setError(null);
+  }
 
   function toggleNote(noteId: string) {
     setSelectedNoteIds((current) =>
-      current.includes(noteId)
-        ? current.filter((id) => id !== noteId)
-        : [...current, noteId],
+      current.includes(noteId) ? current.filter((id) => id !== noteId) : [...current, noteId],
     );
   }
 
   function toggleQuestionType(type: QuizQuestionType) {
     setQuestionTypes((current) =>
-      current.includes(type)
-        ? current.filter((item) => item !== type)
-        : [...current, type],
+      current.includes(type) ? current.filter((item) => item !== type) : [...current, type],
     );
   }
 
-  async function generateQuestions(count: number, append = false) {
+  async function generatePreview() {
     setError(null);
     setIsGenerating(true);
     try {
@@ -244,44 +253,194 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
             noteIds: selectedNoteIds,
             difficulty,
             questionTypes,
-            count,
-            previousPrompts: questions.map((question) => question.prompt),
+            count: questionCount,
           }),
         }),
       );
 
-      setQuestions((current) =>
-        append ? [...current, ...payload.questions] : payload.questions,
-      );
-      if (!append) {
-        setCurrentIndex(0);
-      }
-      return true;
+      const selectedTitles = notes.filter((note) => selectedNoteIds.includes(note.id)).map((note) => note.title);
+      setDraftQuestions(payload.questions);
+      setDraftTitle(selectedTitles.length === 1 ? `${selectedTitles[0]} quiz` : "Generated note quiz");
+      setView("preview");
     } catch (generationError) {
-      setError(
-        generationError instanceof Error
-          ? generationError.message
-          : "Quiz generation failed",
-      );
-      return false;
+      setError(generationError instanceof Error ? generationError.message : "Quiz generation failed");
     } finally {
       setIsGenerating(false);
     }
   }
 
-  async function startQuiz() {
-    setFinished(false);
-    setAnswers({});
-    setQuestions([]);
-    setCurrentIndex(0);
-    setRemainingSeconds(Math.max(1, timeMinutes) * 60);
-    const generated = await generateQuestions(
-      mode === "exam" ? questionCount : 1,
+  function updateDraftQuestion(index: number, update: Partial<QuizQuestion>) {
+    setDraftQuestions((current) =>
+      current.map((question, questionIndex) =>
+        questionIndex === index
+          ? {
+              ...question,
+              ...update,
+            }
+          : question,
+      ),
     );
-    setStarted(generated);
   }
 
-  async function evaluateCurrentAnswer() {
+  function updateDraftChoice(questionIndex: number, choiceIndex: number, value: string) {
+    setDraftQuestions((current) =>
+      current.map((question, index) => {
+        if (index !== questionIndex) {
+          return question;
+        }
+
+        const choices = [...(question.choices ?? [])];
+        choices[choiceIndex] = value;
+        return { ...question, choices };
+      }),
+    );
+  }
+
+  function removeDraftQuestion(index: number) {
+    setDraftQuestions((current) => current.filter((_, questionIndex) => questionIndex !== index));
+  }
+
+  async function saveDraftQuiz() {
+    if (draftQuestions.length === 0 || !draftTitle.trim()) {
+      return;
+    }
+
+    setError(null);
+    setIsSaving(true);
+    try {
+      const sourceNoteTitles = getSourceTitles(draftQuestions, notes, selectedNoteIds);
+      const payload = await readJsonResponse<{ quiz: SavedQuiz }>(
+        await fetch(editingQuizId ? `/api/quizzes/${editingQuizId}` : "/api/quizzes", {
+          method: editingQuizId ? "PATCH" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: draftTitle,
+            sourceNoteIds: selectedNoteIds,
+            sourceNoteTitles,
+            questions: draftQuestions,
+            difficulty,
+            mode,
+            questionTypes,
+            timeLimitMinutes: mode === "exam" ? timeMinutes : null,
+          }),
+        }),
+      );
+
+      setQuizzes((current) =>
+        editingQuizId
+          ? current.map((quiz) => (quiz.id === payload.quiz.id ? payload.quiz : quiz))
+          : [payload.quiz, ...current],
+      );
+      setActiveQuizId(payload.quiz.id);
+      setView("library");
+      setEditingQuizId(null);
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Quiz save failed");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function duplicateQuiz(quiz: SavedQuiz) {
+    setError(null);
+    setIsSaving(true);
+    try {
+      const copy = createQuizCopy(quiz);
+      const payload = await readJsonResponse<{ quiz: SavedQuiz }>(
+        await fetch("/api/quizzes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(copy),
+        }),
+      );
+
+      setQuizzes((current) => [payload.quiz, ...current]);
+      setActiveQuizId(payload.quiz.id);
+    } catch (copyError) {
+      setError(copyError instanceof Error ? copyError.message : "Quiz duplicate failed");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function editQuiz(quiz: SavedQuiz) {
+    setSelectedNoteIds(quiz.sourceNoteIds);
+    setMode(quiz.mode);
+    setTimeMinutes(quiz.timeLimitMinutes ?? 20);
+    setQuestionCount(quiz.questionCount);
+    setQuestionTypes(quiz.questionTypes);
+    setDifficulty(quiz.difficulty);
+    setDraftTitle(quiz.title);
+    setDraftQuestions(quiz.questions);
+    setEditingQuizId(quiz.id);
+    setView("preview");
+    setError(null);
+  }
+
+  async function deleteQuiz(quizId: string) {
+    setError(null);
+    setIsSaving(true);
+    try {
+      await readJsonResponse<{ success: true }>(
+        await fetch(`/api/quizzes/${quizId}`, {
+          method: "DELETE",
+        }),
+      );
+
+      setQuizzes((current) => current.filter((quiz) => quiz.id !== quizId));
+      setAttempts((current) => current.filter((attempt) => attempt.quizId !== quizId));
+      setDeleteQuizId(null);
+      if (activeQuizId === quizId) {
+        setActiveQuizId(quizzes.find((quiz) => quiz.id !== quizId)?.id ?? "");
+      }
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : "Quiz delete failed");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function startTaking(quiz: SavedQuiz) {
+    setActiveQuizId(quiz.id);
+    setAnswers({});
+    setCurrentIndex(0);
+    setRemainingSeconds((quiz.timeLimitMinutes ?? 0) * 60);
+    setStartedAt(Date.now());
+    setLatestAttempt(null);
+    setSelectedAttemptId("");
+    setView("take");
+    setError(null);
+  }
+
+  function updateAnswer(questionId: string, value: string) {
+    setAnswers((current) => ({
+      ...current,
+      [questionId]: {
+        questionId,
+        answer: value,
+        evaluation: current[questionId]?.evaluation,
+      },
+    }));
+  }
+
+  async function evaluateQuestion(question: QuizQuestion, answer: string): Promise<QuizEvaluation> {
+    const objective = gradeObjectiveAnswer(question, answer);
+    if (objective) {
+      return objective;
+    }
+
+    const payload = await readJsonResponse<{ evaluation: QuizEvaluation }>(
+      await fetch("/api/quizzes/evaluate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question, answer }),
+      }),
+    );
+
+    return payload.evaluation;
+  }
+
+  async function checkCurrentAnswer() {
     if (!currentQuestion || !currentAnswer.trim()) {
       return;
     }
@@ -289,96 +448,277 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
     setError(null);
     setIsEvaluating(true);
     try {
-      const payload = await readJsonResponse<{ evaluation: QuizEvaluation }>(
-        await fetch("/api/quizzes/evaluate", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            question: currentQuestion,
-            answer: currentAnswer,
-          }),
-        }),
-      );
-
+      const evaluation = await evaluateQuestion(currentQuestion, currentAnswer);
       setAnswers((current) => ({
         ...current,
         [currentQuestion.id]: {
+          questionId: currentQuestion.id,
           answer: currentAnswer,
-          evaluation: payload.evaluation,
+          evaluation,
         },
       }));
     } catch (evaluationError) {
-      setError(
-        evaluationError instanceof Error
-          ? evaluationError.message
-          : "Answer evaluation failed",
-      );
+      setError(evaluationError instanceof Error ? evaluationError.message : "Answer evaluation failed");
     } finally {
       setIsEvaluating(false);
     }
   }
 
-  function updateAnswer(value: string) {
-    if (!currentQuestion) {
+  async function finishAttempt() {
+    if (!activeQuiz || isFinishing) {
       return;
     }
 
-    setAnswers((current) => ({
-      ...current,
-      [currentQuestion.id]: {
-        ...current[currentQuestion.id],
-        answer: value,
-      },
-    }));
-  }
-
-  async function nextInfiniteQuestion() {
-    if (currentIndex < questions.length - 1) {
-      setCurrentIndex((index) => index + 1);
-      return;
-    }
-
-    const generated = await generateQuestions(1, true);
-    if (generated) {
-      setCurrentIndex((index) => index + 1);
-    }
-  }
-
-  function resetQuiz() {
-    setStarted(false);
-    setFinished(false);
-    setQuestions([]);
-    setAnswers({});
-    setCurrentIndex(0);
-    setRemainingSeconds(0);
     setError(null);
+    setIsFinishing(true);
+    try {
+      const completedAnswers: QuizAttemptAnswer[] = [];
+      for (const question of activeQuiz.questions) {
+        const answer = answers[question.id];
+        if (!answer?.answer.trim()) {
+          completedAnswers.push({
+            questionId: question.id,
+            answer: "",
+            evaluation: createUnansweredEvaluation(question),
+          });
+          continue;
+        }
+
+        if (answer.evaluation) {
+          completedAnswers.push(answer);
+          continue;
+        }
+
+        try {
+          completedAnswers.push({
+            ...answer,
+            evaluation: await evaluateQuestion(question, answer.answer),
+          });
+        } catch {
+          completedAnswers.push({
+            ...answer,
+            evaluation: {
+              correct: false,
+              score: 0,
+              feedback: "This answer could not be evaluated automatically.",
+              idealAnswer: question.correctAnswer,
+            },
+          });
+        }
+      }
+
+      const summary = summarizeAttempt(activeQuiz.questions, completedAnswers);
+      const timeSpentSeconds = startedAt ? Math.max(0, Math.round((Date.now() - startedAt) / 1000)) : null;
+      const payload = await readJsonResponse<{ attempt: QuizAttempt }>(
+        await fetch(`/api/quizzes/${activeQuiz.id}/attempts`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ...summary,
+            timeSpentSeconds,
+            mode: activeQuiz.mode,
+          }),
+        }),
+      );
+
+      setAnswers(Object.fromEntries(summary.answers.map((answer) => [answer.questionId, answer])));
+      setAttempts((current) => [payload.attempt, ...current]);
+      setLatestAttempt(payload.attempt);
+      setSelectedAttemptId(payload.attempt.id);
+      setView("results");
+    } catch (finishError) {
+      setError(finishError instanceof Error ? finishError.message : "Quiz finish failed");
+    } finally {
+      setIsFinishing(false);
+    }
   }
 
-  return (
-    <main className="flex h-full flex-col gap-4">
-      {error ? (
-        <div className="shrink-0 rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
-          {error}
-        </div>
-      ) : null}
+  function renderLibrary() {
+    return (
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <section className="space-y-4">
+          {quizzes.length === 0 ? (
+            <Card className="border-dashed">
+              <CardHeader>
+                <CardTitle>No saved quizzes yet</CardTitle>
+                <CardDescription>
+                  Create a quiz from notes, review generated questions, then save it here.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button type="button" leadingIcon={<Plus className="size-4" />} onClick={openCreate}>
+                  Create quiz
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {quizzes.map((quiz) => {
+                const lastAttempt = attempts.find((attempt) => attempt.quizId === quiz.id);
+                return (
+                  <Card
+                    key={quiz.id}
+                    className={cx(
+                      "transition hover:border-border-strong hover:bg-surface-muted",
+                      activeQuiz?.id === quiz.id ? "border-accent" : "",
+                    )}
+                  >
+                    <CardHeader>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant="accent">{quiz.mode}</Badge>
+                        <Badge variant="outline">{quiz.difficulty}</Badge>
+                        <Badge variant="outline">{quiz.questionCount} questions</Badge>
+                      </div>
+                      <CardTitle>{quiz.title}</CardTitle>
+                      <CardDescription>
+                        Updated {formatDate(quiz.updatedAt)}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                      <div className="flex flex-wrap gap-2">
+                        {quiz.sourceNoteTitles.slice(0, 4).map((title) => (
+                          <Badge key={title} variant="neutral">
+                            {title}
+                          </Badge>
+                        ))}
+                      </div>
+                      {lastAttempt ? (
+                        <p className="text-sm text-muted-foreground">
+                          Last result {formatPercent(lastAttempt.score)} on {formatDate(lastAttempt.completedAt)}
+                        </p>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">No completed attempts yet.</p>
+                      )}
+                      <div className="flex flex-wrap gap-2">
+                        <Button type="button" size="sm" onClick={() => startTaking(quiz)} leadingIcon={<Play className="size-4" />}>
+                          Take
+                        </Button>
+                        <Button type="button" size="sm" variant="outline" onClick={() => setActiveQuizId(quiz.id)}>
+                          Open
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </section>
 
-      <div className="grid min-h-0 flex-1 gap-6 lg:grid-cols-[380px_minmax(0,1fr)]">
-        <Card className="flex min-h-0 flex-col overflow-hidden">
-          <CardHeader className="shrink-0">
-            <CardTitle>Quiz setup</CardTitle>
-            <CardDescription>
-              Select notes, question format, difficulty, and quiz mode.
-            </CardDescription>
+        <aside className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>{activeQuiz?.title ?? "Quiz detail"}</CardTitle>
+              <CardDescription>
+                {activeQuiz ? "Review metadata, questions, and previous results." : "Select a saved quiz."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {activeQuiz ? (
+                <>
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <div className="rounded-lg border border-border bg-surface-muted p-3">
+                      <div className="text-xs text-muted-foreground">Questions</div>
+                      <div className="font-semibold text-foreground">{activeQuiz.questionCount}</div>
+                    </div>
+                    <div className="rounded-lg border border-border bg-surface-muted p-3">
+                      <div className="text-xs text-muted-foreground">Mode</div>
+                      <div className="font-semibold capitalize text-foreground">{activeQuiz.mode}</div>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <h2 className="text-sm font-medium text-foreground">Questions</h2>
+                    <div className="max-h-64 space-y-2 overflow-auto pr-1">
+                      {activeQuiz.questions.map((question, index) => (
+                        <div key={question.id} className="rounded-lg border border-border bg-surface-muted p-3 text-sm">
+                          <div className="mb-1 flex items-center gap-2">
+                            <Badge variant="outline">{index + 1}</Badge>
+                            <Badge variant="neutral">{question.type.replace("_", " ")}</Badge>
+                          </div>
+                          <MarkdownText markdown={question.prompt} className="line-clamp-3" />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <h2 className="text-sm font-medium text-foreground">Previous results</h2>
+                    {activeAttempts.length === 0 ? (
+                      <p className="rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm text-muted-foreground">
+                        Attempts will appear after quiz completion.
+                      </p>
+                    ) : (
+                      activeAttempts.slice(0, 4).map((attempt) => (
+                        <button
+                          key={attempt.id}
+                          type="button"
+                          className="flex w-full items-center justify-between rounded-lg border border-border px-3 py-2 text-left text-sm hover:bg-surface-muted"
+                          onClick={() => {
+                            setSelectedAttemptId(attempt.id);
+                            setLatestAttempt(attempt);
+                            setView("results");
+                          }}
+                        >
+                          <span>{formatDate(attempt.completedAt)}</span>
+                          <Badge variant="accent">{formatPercent(attempt.score)}</Badge>
+                        </button>
+                      ))
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="button" size="sm" leadingIcon={<Play className="size-4" />} onClick={() => startTaking(activeQuiz)}>
+                      Take
+                    </Button>
+                    <Button type="button" size="sm" variant="outline" leadingIcon={<Pencil className="size-4" />} onClick={() => editQuiz(activeQuiz)}>
+                      Edit
+                    </Button>
+                    <Button type="button" size="sm" variant="outline" leadingIcon={<Copy className="size-4" />} disabled={isSaving} onClick={() => void duplicateQuiz(activeQuiz)}>
+                      Duplicate
+                    </Button>
+                    <Button type="button" size="sm" variant="destructive" leadingIcon={<Trash2 className="size-4" />} onClick={() => setDeleteQuizId(activeQuiz.id)}>
+                      Delete
+                    </Button>
+                  </div>
+                </>
+              ) : null}
+            </CardContent>
+          </Card>
+
+          {deleteQuizId ? (
+            <Card className="border-red-200 dark:border-red-950/70">
+              <CardHeader>
+                <CardTitle>Delete quiz?</CardTitle>
+                <CardDescription>This removes quiz and saved attempts.</CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                <Button type="button" variant="destructive" disabled={isSaving} onClick={() => void deleteQuiz(deleteQuizId)}>
+                  Confirm delete
+                </Button>
+                <Button type="button" variant="outline" onClick={() => setDeleteQuizId(null)}>
+                  Cancel
+                </Button>
+              </CardContent>
+            </Card>
+          ) : null}
+        </aside>
+      </div>
+    );
+  }
+
+  function renderCreate() {
+    return (
+      <div className="grid gap-6 lg:grid-cols-[420px_minmax(0,1fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create quiz</CardTitle>
+            <CardDescription>Select note context before generation starts.</CardDescription>
           </CardHeader>
-          <CardContent className="min-h-0 flex-1 space-y-6 overflow-y-auto">
+          <CardContent className="space-y-6">
             <section className="space-y-3">
               <div className="flex items-center justify-between gap-3">
-                <h2 className="text-sm font-medium text-foreground">Notes</h2>
-                <Badge variant="outline">
-                  {selectedNoteIds.length} selected
-                </Badge>
+                <h2 className="text-sm font-medium text-foreground">Source notes</h2>
+                <Badge variant="outline">{selectedNoteIds.length} selected</Badge>
               </div>
-              <div className="max-h-72 space-y-2 overflow-auto pr-1">
+              <div className="max-h-80 space-y-2 overflow-auto pr-1">
                 {notes.length === 0 ? (
                   <p className="rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm text-muted-foreground">
                     Create or upload notes first.
@@ -389,26 +729,20 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                       key={note.id}
                       className={cx(
                         "flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-surface px-3 py-3 text-sm transition",
-                        note.hasEmbedding
-                          ? "hover:border-border-strong hover:bg-surface-muted"
-                          : "cursor-not-allowed opacity-60",
+                        note.hasEmbedding ? "hover:border-border-strong hover:bg-surface-muted" : "cursor-not-allowed opacity-60",
                       )}
                     >
                       <input
                         type="checkbox"
                         className="mt-1 size-4 accent-[var(--accent)]"
                         checked={selectedNoteIds.includes(note.id)}
-                        disabled={!note.hasEmbedding || started}
+                        disabled={!note.hasEmbedding || isGenerating}
                         onChange={() => toggleNote(note.id)}
                       />
                       <span className="min-w-0 flex-1">
-                        <span className="block truncate font-medium text-foreground">
-                          {note.title}
-                        </span>
+                        <span className="block truncate font-medium text-foreground">{note.title}</span>
                         <span className="text-xs text-muted-foreground">
-                          {note.hasEmbedding
-                            ? "Embedding ready"
-                            : "No embedding stored"}
+                          {note.hasEmbedding ? `Embedding ready - updated ${formatDate(note.updatedAt)}` : "No embedding stored. Upload or regenerate notes before using this context."}
                         </span>
                       </span>
                     </label>
@@ -416,87 +750,68 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                 )}
               </div>
             </section>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" disabled={!canGenerate} leadingIcon={isGenerating ? <Loader2 className="size-4 animate-spin" /> : <FileQuestion className="size-4" />} onClick={() => void generatePreview()}>
+                Generate preview
+              </Button>
+              <Button type="button" variant="outline" onClick={() => openLibrary()}>
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
 
-            <section className="space-y-3">
-              <h2 className="text-sm font-medium text-foreground">Mode</h2>
-              <div className="grid grid-cols-2 gap-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Quiz settings</CardTitle>
+            <CardDescription>Mode, difficulty, question types, count, and time limit.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <section className="grid gap-3 md:grid-cols-2">
+              {modeOptions.map((option) => (
                 <button
+                  key={option.value}
                   type="button"
-                  disabled={started}
                   className={cx(
-                    "flex items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition disabled:opacity-60",
-                    mode === "infinite"
-                      ? "border-accent bg-accent-soft text-accent"
-                      : "border-border bg-surface text-muted-foreground hover:bg-surface-muted",
+                    "rounded-lg border px-4 py-3 text-left text-sm transition",
+                    mode === option.value ? "border-accent bg-accent-soft text-accent" : "border-border bg-surface hover:bg-surface-muted",
                   )}
-                  onClick={() => setMode("infinite")}
+                  onClick={() => setMode(option.value)}
                 >
-                  <Infinity className="size-4" />
-                  Infinite
+                  <span className="block font-semibold">{option.label}</span>
+                  <span className="mt-1 block text-muted-foreground">{option.description}</span>
                 </button>
-                <button
-                  type="button"
-                  disabled={started}
-                  className={cx(
-                    "flex items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition disabled:opacity-60",
-                    mode === "exam"
-                      ? "border-accent bg-accent-soft text-accent"
-                      : "border-border bg-surface text-muted-foreground hover:bg-surface-muted",
-                  )}
-                  onClick={() => setMode("exam")}
-                >
-                  <Clock className="size-4" />
-                  Exam
-                </button>
-              </div>
+              ))}
             </section>
-
-            {mode === "exam" ? (
-              <section className="grid grid-cols-2 gap-3">
-                <label className="space-y-2 text-sm font-medium text-foreground">
-                  Time
-                  <Input
-                    type="number"
-                    min={1}
-                    max={240}
-                    value={timeMinutes}
-                    disabled={started}
-                    onChange={(event) =>
-                      setTimeMinutes(Number(event.target.value))
-                    }
-                  />
-                </label>
-                <label className="space-y-2 text-sm font-medium text-foreground">
-                  Questions
-                  <Input
-                    type="number"
-                    min={1}
-                    max={25}
-                    value={questionCount}
-                    disabled={started}
-                    onChange={(event) =>
-                      setQuestionCount(Number(event.target.value))
-                    }
-                  />
-                </label>
-              </section>
-            ) : null}
-
+            <div className="grid gap-4 md:grid-cols-3">
+              <label className="space-y-2 text-sm font-medium text-foreground">
+                Difficulty
+                <Select value={difficulty} onChange={(event) => setDifficulty(event.target.value as QuizDifficulty)}>
+                  {difficultyOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </Select>
+              </label>
+              <label className="space-y-2 text-sm font-medium text-foreground">
+                Questions
+                <Input min={1} max={25} type="number" value={questionCount} onChange={(event) => setQuestionCount(Number(event.target.value))} />
+              </label>
+              <label className="space-y-2 text-sm font-medium text-foreground">
+                Time limit
+                <Input min={1} max={240} type="number" disabled={mode !== "exam"} value={timeMinutes} onChange={(event) => setTimeMinutes(Number(event.target.value))} />
+              </label>
+            </div>
             <section className="space-y-3">
-              <h2 className="text-sm font-medium text-foreground">
-                Question types
-              </h2>
-              <div className="space-y-2">
+              <h2 className="text-sm font-medium text-foreground">Question types</h2>
+              <div className="grid gap-2 md:grid-cols-3">
                 {questionTypeOptions.map((option) => (
-                  <label
-                    key={option.value}
-                    className="flex items-center gap-3 text-sm text-foreground"
-                  >
+                  <label key={option.value} className="flex items-center gap-3 rounded-lg border border-border bg-surface px-3 py-3 text-sm">
                     <input
                       type="checkbox"
                       className="size-4 accent-[var(--accent)]"
                       checked={questionTypes.includes(option.value)}
-                      disabled={started}
                       onChange={() => toggleQuestionType(option.value)}
                     />
                     {option.label}
@@ -504,311 +819,371 @@ export function QuizzesClient({ notes }: QuizzesClientProps) {
                 ))}
               </div>
             </section>
-
             <section className="space-y-3">
-              <h2 className="text-sm font-medium text-foreground">
-                Difficulty
-              </h2>
-              <div className="grid grid-cols-3 gap-2">
-                {difficultyOptions.map((option) => (
-                  <button
-                    key={option.value}
-                    type="button"
-                    disabled={started}
-                    className={cx(
-                      "rounded-lg border px-3 py-2 text-sm font-medium capitalize transition disabled:opacity-60",
-                      difficulty === option.value
-                        ? "border-accent bg-accent-soft text-accent"
-                        : "border-border bg-surface text-muted-foreground hover:bg-surface-muted",
-                    )}
-                    onClick={() => setDifficulty(option.value)}
-                  >
-                    {option.label}
-                  </button>
-                ))}
-              </div>
-            </section>
-
-            <Button
-              type="button"
-              className="w-full"
-              disabled={!canStart || started || isGenerating}
-              leadingIcon={
-                isGenerating ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <Play className="size-4" />
-                )
-              }
-              onClick={startQuiz}
-            >
-              Start quiz
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card className="flex min-h-0 flex-col overflow-hidden">
-          <CardHeader className="shrink-0 gap-4 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-2">
-              <CardTitle>Question workspace</CardTitle>
-              <CardDescription>
-                {started
-                  ? mode === "exam"
-                    ? `${answeredCount}/${questions.length} answered`
-                    : `${answeredCount} answered in this session`
-                  : "Configure a quiz to begin."}
-              </CardDescription>
-            </div>
-            {started ? (
-              <div className="flex flex-wrap items-center gap-2">
-                {mode === "exam" ? (
-                  <Badge variant={examExpired ? "neutral" : "accent"}>
-                    <Clock className="size-3.5" />
-                    {formatTimer(remainingSeconds)}
-                  </Badge>
-                ) : (
-                  <Badge variant="accent">
-                    <Infinity className="size-3.5" />
-                    Infinite
-                  </Badge>
-                )}
-                <Badge variant="outline">{difficulty}</Badge>
-              </div>
-            ) : null}
-          </CardHeader>
-          <CardContent className="min-h-0 flex-1 overflow-y-auto">
-            {!started ? (
-              <div className="flex min-h-96 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-surface-muted px-6 text-center">
-                <Brain className="size-10 text-muted-foreground" />
-                <div className="space-y-1">
-                  <h2 className="text-base font-semibold text-foreground">
-                    Ready when your notes are selected
-                  </h2>
-                  <p className="max-w-md text-sm leading-6 text-muted-foreground">
-                    Generated questions use the embeddings stored on the
-                    selected note rows, plus their readable note content.
-                  </p>
-                </div>
-              </div>
-            ) : isGenerating && questions.length === 0 ? (
-              <div className="flex min-h-96 items-center justify-center gap-3 text-sm text-muted-foreground">
-                <Loader2 className="size-5 animate-spin" />
-                Generating questions with Gemini
-              </div>
-            ) : finished ? (
-              <div className="flex min-h-96 flex-col justify-center gap-5">
-                <div className="space-y-2 text-center">
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Exam complete
-                  </h2>
-                  <p className="text-sm text-muted-foreground">
-                    Score: {correctCount}/{answeredCount || questions.length}{" "}
-                    correct
-                  </p>
-                </div>
-                <div className="grid gap-2">
-                  {questions.map((question, index) => {
-                    const evaluation = answers[question.id]?.evaluation;
-                    return (
-                      <button
-                        key={question.id}
-                        type="button"
-                        className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2 text-left text-sm hover:bg-surface-muted"
-                        onClick={() => {
-                          setFinished(false);
-                          setCurrentIndex(index);
-                        }}
-                      >
-                        <MarkdownText
-                          markdown={question.prompt}
-                          className="truncate text-sm"
-                        />
-                        {evaluation ? (
-                          evaluation.correct ? (
-                            <CheckCircle2 className="size-4 shrink-0 text-green-600" />
-                          ) : (
-                            <XCircle className="size-4 shrink-0 text-danger" />
-                          )
-                        ) : (
-                          <Badge variant="outline">Unanswered</Badge>
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : currentQuestion ? (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant="accent">Question {currentIndex + 1}</Badge>
-                  <Badge variant="outline">
-                    {currentQuestion.type.replace("_", " ")}
-                  </Badge>
-                  {currentQuestion.sourceNoteTitles.map((title) => (
-                    <Badge key={title} variant="neutral">
-                      {title}
+              <h2 className="text-sm font-medium text-foreground">Selected context</h2>
+              {selectedNoteIds.length === 0 ? (
+                <p className="rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm text-muted-foreground">
+                  Select one or more embedding-ready notes.
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {notes.filter((note) => selectedNoteIds.includes(note.id)).map((note) => (
+                    <Badge key={note.id} variant="accent">
+                      {note.title}
                     </Badge>
                   ))}
                 </div>
-
-                <div className="space-y-3">
-                  <MarkdownText
-                    markdown={currentQuestion.prompt}
-                    className="space-y-3 text-xl font-semibold leading-8"
-                  />
-                  {currentQuestion.type === "multiple_choice" ||
-                  currentQuestion.type === "true_false" ? (
-                    <div className="grid gap-2">
-                      {(currentQuestion.choices ?? []).map((choice) => (
-                        <label
-                          key={choice}
-                          className={cx(
-                            "flex cursor-pointer items-center gap-3 rounded-lg border border-border px-3 py-3 text-sm transition hover:bg-surface-muted",
-                            currentAnswer === choice
-                              ? "border-accent bg-accent-soft text-accent"
-                              : "text-foreground",
-                          )}
-                        >
-                          <input
-                            type="radio"
-                            name={currentQuestion.id}
-                            className="size-4 accent-[var(--accent)]"
-                            checked={currentAnswer === choice}
-                            disabled={Boolean(currentEvaluation) || examExpired}
-                            onChange={() => updateAnswer(choice)}
-                          />
-                          <MarkdownText markdown={choice} className="text-sm" />
-                        </label>
-                      ))}
-                    </div>
-                  ) : (
-                    <Textarea
-                      value={currentAnswer}
-                      disabled={Boolean(currentEvaluation) || examExpired}
-                      placeholder="Type your answer..."
-                      rows={7}
-                      onChange={(event) => updateAnswer(event.target.value)}
-                    />
-                  )}
-                </div>
-
-                {currentEvaluation ? (
-                  <div
-                    className={cx(
-                      "rounded-lg border px-4 py-3 text-sm leading-6",
-                      currentEvaluation.correct
-                        ? "border-green-200 bg-green-50 text-green-800 dark:border-green-950/70 dark:bg-green-950/20 dark:text-green-200"
-                        : "border-red-200 bg-danger-soft text-danger dark:border-red-950/70",
-                    )}
-                  >
-                    <div className="font-medium">
-                      {currentEvaluation.correct ? "Correct" : "Needs work"} ·
-                      Score {Math.round(currentEvaluation.score * 100)}%
-                    </div>
-                    <MarkdownText
-                      markdown={currentEvaluation.feedback}
-                      className="mt-1 space-y-2"
-                    />
-                    <div className="mt-2 space-y-1">
-                      <div className="font-medium">Ideal answer:</div>
-                      <MarkdownText
-                        markdown={currentEvaluation.idealAnswer}
-                        className="space-y-2"
-                      />
-                    </div>
-                  </div>
-                ) : examExpired ? (
-                  <div className="rounded-lg border border-border bg-surface-muted px-4 py-3 text-sm text-muted-foreground">
-                    Exam time has ended.
-                  </div>
-                ) : null}
-
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div className="flex flex-wrap gap-2">
-                    {mode === "exam" ? (
-                      <>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          disabled={currentIndex === 0}
-                          onClick={() =>
-                            setCurrentIndex((index) => Math.max(0, index - 1))
-                          }
-                        >
-                          Previous
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          disabled={currentIndex >= questions.length - 1}
-                          onClick={() =>
-                            setCurrentIndex((index) =>
-                              Math.min(questions.length - 1, index + 1),
-                            )
-                          }
-                        >
-                          Next
-                        </Button>
-                      </>
-                    ) : null}
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={
-                        !currentAnswer.trim() ||
-                        Boolean(currentEvaluation) ||
-                        isEvaluating ||
-                        examExpired
-                      }
-                      leadingIcon={
-                        isEvaluating ? (
-                          <Loader2 className="size-4 animate-spin" />
-                        ) : undefined
-                      }
-                      onClick={evaluateCurrentAnswer}
-                    >
-                      Check answer
-                    </Button>
-                    {mode === "infinite" ? (
-                      <Button
-                        type="button"
-                        disabled={!currentEvaluation || isGenerating}
-                        leadingIcon={
-                          isGenerating ? (
-                            <Loader2 className="size-4 animate-spin" />
-                          ) : undefined
-                        }
-                        onClick={nextInfiniteQuestion}
-                      >
-                        Next question
-                      </Button>
-                    ) : (
-                      <Button type="button" onClick={() => setFinished(true)}>
-                        Finish exam
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              </div>
-            ) : null}
+              )}
+            </section>
           </CardContent>
-
-          <div className="shrink-0 flex items-center justify-between gap-3">
-            {started ? (
-              <Button
-                type="button"
-                variant="outline"
-                leadingIcon={<RotateCcw className="size-4" />}
-                onClick={resetQuiz}
-              >
-                Reset
-              </Button>
-            ) : null}
-          </div>
         </Card>
       </div>
+    );
+  }
+
+  function renderPreview() {
+    return (
+      <div className="grid gap-6 xl:grid-cols-[360px_minmax(0,1fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Preview and edit</CardTitle>
+            <CardDescription>Generated questions are editable before saving or taking.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              Quiz title
+              <Input value={draftTitle} onChange={(event) => setDraftTitle(event.target.value)} />
+            </label>
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className="rounded-lg border border-border bg-surface-muted p-3">
+                <div className="text-xs text-muted-foreground">Mode</div>
+                <div className="font-semibold capitalize text-foreground">{mode}</div>
+              </div>
+              <div className="rounded-lg border border-border bg-surface-muted p-3">
+                <div className="text-xs text-muted-foreground">Questions</div>
+                <div className="font-semibold text-foreground">{draftQuestions.length}</div>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" disabled={draftQuestions.length === 0 || !draftTitle.trim() || isSaving} leadingIcon={isSaving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />} onClick={() => void saveDraftQuiz()}>
+                Save quiz
+              </Button>
+              <Button type="button" variant="outline" onClick={() => setView(editingQuizId ? "library" : "create")}>
+                Back
+              </Button>
+              <Button type="button" variant="ghost" onClick={() => openLibrary(activeQuizId)}>
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <section className="space-y-4">
+          {draftQuestions.map((question, index) => (
+            <Card key={question.id}>
+              <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <CardTitle>Question {index + 1}</CardTitle>
+                  <CardDescription>{question.type.replace("_", " ")}</CardDescription>
+                </div>
+                <Button type="button" size="sm" variant="destructive" leadingIcon={<Trash2 className="size-4" />} onClick={() => removeDraftQuestion(index)}>
+                  Remove
+                </Button>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <label className="space-y-2 text-sm font-medium text-foreground">
+                  Prompt
+                  <Textarea rows={3} value={question.prompt} onChange={(event) => updateDraftQuestion(index, { prompt: event.target.value })} />
+                </label>
+                {question.choices?.length ? (
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {question.choices.map((choice, choiceIndex) => (
+                      <label key={`${question.id}-${choiceIndex}`} className="space-y-2 text-sm font-medium text-foreground">
+                        Choice {choiceIndex + 1}
+                        <Input value={choice} onChange={(event) => updateDraftChoice(index, choiceIndex, event.target.value)} />
+                      </label>
+                    ))}
+                  </div>
+                ) : null}
+                <div className="grid gap-4 md:grid-cols-2">
+                  <label className="space-y-2 text-sm font-medium text-foreground">
+                    Correct answer
+                    <Input value={question.correctAnswer} onChange={(event) => updateDraftQuestion(index, { correctAnswer: event.target.value })} />
+                  </label>
+                  <label className="space-y-2 text-sm font-medium text-foreground">
+                    Source metadata
+                    <Input
+                      value={question.sourceNoteTitles.join(", ")}
+                      onChange={(event) =>
+                        updateDraftQuestion(index, {
+                          sourceNoteTitles: event.target.value.split(",").map((item) => item.trim()).filter(Boolean),
+                        })
+                      }
+                    />
+                  </label>
+                </div>
+                <label className="space-y-2 text-sm font-medium text-foreground">
+                  Explanation
+                  <Textarea rows={3} value={question.explanation} onChange={(event) => updateDraftQuestion(index, { explanation: event.target.value })} />
+                </label>
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+      </div>
+    );
+  }
+
+  function renderTake() {
+    if (!activeQuiz || !currentQuestion) {
+      return null;
+    }
+
+    return (
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>{activeQuiz.title}</CardTitle>
+            <CardDescription>
+              Question {currentIndex + 1} of {activeQuiz.questions.length}
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="accent">{activeQuiz.mode}</Badge>
+            {activeQuiz.mode === "exam" ? (
+              <Badge variant={examExpired ? "neutral" : "accent"}>
+                <Clock className="size-3.5" />
+                {formatTimer(remainingSeconds)}
+              </Badge>
+            ) : null}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {examExpired ? (
+            <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+              Time expired. Finish quiz to save results.
+            </div>
+          ) : null}
+          <div className="h-2 rounded-full bg-surface-muted">
+            <div
+              className="h-2 rounded-full bg-accent transition-all"
+              style={{ width: `${((currentIndex + 1) / activeQuiz.questions.length) * 100}%` }}
+            />
+          </div>
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="outline">{currentQuestion.type.replace("_", " ")}</Badge>
+              {currentQuestion.sourceNoteTitles.map((title) => (
+                <Badge key={title} variant="neutral">
+                  {title}
+                </Badge>
+              ))}
+            </div>
+            <MarkdownText markdown={currentQuestion.prompt} className="space-y-3 text-xl font-semibold leading-8" />
+          </div>
+          {currentQuestion.type === "multiple_choice" || currentQuestion.type === "true_false" ? (
+            <div className="grid gap-2">
+              {(currentQuestion.choices ?? []).map((choice) => (
+                <label
+                  key={choice}
+                  className={cx(
+                    "flex cursor-pointer items-center gap-3 rounded-lg border border-border px-3 py-3 text-sm transition hover:bg-surface-muted",
+                    currentAnswer === choice ? "border-accent bg-accent-soft text-accent" : "text-foreground",
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name={currentQuestion.id}
+                    className="size-4 accent-[var(--accent)]"
+                    checked={currentAnswer === choice}
+                    disabled={Boolean(currentEvaluation) || examExpired || isFinishing}
+                    onChange={() => updateAnswer(currentQuestion.id, choice)}
+                  />
+                  <MarkdownText markdown={choice} className="text-sm" />
+                </label>
+              ))}
+            </div>
+          ) : (
+            <Textarea
+              value={currentAnswer}
+              disabled={Boolean(currentEvaluation) || examExpired || isFinishing}
+              placeholder="Type your answer..."
+              rows={7}
+              onChange={(event) => updateAnswer(currentQuestion.id, event.target.value)}
+            />
+          )}
+          {currentEvaluation && activeQuiz.mode === "practice" ? (
+            <div
+              className={cx(
+                "rounded-lg border px-4 py-3 text-sm leading-6",
+                currentEvaluation.correct
+                  ? "border-green-200 bg-green-50 text-green-800 dark:border-green-950/70 dark:bg-green-950/20 dark:text-green-200"
+                  : "border-red-200 bg-danger-soft text-danger dark:border-red-950/70",
+              )}
+            >
+              <div className="font-medium">
+                {currentEvaluation.correct ? "Correct" : "Needs work"} - Score {formatPercent(currentEvaluation.score)}
+              </div>
+              <MarkdownText markdown={currentEvaluation.feedback} className="mt-1 space-y-2" />
+              <div className="mt-2 font-medium">Ideal answer</div>
+              <MarkdownText markdown={currentEvaluation.idealAnswer} className="mt-1 space-y-2" />
+            </div>
+          ) : null}
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" disabled={currentIndex === 0 || isFinishing} onClick={() => setCurrentIndex((index) => Math.max(0, index - 1))}>
+                Previous
+              </Button>
+              <Button type="button" variant="outline" disabled={currentIndex >= activeQuiz.questions.length - 1 || isFinishing} onClick={() => setCurrentIndex((index) => Math.min(activeQuiz.questions.length - 1, index + 1))}>
+                Next
+              </Button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {activeQuiz.mode === "practice" ? (
+                <Button type="button" variant="outline" disabled={!currentAnswer.trim() || Boolean(currentEvaluation) || isEvaluating || isFinishing} leadingIcon={isEvaluating ? <Loader2 className="size-4 animate-spin" /> : <CheckCircle2 className="size-4" />} onClick={() => void checkCurrentAnswer()}>
+                  Check answer
+                </Button>
+              ) : null}
+              <Button type="button" variant="outline" disabled={isFinishing} onClick={() => openLibrary(activeQuiz.id)}>
+                Exit
+              </Button>
+              <Button type="button" disabled={isFinishing} leadingIcon={isFinishing ? <Loader2 className="size-4 animate-spin" /> : undefined} onClick={() => void finishAttempt()}>
+                Finish quiz
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  function renderResults() {
+    if (!activeQuiz || !selectedAttempt) {
+      return null;
+    }
+
+    const byQuestionId = new Map(selectedAttempt.answers.map((answer) => [answer.questionId, answer]));
+
+    return (
+      <div className="grid gap-6 xl:grid-cols-[360px_minmax(0,1fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Results</CardTitle>
+            <CardDescription>{activeQuiz.title}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="rounded-lg border border-border bg-surface-muted p-4">
+              <div className="text-3xl font-semibold text-foreground">{formatPercent(selectedAttempt.score)}</div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {selectedAttempt.correctCount}/{selectedAttempt.questionCount} correct, {selectedAttempt.answeredCount} answered.
+              </p>
+            </div>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>Completed {formatDate(selectedAttempt.completedAt)}</p>
+              {selectedAttempt.timeSpentSeconds !== null ? <p>Time spent {formatTimer(selectedAttempt.timeSpentSeconds)}</p> : null}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" leadingIcon={<RotateCcw className="size-4" />} onClick={() => startTaking(activeQuiz)}>
+                Retake
+              </Button>
+              <Button type="button" variant="outline" onClick={() => openLibrary(activeQuiz.id)}>
+                Back to detail
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <section className="space-y-4">
+          {activeQuiz.questions.map((question, index) => {
+            const answer = byQuestionId.get(question.id);
+            const evaluation = answer?.evaluation ?? createUnansweredEvaluation(question);
+            return (
+              <Card key={question.id} className={evaluation.correct ? "border-green-200 dark:border-green-950/70" : "border-red-200 dark:border-red-950/70"}>
+                <CardHeader>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">Question {index + 1}</Badge>
+                    {evaluation.correct ? (
+                      <Badge variant="accent">
+                        <CheckCircle2 className="size-3.5" />
+                        Correct
+                      </Badge>
+                    ) : (
+                      <Badge variant="neutral">
+                        <XCircle className="size-3.5" />
+                        Missed
+                      </Badge>
+                    )}
+                  </div>
+                  <CardTitle className="text-base">Review</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm">
+                  <MarkdownText markdown={question.prompt} className="space-y-2 font-medium" />
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="rounded-lg border border-border bg-surface-muted p-3">
+                      <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Your answer</div>
+                      <MarkdownText markdown={answer?.answer.trim() || "Unanswered"} className="space-y-2" />
+                    </div>
+                    <div className="rounded-lg border border-border bg-surface-muted p-3">
+                      <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Correct answer</div>
+                      <MarkdownText markdown={question.correctAnswer} className="space-y-2" />
+                    </div>
+                  </div>
+                  <div className="rounded-lg border border-border bg-surface p-3">
+                    <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Feedback</div>
+                    <MarkdownText markdown={evaluation.feedback} className="space-y-2" />
+                    <div className="mt-3 mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Explanation</div>
+                    <MarkdownText markdown={question.explanation || evaluation.idealAnswer} className="space-y-2" />
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+      <PageHeader
+        eyebrow="Quizzing"
+        title="Quizzes"
+        description="Manage saved quizzes, generate from notes, edit before saving, take focused attempts, and review results."
+        actions={
+          view === "library" ? (
+            <Button type="button" leadingIcon={<Plus className="size-4" />} onClick={openCreate}>
+              Create quiz
+            </Button>
+          ) : null
+        }
+      />
+
+      {error ? (
+        <div className="rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
+          {error}
+        </div>
+      ) : null}
+
+      {view !== "library" ? (
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={() => openLibrary(activeQuizId)}>
+            My Quizzes
+          </Button>
+          {view === "take" && activeQuiz ? (
+            <Badge variant="outline">
+              <Edit3 className="size-3.5" />
+              Focus mode
+            </Badge>
+          ) : null}
+        </div>
+      ) : null}
+
+      {view === "library" ? renderLibrary() : null}
+      {view === "create" ? renderCreate() : null}
+      {view === "preview" ? renderPreview() : null}
+      {view === "take" ? renderTake() : null}
+      {view === "results" ? renderResults() : null}
     </main>
   );
 }

--- a/app/quizzes/quizzes-client.tsx
+++ b/app/quizzes/quizzes-client.tsx
@@ -195,6 +195,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
   const [difficulty, setDifficulty] = useState<QuizDifficulty>("medium");
   const [draftTitle, setDraftTitle] = useState("");
   const [draftQuestions, setDraftQuestions] = useState<QuizQuestion[]>([]);
+  const [draftQuestionIndex, setDraftQuestionIndex] = useState(0);
   const [editingQuizId, setEditingQuizId] = useState<string | null>(null);
 
   const [answers, setAnswers] = useState<Record<string, QuizAttemptAnswer>>({});
@@ -218,6 +219,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
     activeAttempts[0] ??
     null;
   const currentQuestion = activeQuiz?.questions[currentIndex] ?? null;
+  const activeDraftQuestion = draftQuestions[draftQuestionIndex] ?? null;
   const currentAnswer = currentQuestion ? answers[currentQuestion.id]?.answer ?? "" : "";
   const currentEvaluation = currentQuestion ? answers[currentQuestion.id]?.evaluation : undefined;
   const canGenerate = selectedNoteIds.length > 0 && questionTypes.length > 0 && embeddedNotes.length > 0 && !isGenerating;
@@ -235,6 +237,10 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
     return () => window.clearInterval(timer);
   }, [activeQuiz?.mode, isFinishing, remainingSeconds, view]);
 
+  useEffect(() => {
+    setDraftQuestionIndex((index) => Math.min(Math.max(index, 0), Math.max(draftQuestions.length - 1, 0)));
+  }, [draftQuestions.length]);
+
   function resetCreateForm() {
     setSelectedNoteIds([]);
     setMode("practice");
@@ -244,6 +250,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
     setDifficulty("medium");
     setDraftTitle("");
     setDraftQuestions([]);
+    setDraftQuestionIndex(0);
     setEditingQuizId(null);
   }
 
@@ -293,6 +300,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
 
       const selectedTitles = notes.filter((note) => selectedNoteIds.includes(note.id)).map((note) => note.title);
       setDraftQuestions(payload.questions);
+      setDraftQuestionIndex(0);
       setDraftTitle(selectedTitles.length === 1 ? `${selectedTitles[0]} quiz` : "Generated note quiz");
       setView("preview");
     } catch (generationError) {
@@ -352,11 +360,13 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
 
   function removeDraftQuestion(index: number) {
     setDraftQuestions((current) => current.filter((_, questionIndex) => questionIndex !== index));
+    setDraftQuestionIndex((current) => Math.max(0, Math.min(current, draftQuestions.length - 2)));
   }
 
   function addDraftQuestion() {
     const selectedTitles = notes.filter((note) => selectedNoteIds.includes(note.id)).map((note) => note.title);
     setDraftQuestions((current) => [...current, makeDraftQuestion(selectedTitles)]);
+    setDraftQuestionIndex(draftQuestions.length);
   }
 
   async function saveDraftQuiz() {
@@ -431,6 +441,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
     setDifficulty(quiz.difficulty);
     setDraftTitle(quiz.title);
     setDraftQuestions(quiz.questions);
+    setDraftQuestionIndex(0);
     setEditingQuizId(quiz.id);
     setView("preview");
     setError(null);
@@ -596,8 +607,8 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
     const totalQuestions = quizzes.reduce((sum, quiz) => sum + quiz.questionCount, 0);
 
     return (
-      <section className="space-y-8">
-        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+      <section className="flex h-full min-h-0 flex-col gap-5">
+        <div className="flex shrink-0 flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div className="flex flex-wrap gap-2">
             <StatPill>{quizzes.length} quizzes</StatPill>
             <StatPill>{totalQuestions} questions</StatPill>
@@ -608,7 +619,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
         </div>
 
         {quizzes.length === 0 ? (
-          <div className="flex min-h-[28rem] items-center justify-center rounded-[var(--radius-xl)] border border-dashed border-border bg-surface/70 p-8">
+          <div className="flex min-h-0 flex-1 items-center justify-center rounded-[var(--radius-xl)] border border-dashed border-border bg-surface/70 p-8">
             <div className="flex max-w-sm flex-col items-center text-center">
               <FileQuestion className="mb-5 size-12 text-muted-foreground" />
               <h2 className="text-lg font-semibold text-foreground">No saved quizzes</h2>
@@ -616,7 +627,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
             </div>
           </div>
         ) : (
-          <div className="grid gap-4 xl:grid-cols-2">
+          <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto pr-1 xl:grid-cols-2">
             {quizzes.map((quiz) => {
               const quizAttempts = attempts.filter((attempt) => attempt.quizId === quiz.id);
               const lastAttempt = quizAttempts[0];
@@ -654,7 +665,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
                     <div className="space-y-2">
                       <h3 className="text-sm font-medium text-foreground">Questions</h3>
                       <div className="grid gap-2">
-                        {quiz.questions.slice(0, 3).map((question, index) => (
+                        {quiz.questions.slice(0, 2).map((question, index) => (
                           <button
                             key={question.id}
                             type="button"
@@ -742,8 +753,8 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
 
   function renderCreate() {
     return (
-      <Card>
-        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <Card className="flex h-full min-h-0 flex-col">
+        <CardHeader className="shrink-0 gap-4 py-5 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <CardTitle className="text-xl">Create Quiz</CardTitle>
             <CardDescription>Choose note context and quiz settings.</CardDescription>
@@ -753,15 +764,15 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
             <StepPill>Preview</StepPill>
           </div>
         </CardHeader>
-        <CardContent className="space-y-8">
-          <section className="space-y-4">
+        <CardContent className="flex min-h-0 flex-1 flex-col gap-5 pb-5">
+          <section className="flex min-h-0 flex-1 flex-col gap-3">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-sm font-semibold text-foreground">Notes</h2>
               <Badge variant="outline" className="text-sm">
                 {selectedNoteIds.length} selected
               </Badge>
             </div>
-            <div className="grid gap-3 lg:grid-cols-2">
+            <div className="grid min-h-0 flex-1 gap-3 overflow-y-auto pr-1 lg:grid-cols-2">
               {notes.length === 0 ? (
                 <p className="rounded-lg border border-border bg-surface-muted px-3 py-3 text-sm text-muted-foreground">
                   Create or upload notes first.
@@ -795,15 +806,15 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
             </div>
           </section>
 
-          <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
+          <section className="grid shrink-0 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
             <div className="space-y-4">
               <h2 className="text-sm font-semibold text-foreground">Question types</h2>
-              <div className="grid gap-3 md:grid-cols-3">
+              <div className="grid gap-2 md:grid-cols-3">
                 {questionTypeOptions.map((option) => (
                   <label
                     key={option.value}
                     className={cx(
-                      "flex cursor-pointer items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 text-sm transition hover:bg-surface-muted",
+                      "flex cursor-pointer items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2 text-sm transition hover:bg-surface-muted",
                       questionTypes.includes(option.value) ? "border-accent bg-accent-soft/60 text-accent" : "",
                     )}
                   >
@@ -817,13 +828,13 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
                   </label>
                 ))}
               </div>
-              <div className="grid gap-3 md:grid-cols-2">
+              <div className="grid gap-2 md:grid-cols-2">
                 {modeOptions.map((option) => (
                   <button
                     key={option.value}
                     type="button"
                     className={cx(
-                      "rounded-lg border px-4 py-3 text-left text-sm transition",
+                    "rounded-lg border px-3 py-2 text-left text-sm transition",
                       mode === option.value
                         ? "border-accent bg-accent-soft text-accent"
                         : "border-border bg-surface hover:bg-surface-muted",
@@ -837,7 +848,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
               </div>
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-3 xl:grid-cols-1">
+            <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
               <label className="space-y-2 text-sm font-medium text-foreground">
                 Difficulty
                 <Select value={difficulty} onChange={(event) => setDifficulty(event.target.value as QuizDifficulty)}>
@@ -859,7 +870,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
             </div>
           </section>
 
-          <div className="flex flex-wrap gap-2">
+          <div className="flex shrink-0 flex-wrap gap-2">
             <Button
               type="button"
               disabled={!canGenerate}
@@ -879,8 +890,8 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
 
   function renderPreview() {
     return (
-      <Card>
-        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <Card className="flex h-full min-h-0 flex-col">
+        <CardHeader className="shrink-0 gap-4 py-5 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <CardTitle className="text-xl">Preview Quiz</CardTitle>
             <CardDescription>Edit before saving.</CardDescription>
@@ -890,14 +901,13 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
             <StepPill active>Preview</StepPill>
           </div>
         </CardHeader>
-        <CardContent className="space-y-7">
-          <label className="block space-y-2 text-sm font-medium text-foreground">
-            Quiz name
-            <Input value={draftTitle} onChange={(event) => setDraftTitle(event.target.value)} />
-          </label>
-
-          <section className="grid gap-4 lg:grid-cols-4">
-            <label className="space-y-2 text-sm font-medium text-foreground">
+        <CardContent className="flex min-h-0 flex-1 flex-col gap-4 pb-5">
+          <section className="grid shrink-0 gap-3 lg:grid-cols-[minmax(260px,1fr)_160px_160px_140px]">
+            <label className="space-y-1.5 text-sm font-medium text-foreground">
+              Quiz name
+              <Input value={draftTitle} onChange={(event) => setDraftTitle(event.target.value)} />
+            </label>
+            <label className="space-y-1.5 text-sm font-medium text-foreground">
               Mode
               <Select value={mode} onChange={(event) => setMode(event.target.value as QuizMode)}>
                 {modeOptions.map((option) => (
@@ -907,7 +917,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
                 ))}
               </Select>
             </label>
-            <label className="space-y-2 text-sm font-medium text-foreground">
+            <label className="space-y-1.5 text-sm font-medium text-foreground">
               Difficulty
               <Select value={difficulty} onChange={(event) => setDifficulty(event.target.value as QuizDifficulty)}>
                 {difficultyOptions.map((option) => (
@@ -917,62 +927,83 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
                 ))}
               </Select>
             </label>
-            <label className="space-y-2 text-sm font-medium text-foreground">
-              Time limit
+            <label className="space-y-1.5 text-sm font-medium text-foreground">
+              Time
               <Input min={1} max={240} type="number" disabled={mode !== "exam"} value={timeMinutes} onChange={(event) => setTimeMinutes(Number(event.target.value))} />
-            </label>
-            <label className="space-y-2 text-sm font-medium text-foreground">
-              Question types
-              <Input
-                value={questionTypes.map((type) => type.replace("_", " ")).join(", ")}
-                readOnly
-                className="text-muted-foreground"
-              />
             </label>
           </section>
 
-          <section className="space-y-4">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <h2 className="text-base font-semibold text-foreground">Questions</h2>
-              <Button type="button" variant="outline" leadingIcon={<Plus className="size-4" />} onClick={addDraftQuestion}>
-                Add question
-              </Button>
-            </div>
-
-            {draftQuestions.length === 0 ? (
-              <div className="rounded-[var(--radius-xl)] border border-dashed border-border bg-surface-muted px-6 py-10 text-center">
-                <FileQuestion className="mx-auto mb-3 size-8 text-muted-foreground" />
-                <h3 className="font-semibold text-foreground">No questions in preview</h3>
-                <p className="mt-1 text-sm text-muted-foreground">Add a question or go back to generate from context.</p>
+          <section className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
+            <aside className="flex min-h-0 flex-col rounded-[var(--radius-xl)] border border-border bg-surface-muted/60">
+              <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border p-3">
+                <h2 className="text-sm font-semibold text-foreground">Questions</h2>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  aria-label="Add question"
+                  leadingIcon={<Plus className="size-4" />}
+                  onClick={addDraftQuestion}
+                >
+                  Add
+                </Button>
               </div>
-            ) : (
-              <div className="space-y-5">
-                {draftQuestions.map((question, index) => (
-                  <div key={question.id} className="rounded-[var(--radius-xl)] border border-border bg-surface-muted/60 p-5">
-                    <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
-                      <Badge variant="outline">Question {index + 1}</Badge>
-                      <Button type="button" size="sm" variant="ghost" leadingIcon={<Trash2 className="size-4" />} onClick={() => removeDraftQuestion(index)}>
-                        Remove
-                      </Button>
-                    </div>
+              <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-3">
+                {draftQuestions.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-border px-3 py-6 text-center">
+                    <FileQuestion className="mx-auto mb-2 size-7 text-muted-foreground" />
+                    <p className="text-sm font-medium text-foreground">No questions</p>
+                    <p className="mt-1 text-xs text-muted-foreground">Add or generate from context.</p>
+                  </div>
+                ) : (
+                  draftQuestions.map((question, index) => (
+                    <button
+                      key={question.id}
+                      type="button"
+                      className={cx(
+                        "w-full rounded-lg border px-3 py-2 text-left text-sm transition",
+                        draftQuestionIndex === index
+                          ? "border-accent bg-accent-soft text-accent"
+                          : "border-border bg-surface hover:bg-surface-muted",
+                      )}
+                      onClick={() => setDraftQuestionIndex(index)}
+                    >
+                      <span className="block font-semibold">Question {index + 1}</span>
+                      <span className="mt-1 block truncate text-xs text-muted-foreground">
+                        {question.prompt || question.type.replace("_", " ")}
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </aside>
 
-                    <div className="grid gap-4 lg:grid-cols-2">
-                      <label className="space-y-2 text-sm font-medium text-foreground">
-                        Prompt
-                        <Textarea rows={7} value={question.prompt} onChange={(event) => updateDraftQuestion(index, { prompt: event.target.value })} />
-                      </label>
-                      <label className="space-y-2 text-sm font-medium text-foreground">
-                        Correct answer
-                        <Textarea rows={7} value={question.correctAnswer} onChange={(event) => updateDraftQuestion(index, { correctAnswer: event.target.value })} />
-                      </label>
-                    </div>
+            {activeDraftQuestion ? (
+              <div className="flex min-h-0 flex-col rounded-[var(--radius-xl)] border border-border bg-surface-muted/60 p-4">
+                <div className="mb-3 flex shrink-0 flex-wrap items-center justify-between gap-3">
+                  <Badge variant="outline">Question {draftQuestionIndex + 1}</Badge>
+                  <Button type="button" size="sm" variant="ghost" leadingIcon={<Trash2 className="size-4" />} onClick={() => removeDraftQuestion(draftQuestionIndex)}>
+                    Remove
+                  </Button>
+                </div>
 
-                    <div className="mt-4 grid gap-4 lg:grid-cols-[220px_minmax(0,1fr)]">
-                      <label className="space-y-2 text-sm font-medium text-foreground">
+                <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-2">
+                  <div className="flex min-h-0 flex-col gap-3">
+                    <label className="flex min-h-0 flex-1 flex-col gap-1.5 text-sm font-medium text-foreground">
+                      Prompt
+                      <Textarea
+                        rows={7}
+                        value={activeDraftQuestion.prompt}
+                        className="min-h-0 flex-1 resize-none"
+                        onChange={(event) => updateDraftQuestion(draftQuestionIndex, { prompt: event.target.value })}
+                      />
+                    </label>
+                    <div className="grid shrink-0 gap-3 md:grid-cols-[180px_minmax(0,1fr)]">
+                      <label className="space-y-1.5 text-sm font-medium text-foreground">
                         Type
                         <Select
-                          value={question.type}
-                          onChange={(event) => updateDraftQuestionType(index, event.target.value as QuizQuestionType)}
+                          value={activeDraftQuestion.type}
+                          onChange={(event) => updateDraftQuestionType(draftQuestionIndex, event.target.value as QuizQuestionType)}
                         >
                           {questionTypeOptions.map((option) => (
                             <option key={option.value} value={option.value}>
@@ -981,12 +1012,12 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
                           ))}
                         </Select>
                       </label>
-                      <label className="space-y-2 text-sm font-medium text-foreground">
+                      <label className="space-y-1.5 text-sm font-medium text-foreground">
                         Source metadata
                         <Input
-                          value={question.sourceNoteTitles.join(", ")}
+                          value={activeDraftQuestion.sourceNoteTitles.join(", ")}
                           onChange={(event) =>
-                            updateDraftQuestion(index, {
+                            updateDraftQuestion(draftQuestionIndex, {
                               sourceNoteTitles: event.target.value
                                 .split(",")
                                 .map((item) => item.trim())
@@ -996,39 +1027,53 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
                         />
                       </label>
                     </div>
-
-                    {question.type === "multiple_choice" && question.choices?.length ? (
-                      <div className="mt-4 grid gap-3 md:grid-cols-2">
-                        {question.choices.map((choice, choiceIndex) => (
-                          <label key={`${question.id}-${choiceIndex}`} className="space-y-2 text-sm font-medium text-foreground">
-                            Choice {choiceIndex + 1}
-                            <Input value={choice} onChange={(event) => updateDraftChoice(index, choiceIndex, event.target.value)} />
-                          </label>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    <label className="mt-4 block space-y-2 text-sm font-medium text-foreground">
-                      Explanation
-                      <Textarea rows={3} value={question.explanation} onChange={(event) => updateDraftQuestion(index, { explanation: event.target.value })} />
-                    </label>
-
-                    {question.sourceNoteTitles.length > 0 ? (
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {question.sourceNoteTitles.map((title) => (
-                          <Badge key={title} variant="neutral">
-                            {title}
-                          </Badge>
-                        ))}
-                      </div>
-                    ) : null}
                   </div>
-                ))}
+
+                  <div className="flex min-h-0 flex-col gap-3">
+                    <label className="flex min-h-0 flex-1 flex-col gap-1.5 text-sm font-medium text-foreground">
+                      Correct answer
+                      <Textarea
+                        rows={7}
+                        value={activeDraftQuestion.correctAnswer}
+                        className="min-h-0 flex-1 resize-none"
+                        onChange={(event) => updateDraftQuestion(draftQuestionIndex, { correctAnswer: event.target.value })}
+                      />
+                    </label>
+                    <label className="flex min-h-0 flex-1 flex-col gap-1.5 text-sm font-medium text-foreground">
+                      Explanation
+                      <Textarea
+                        rows={3}
+                        value={activeDraftQuestion.explanation}
+                        className="min-h-0 flex-1 resize-none"
+                        onChange={(event) => updateDraftQuestion(draftQuestionIndex, { explanation: event.target.value })}
+                      />
+                    </label>
+                  </div>
+                </div>
+
+                {activeDraftQuestion.type === "multiple_choice" && activeDraftQuestion.choices?.length ? (
+                  <div className="mt-3 grid shrink-0 gap-2 md:grid-cols-4">
+                    {activeDraftQuestion.choices.map((choice, choiceIndex) => (
+                      <label key={`${activeDraftQuestion.id}-${choiceIndex}`} className="space-y-1.5 text-sm font-medium text-foreground">
+                        Choice {choiceIndex + 1}
+                        <Input value={choice} onChange={(event) => updateDraftChoice(draftQuestionIndex, choiceIndex, event.target.value)} />
+                      </label>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="flex min-h-0 items-center justify-center rounded-[var(--radius-xl)] border border-dashed border-border bg-surface-muted">
+                <div className="text-center">
+                  <FileQuestion className="mx-auto mb-3 size-8 text-muted-foreground" />
+                  <p className="font-semibold text-foreground">No questions in preview</p>
+                  <p className="mt-1 text-sm text-muted-foreground">Add a question or go back to generate from context.</p>
+                </div>
               </div>
             )}
           </section>
 
-          <div className="flex flex-wrap gap-2">
+          <div className="flex shrink-0 flex-wrap gap-2">
             <Button
               type="button"
               disabled={draftQuestions.length === 0 || !draftTitle.trim() || isSaving}
@@ -1055,8 +1100,8 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
     }
 
     return (
-      <Card>
-        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <Card className="flex h-full min-h-0 flex-col">
+        <CardHeader className="shrink-0 gap-4 py-5 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <CardTitle>{activeQuiz.title}</CardTitle>
             <CardDescription>
@@ -1073,20 +1118,20 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
             ) : null}
           </div>
         </CardHeader>
-        <CardContent className="space-y-6">
+        <CardContent className="flex min-h-0 flex-1 flex-col gap-4 pb-5">
           {examExpired ? (
             <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
               <AlertTriangle className="mt-0.5 size-4 shrink-0" />
               Time expired. Finish quiz to save results.
             </div>
           ) : null}
-          <div className="h-2 rounded-full bg-surface-muted">
+          <div className="h-2 shrink-0 rounded-full bg-surface-muted">
             <div
               className="h-2 rounded-full bg-accent transition-all"
               style={{ width: `${((currentIndex + 1) / activeQuiz.questions.length) * 100}%` }}
             />
           </div>
-          <div className="space-y-3">
+          <div className="min-h-0 shrink overflow-y-auto rounded-lg border border-border bg-surface-muted p-4">
             <div className="flex flex-wrap gap-2">
               <Badge variant="outline">{currentQuestion.type.replace("_", " ")}</Badge>
               {currentQuestion.sourceNoteTitles.map((title) => (
@@ -1098,7 +1143,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
             <MarkdownText markdown={currentQuestion.prompt} className="space-y-3 text-xl font-semibold leading-8" />
           </div>
           {currentQuestion.type === "multiple_choice" || currentQuestion.type === "true_false" ? (
-            <div className="grid gap-2">
+            <div className="grid shrink-0 gap-2">
               {(currentQuestion.choices ?? []).map((choice) => (
                 <label
                   key={choice}
@@ -1125,6 +1170,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
               disabled={Boolean(currentEvaluation) || examExpired || isFinishing}
               placeholder="Type your answer..."
               rows={7}
+              className="min-h-0 flex-1 resize-none"
               onChange={(event) => updateAnswer(currentQuestion.id, event.target.value)}
             />
           )}
@@ -1145,7 +1191,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
               <MarkdownText markdown={currentEvaluation.idealAnswer} className="mt-1 space-y-2" />
             </div>
           ) : null}
-          <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex shrink-0 flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap gap-2">
               <Button type="button" variant="outline" disabled={currentIndex === 0 || isFinishing} onClick={() => setCurrentIndex((index) => Math.max(0, index - 1))}>
                 Previous
@@ -1179,15 +1225,21 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
     }
 
     const byQuestionId = new Map(selectedAttempt.answers.map((answer) => [answer.questionId, answer]));
+    const resultQuestionIndex = Math.min(currentIndex, activeQuiz.questions.length - 1);
+    const resultQuestion = activeQuiz.questions[resultQuestionIndex];
+    const resultAnswer = resultQuestion ? byQuestionId.get(resultQuestion.id) : undefined;
+    const resultEvaluation = resultQuestion
+      ? resultAnswer?.evaluation ?? createUnansweredEvaluation(resultQuestion)
+      : null;
 
     return (
-      <div className="grid gap-6 xl:grid-cols-[360px_minmax(0,1fr)]">
-        <Card>
-          <CardHeader>
+      <div className="grid h-full min-h-0 gap-4 xl:grid-cols-[300px_minmax(0,1fr)]">
+        <Card className="flex min-h-0 flex-col">
+          <CardHeader className="shrink-0 py-5">
             <CardTitle>Results</CardTitle>
             <CardDescription>{activeQuiz.title}</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-5">
+          <CardContent className="flex min-h-0 flex-1 flex-col gap-4 pb-5">
             <div className="rounded-lg border border-border bg-surface-muted p-4">
               <div className="text-3xl font-semibold text-foreground">{formatPercent(selectedAttempt.score)}</div>
               <p className="mt-1 text-sm text-muted-foreground">
@@ -1197,6 +1249,32 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
             <div className="space-y-2 text-sm text-muted-foreground">
               <p>Completed {formatDate(selectedAttempt.completedAt)}</p>
               {selectedAttempt.timeSpentSeconds !== null ? <p>Time spent {formatTimer(selectedAttempt.timeSpentSeconds)}</p> : null}
+            </div>
+            <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
+              {activeQuiz.questions.map((question, index) => {
+                const answer = byQuestionId.get(question.id);
+                const evaluation = answer?.evaluation ?? createUnansweredEvaluation(question);
+                return (
+                  <button
+                    key={question.id}
+                    type="button"
+                    className={cx(
+                      "flex w-full items-center justify-between gap-3 rounded-lg border px-3 py-2 text-left text-sm transition",
+                      resultQuestionIndex === index
+                        ? "border-accent bg-accent-soft text-accent"
+                        : "border-border bg-surface hover:bg-surface-muted",
+                    )}
+                    onClick={() => setCurrentIndex(index)}
+                  >
+                    <span>Question {index + 1}</span>
+                    {evaluation.correct ? (
+                      <CheckCircle2 className="size-4 text-accent" />
+                    ) : (
+                      <XCircle className="size-4 text-muted-foreground" />
+                    )}
+                  </button>
+                );
+              })}
             </div>
             <div className="flex flex-wrap gap-2">
               <Button type="button" leadingIcon={<RotateCcw className="size-4" />} onClick={() => startTaking(activeQuiz)}>
@@ -1209,78 +1287,77 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
           </CardContent>
         </Card>
 
-        <section className="space-y-4">
-          {activeQuiz.questions.map((question, index) => {
-            const answer = byQuestionId.get(question.id);
-            const evaluation = answer?.evaluation ?? createUnansweredEvaluation(question);
-            return (
-              <Card key={question.id} className={evaluation.correct ? "border-green-200 dark:border-green-950/70" : "border-red-200 dark:border-red-950/70"}>
-                <CardHeader>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge variant="outline">Question {index + 1}</Badge>
-                    {evaluation.correct ? (
-                      <Badge variant="accent">
-                        <CheckCircle2 className="size-3.5" />
-                        Correct
-                      </Badge>
-                    ) : (
-                      <Badge variant="neutral">
-                        <XCircle className="size-3.5" />
-                        Missed
-                      </Badge>
-                    )}
-                  </div>
-                  <CardTitle className="text-base">Review</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4 text-sm">
-                  <MarkdownText markdown={question.prompt} className="space-y-2 font-medium" />
-                  <div className="grid gap-3 md:grid-cols-2">
-                    <div className="rounded-lg border border-border bg-surface-muted p-3">
-                      <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Your answer</div>
-                      <MarkdownText markdown={answer?.answer.trim() || "Unanswered"} className="space-y-2" />
-                    </div>
-                    <div className="rounded-lg border border-border bg-surface-muted p-3">
-                      <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Correct answer</div>
-                      <MarkdownText markdown={question.correctAnswer} className="space-y-2" />
-                    </div>
-                  </div>
-                  <div className="rounded-lg border border-border bg-surface p-3">
-                    <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Feedback</div>
-                    <MarkdownText markdown={evaluation.feedback} className="space-y-2" />
-                    <div className="mt-3 mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Explanation</div>
-                    <MarkdownText markdown={question.explanation || evaluation.idealAnswer} className="space-y-2" />
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </section>
+        {resultQuestion && resultEvaluation ? (
+          <Card className={cx("flex min-h-0 flex-col", resultEvaluation.correct ? "border-green-200 dark:border-green-950/70" : "border-red-200 dark:border-red-950/70")}>
+            <CardHeader className="shrink-0 py-5">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">Question {resultQuestionIndex + 1}</Badge>
+                {resultEvaluation.correct ? (
+                  <Badge variant="accent">
+                    <CheckCircle2 className="size-3.5" />
+                    Correct
+                  </Badge>
+                ) : (
+                  <Badge variant="neutral">
+                    <XCircle className="size-3.5" />
+                    Missed
+                  </Badge>
+                )}
+              </div>
+              <CardTitle className="text-base">Review</CardTitle>
+            </CardHeader>
+            <CardContent className="flex min-h-0 flex-1 flex-col gap-3 text-sm">
+              <div className="min-h-0 overflow-y-auto rounded-lg border border-border bg-surface-muted p-3">
+                <MarkdownText markdown={resultQuestion.prompt} className="space-y-2 font-medium" />
+              </div>
+              <div className="grid min-h-0 flex-1 gap-3 md:grid-cols-2">
+                <div className="min-h-0 overflow-y-auto rounded-lg border border-border bg-surface-muted p-3">
+                  <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Your answer</div>
+                  <MarkdownText markdown={resultAnswer?.answer.trim() || "Unanswered"} className="space-y-2" />
+                </div>
+                <div className="min-h-0 overflow-y-auto rounded-lg border border-border bg-surface-muted p-3">
+                  <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Correct answer</div>
+                  <MarkdownText markdown={resultQuestion.correctAnswer} className="space-y-2" />
+                </div>
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-border bg-surface p-3">
+                <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Feedback</div>
+                <MarkdownText markdown={resultEvaluation.feedback} className="space-y-2" />
+                <div className="mt-3 mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Explanation</div>
+                <MarkdownText markdown={resultQuestion.explanation || resultEvaluation.idealAnswer} className="space-y-2" />
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
       </div>
     );
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8">
-      <header className="space-y-4">
+    <main
+      data-testid="quizzes-one-page"
+      className="mx-auto flex h-full min-h-0 w-full max-w-7xl flex-col gap-4 overflow-hidden px-4 py-5 sm:px-6 lg:px-8"
+    >
+      <header className="shrink-0">
         <div>
-          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.28em] text-muted-foreground">QUIZZES</p>
-          <h1 className="text-4xl font-semibold tracking-tight text-foreground">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">QUIZZES</p>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
             {view === "library" ? "My Quizzes" : "Quizzes"}
           </h1>
-          <p className="mt-4 max-w-2xl text-base text-muted-foreground">
+          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
             Focused quiz library, generation queue, and question editor.
           </p>
         </div>
       </header>
 
       {error ? (
-        <div className="rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
+        <div className="shrink-0 rounded-lg border border-red-200 bg-danger-soft px-4 py-2 text-sm text-danger dark:border-red-950/70">
           {error}
         </div>
       ) : null}
 
       {view !== "library" ? (
-        <div className="flex flex-wrap gap-2">
+        <div className="flex shrink-0 flex-wrap gap-2">
           <Button type="button" variant="ghost" size="sm" onClick={() => openLibrary(activeQuizId)}>
             My Quizzes
           </Button>
@@ -1288,11 +1365,13 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
         </div>
       ) : null}
 
-      {view === "library" ? renderLibrary() : null}
-      {view === "create" ? renderCreate() : null}
-      {view === "preview" ? renderPreview() : null}
-      {view === "take" ? renderTake() : null}
-      {view === "results" ? renderResults() : null}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {view === "library" ? renderLibrary() : null}
+        {view === "create" ? renderCreate() : null}
+        {view === "preview" ? renderPreview() : null}
+        {view === "take" ? renderTake() : null}
+        {view === "results" ? renderResults() : null}
+      </div>
     </main>
   );
 }

--- a/app/quizzes/quizzes-client.tsx
+++ b/app/quizzes/quizzes-client.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
   Clock,
   Copy,
-  Edit3,
   FileQuestion,
   Loader2,
   Pencil,
@@ -25,7 +25,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input, Select, Textarea } from "@/components/ui/input";
-import { PageHeader } from "@/components/ui/page-header";
 import { createUnansweredEvaluation, gradeObjectiveAnswer, summarizeAttempt } from "@/lib/quizzes/attempts";
 import type { QuizDifficulty, QuizQuestion, QuizQuestionType } from "@/lib/quizzes/gemini";
 import type { QuizAttempt, QuizAttemptAnswer, QuizEvaluation, QuizMode, SavedQuiz } from "@/lib/quizzes/types";
@@ -121,6 +120,40 @@ function MarkdownText({ markdown, className }: { markdown: string; className?: s
       </ReactMarkdown>
     </div>
   );
+}
+
+function StepPill({ active, children }: { active?: boolean; children: ReactNode }) {
+  return (
+    <span
+      className={cx(
+        "inline-flex h-9 items-center rounded-full border px-3 text-sm font-medium",
+        active
+          ? "border-accent/20 bg-accent-soft text-accent"
+          : "border-border bg-transparent text-muted-foreground",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function StatPill({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex h-8 items-center rounded-full border border-border bg-transparent px-3 text-sm font-medium text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+function makeDraftQuestion(sourceNoteTitles: string[]): QuizQuestion {
+  return {
+    id: crypto.randomUUID(),
+    type: "free_response",
+    prompt: "",
+    correctAnswer: "",
+    explanation: "",
+    sourceNoteTitles,
+  };
 }
 
 function getSourceTitles(questions: QuizQuestion[], notes: QuizNoteOption[], selectedNoteIds: string[]) {
@@ -296,8 +329,34 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
     );
   }
 
+  function updateDraftQuestionType(index: number, type: QuizQuestionType) {
+    setDraftQuestions((current) =>
+      current.map((question, questionIndex) => {
+        if (questionIndex !== index) {
+          return question;
+        }
+
+        return {
+          ...question,
+          type,
+          choices:
+            type === "multiple_choice"
+              ? question.choices ?? ["", "", "", ""]
+              : type === "true_false"
+                ? ["True", "False"]
+                : undefined,
+        };
+      }),
+    );
+  }
+
   function removeDraftQuestion(index: number) {
     setDraftQuestions((current) => current.filter((_, questionIndex) => questionIndex !== index));
+  }
+
+  function addDraftQuestion() {
+    const selectedTitles = notes.filter((note) => selectedNoteIds.includes(note.id)).map((note) => note.title);
+    setDraftQuestions((current) => [...current, makeDraftQuestion(selectedTitles)]);
   }
 
   async function saveDraftQuiz() {
@@ -534,256 +593,251 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
   }
 
   function renderLibrary() {
-    return (
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_420px]">
-        <section className="space-y-4">
-          {quizzes.length === 0 ? (
-            <Card className="border-dashed">
-              <CardHeader>
-                <CardTitle>No saved quizzes yet</CardTitle>
-                <CardDescription>
-                  Create a quiz from notes, review generated questions, then save it here.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Button type="button" leadingIcon={<Plus className="size-4" />} onClick={openCreate}>
-                  Create quiz
-                </Button>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="grid gap-4 lg:grid-cols-2">
-              {quizzes.map((quiz) => {
-                const lastAttempt = attempts.find((attempt) => attempt.quizId === quiz.id);
-                return (
-                  <Card
-                    key={quiz.id}
-                    className={cx(
-                      "transition hover:border-border-strong hover:bg-surface-muted",
-                      activeQuiz?.id === quiz.id ? "border-accent" : "",
-                    )}
-                  >
-                    <CardHeader>
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant="accent">{quiz.mode}</Badge>
-                        <Badge variant="outline">{quiz.difficulty}</Badge>
-                        <Badge variant="outline">{quiz.questionCount} questions</Badge>
-                      </div>
-                      <CardTitle>{quiz.title}</CardTitle>
-                      <CardDescription>
-                        Updated {formatDate(quiz.updatedAt)}
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                      <div className="flex flex-wrap gap-2">
-                        {quiz.sourceNoteTitles.slice(0, 4).map((title) => (
-                          <Badge key={title} variant="neutral">
-                            {title}
-                          </Badge>
-                        ))}
-                      </div>
-                      {lastAttempt ? (
-                        <p className="text-sm text-muted-foreground">
-                          Last result {formatPercent(lastAttempt.score)} on {formatDate(lastAttempt.completedAt)}
-                        </p>
-                      ) : (
-                        <p className="text-sm text-muted-foreground">No completed attempts yet.</p>
-                      )}
-                      <div className="flex flex-wrap gap-2">
-                        <Button type="button" size="sm" onClick={() => startTaking(quiz)} leadingIcon={<Play className="size-4" />}>
-                          Take
-                        </Button>
-                        <Button type="button" size="sm" variant="outline" onClick={() => setActiveQuizId(quiz.id)}>
-                          Open
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                );
-              })}
-            </div>
-          )}
-        </section>
+    const totalQuestions = quizzes.reduce((sum, quiz) => sum + quiz.questionCount, 0);
 
-        <aside className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>{activeQuiz?.title ?? "Quiz detail"}</CardTitle>
-              <CardDescription>
-                {activeQuiz ? "Review metadata, questions, and previous results." : "Select a saved quiz."}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {activeQuiz ? (
-                <>
-                  <div className="grid grid-cols-2 gap-3 text-sm">
-                    <div className="rounded-lg border border-border bg-surface-muted p-3">
-                      <div className="text-xs text-muted-foreground">Questions</div>
-                      <div className="font-semibold text-foreground">{activeQuiz.questionCount}</div>
+    return (
+      <section className="space-y-8">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div className="flex flex-wrap gap-2">
+            <StatPill>{quizzes.length} quizzes</StatPill>
+            <StatPill>{totalQuestions} questions</StatPill>
+          </div>
+          <Button type="button" leadingIcon={<Plus className="size-4" />} onClick={openCreate}>
+            Create quiz
+          </Button>
+        </div>
+
+        {quizzes.length === 0 ? (
+          <div className="flex min-h-[28rem] items-center justify-center rounded-[var(--radius-xl)] border border-dashed border-border bg-surface/70 p-8">
+            <div className="flex max-w-sm flex-col items-center text-center">
+              <FileQuestion className="mb-5 size-12 text-muted-foreground" />
+              <h2 className="text-lg font-semibold text-foreground">No saved quizzes</h2>
+              <p className="mt-2 text-sm text-muted-foreground">Saved quizzes appear here.</p>
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {quizzes.map((quiz) => {
+              const quizAttempts = attempts.filter((attempt) => attempt.quizId === quiz.id);
+              const lastAttempt = quizAttempts[0];
+              const isDeleting = deleteQuizId === quiz.id;
+
+              return (
+                <Card
+                  key={quiz.id}
+                  className={cx(
+                    "transition hover:border-border-strong hover:bg-surface-muted",
+                    activeQuiz?.id === quiz.id ? "border-accent/70" : "",
+                  )}
+                >
+                  <CardHeader className="gap-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="accent">{quiz.mode}</Badge>
+                      <Badge variant="outline">{quiz.difficulty}</Badge>
+                      <Badge variant="outline">{quiz.questionCount} questions</Badge>
+                      {lastAttempt ? <Badge variant="neutral">{formatPercent(lastAttempt.score)} last score</Badge> : null}
                     </div>
-                    <div className="rounded-lg border border-border bg-surface-muted p-3">
-                      <div className="text-xs text-muted-foreground">Mode</div>
-                      <div className="font-semibold capitalize text-foreground">{activeQuiz.mode}</div>
+                    <div>
+                      <CardTitle>{quiz.title}</CardTitle>
+                      <CardDescription>Updated {formatDate(quiz.updatedAt)}</CardDescription>
                     </div>
-                  </div>
-                  <div className="space-y-2">
-                    <h2 className="text-sm font-medium text-foreground">Questions</h2>
-                    <div className="max-h-64 space-y-2 overflow-auto pr-1">
-                      {activeQuiz.questions.map((question, index) => (
-                        <div key={question.id} className="rounded-lg border border-border bg-surface-muted p-3 text-sm">
-                          <div className="mb-1 flex items-center gap-2">
-                            <Badge variant="outline">{index + 1}</Badge>
-                            <Badge variant="neutral">{question.type.replace("_", " ")}</Badge>
-                          </div>
-                          <MarkdownText markdown={question.prompt} className="line-clamp-3" />
-                        </div>
+                  </CardHeader>
+                  <CardContent className="space-y-5">
+                    <div className="flex flex-wrap gap-2">
+                      {quiz.sourceNoteTitles.slice(0, 5).map((title) => (
+                        <Badge key={title} variant="neutral">
+                          {title}
+                        </Badge>
                       ))}
                     </div>
-                  </div>
-                  <div className="space-y-2">
-                    <h2 className="text-sm font-medium text-foreground">Previous results</h2>
-                    {activeAttempts.length === 0 ? (
-                      <p className="rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm text-muted-foreground">
-                        Attempts will appear after quiz completion.
-                      </p>
-                    ) : (
-                      activeAttempts.slice(0, 4).map((attempt) => (
-                        <button
-                          key={attempt.id}
-                          type="button"
-                          className="flex w-full items-center justify-between rounded-lg border border-border px-3 py-2 text-left text-sm hover:bg-surface-muted"
-                          onClick={() => {
-                            setSelectedAttemptId(attempt.id);
-                            setLatestAttempt(attempt);
-                            setView("results");
-                          }}
-                        >
-                          <span>{formatDate(attempt.completedAt)}</span>
-                          <Badge variant="accent">{formatPercent(attempt.score)}</Badge>
-                        </button>
-                      ))
-                    )}
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Button type="button" size="sm" leadingIcon={<Play className="size-4" />} onClick={() => startTaking(activeQuiz)}>
-                      Take
-                    </Button>
-                    <Button type="button" size="sm" variant="outline" leadingIcon={<Pencil className="size-4" />} onClick={() => editQuiz(activeQuiz)}>
-                      Edit
-                    </Button>
-                    <Button type="button" size="sm" variant="outline" leadingIcon={<Copy className="size-4" />} disabled={isSaving} onClick={() => void duplicateQuiz(activeQuiz)}>
-                      Duplicate
-                    </Button>
-                    <Button type="button" size="sm" variant="destructive" leadingIcon={<Trash2 className="size-4" />} onClick={() => setDeleteQuizId(activeQuiz.id)}>
-                      Delete
-                    </Button>
-                  </div>
-                </>
-              ) : null}
-            </CardContent>
-          </Card>
 
-          {deleteQuizId ? (
-            <Card className="border-red-200 dark:border-red-950/70">
-              <CardHeader>
-                <CardTitle>Delete quiz?</CardTitle>
-                <CardDescription>This removes quiz and saved attempts.</CardDescription>
-              </CardHeader>
-              <CardContent className="flex flex-wrap gap-2">
-                <Button type="button" variant="destructive" disabled={isSaving} onClick={() => void deleteQuiz(deleteQuizId)}>
-                  Confirm delete
-                </Button>
-                <Button type="button" variant="outline" onClick={() => setDeleteQuizId(null)}>
-                  Cancel
-                </Button>
-              </CardContent>
-            </Card>
-          ) : null}
-        </aside>
-      </div>
+                    <div className="space-y-2">
+                      <h3 className="text-sm font-medium text-foreground">Questions</h3>
+                      <div className="grid gap-2">
+                        {quiz.questions.slice(0, 3).map((question, index) => (
+                          <button
+                            key={question.id}
+                            type="button"
+                            className="rounded-lg border border-border bg-surface px-3 py-2 text-left text-sm transition hover:bg-surface-muted"
+                            onClick={() => {
+                              setActiveQuizId(quiz.id);
+                              editQuiz(quiz);
+                            }}
+                          >
+                            <span className="mb-1 flex items-center gap-2">
+                              <Badge variant="outline">Question {index + 1}</Badge>
+                              <Badge variant="neutral">{question.type.replace("_", " ")}</Badge>
+                            </span>
+                            <MarkdownText markdown={question.prompt} className="line-clamp-2 text-sm" />
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    {quizAttempts.length > 0 ? (
+                      <div className="space-y-2">
+                        <h3 className="text-sm font-medium text-foreground">Previous results</h3>
+                        <div className="grid gap-2 sm:grid-cols-2">
+                          {quizAttempts.slice(0, 4).map((attempt) => (
+                            <button
+                              key={attempt.id}
+                              type="button"
+                              className="flex items-center justify-between gap-3 rounded-lg border border-border bg-surface px-3 py-2 text-left text-sm transition hover:bg-surface-muted"
+                              onClick={() => {
+                                setActiveQuizId(quiz.id);
+                                setSelectedAttemptId(attempt.id);
+                                setLatestAttempt(attempt);
+                                setView("results");
+                              }}
+                            >
+                              <span className="truncate text-muted-foreground">{formatDate(attempt.completedAt)}</span>
+                              <Badge variant="accent">{formatPercent(attempt.score)}</Badge>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm text-muted-foreground">
+                        Attempts appear after quiz completion.
+                      </p>
+                    )}
+
+                    {isDeleting ? (
+                      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-red-200 bg-danger-soft px-3 py-3 text-sm text-danger dark:border-red-950/70">
+                        <span>Delete quiz and saved attempts?</span>
+                        <span className="flex flex-wrap gap-2">
+                          <Button type="button" size="sm" variant="destructive" disabled={isSaving} onClick={() => void deleteQuiz(quiz.id)}>
+                            Confirm delete
+                          </Button>
+                          <Button type="button" size="sm" variant="outline" onClick={() => setDeleteQuizId(null)}>
+                            Cancel
+                          </Button>
+                        </span>
+                      </div>
+                    ) : (
+                      <div className="flex flex-wrap gap-2">
+                        <Button type="button" size="sm" leadingIcon={<Play className="size-4" />} onClick={() => startTaking(quiz)}>
+                          Take
+                        </Button>
+                        <Button type="button" size="sm" variant="outline" leadingIcon={<Pencil className="size-4" />} onClick={() => editQuiz(quiz)}>
+                          Edit
+                        </Button>
+                        <Button type="button" size="sm" variant="outline" leadingIcon={<Copy className="size-4" />} disabled={isSaving} onClick={() => void duplicateQuiz(quiz)}>
+                          Duplicate
+                        </Button>
+                        <Button type="button" size="sm" variant="destructive" leadingIcon={<Trash2 className="size-4" />} onClick={() => setDeleteQuizId(quiz.id)}>
+                          Delete
+                        </Button>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
     );
   }
 
   function renderCreate() {
     return (
-      <div className="grid gap-6 lg:grid-cols-[420px_minmax(0,1fr)]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Create quiz</CardTitle>
-            <CardDescription>Select note context before generation starts.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <section className="space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-sm font-medium text-foreground">Source notes</h2>
-                <Badge variant="outline">{selectedNoteIds.length} selected</Badge>
-              </div>
-              <div className="max-h-80 space-y-2 overflow-auto pr-1">
-                {notes.length === 0 ? (
-                  <p className="rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm text-muted-foreground">
-                    Create or upload notes first.
-                  </p>
-                ) : (
-                  notes.map((note) => (
-                    <label
-                      key={note.id}
-                      className={cx(
-                        "flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-surface px-3 py-3 text-sm transition",
-                        note.hasEmbedding ? "hover:border-border-strong hover:bg-surface-muted" : "cursor-not-allowed opacity-60",
-                      )}
-                    >
-                      <input
-                        type="checkbox"
-                        className="mt-1 size-4 accent-[var(--accent)]"
-                        checked={selectedNoteIds.includes(note.id)}
-                        disabled={!note.hasEmbedding || isGenerating}
-                        onChange={() => toggleNote(note.id)}
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate font-medium text-foreground">{note.title}</span>
-                        <span className="text-xs text-muted-foreground">
-                          {note.hasEmbedding ? `Embedding ready - updated ${formatDate(note.updatedAt)}` : "No embedding stored. Upload or regenerate notes before using this context."}
-                        </span>
-                      </span>
-                    </label>
-                  ))
-                )}
-              </div>
-            </section>
-            <div className="flex flex-wrap gap-2">
-              <Button type="button" disabled={!canGenerate} leadingIcon={isGenerating ? <Loader2 className="size-4 animate-spin" /> : <FileQuestion className="size-4" />} onClick={() => void generatePreview()}>
-                Generate preview
-              </Button>
-              <Button type="button" variant="outline" onClick={() => openLibrary()}>
-                Cancel
-              </Button>
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle className="text-xl">Create Quiz</CardTitle>
+            <CardDescription>Choose note context and quiz settings.</CardDescription>
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <StepPill active>Context</StepPill>
+            <StepPill>Preview</StepPill>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-8">
+          <section className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold text-foreground">Notes</h2>
+              <Badge variant="outline" className="text-sm">
+                {selectedNoteIds.length} selected
+              </Badge>
             </div>
-          </CardContent>
-        </Card>
+            <div className="grid gap-3 lg:grid-cols-2">
+              {notes.length === 0 ? (
+                <p className="rounded-lg border border-border bg-surface-muted px-3 py-3 text-sm text-muted-foreground">
+                  Create or upload notes first.
+                </p>
+              ) : (
+                notes.map((note) => (
+                  <label
+                    key={note.id}
+                    className={cx(
+                      "flex min-h-20 cursor-pointer items-start gap-4 rounded-lg border border-border bg-surface px-4 py-4 text-sm transition",
+                      note.hasEmbedding ? "hover:border-border-strong hover:bg-surface-muted" : "cursor-not-allowed opacity-60",
+                      selectedNoteIds.includes(note.id) ? "border-accent bg-accent-soft/60" : "",
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      className="mt-1 size-4 accent-[var(--accent)]"
+                      checked={selectedNoteIds.includes(note.id)}
+                      disabled={!note.hasEmbedding || isGenerating}
+                      onChange={() => toggleNote(note.id)}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-semibold text-foreground">{note.title}</span>
+                      <span className="mt-1 block text-sm text-muted-foreground">
+                        {note.hasEmbedding ? "Embedding ready" : "Embedding required"}
+                      </span>
+                    </span>
+                  </label>
+                ))
+              )}
+            </div>
+          </section>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Quiz settings</CardTitle>
-            <CardDescription>Mode, difficulty, question types, count, and time limit.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <section className="grid gap-3 md:grid-cols-2">
-              {modeOptions.map((option) => (
-                <button
-                  key={option.value}
-                  type="button"
-                  className={cx(
-                    "rounded-lg border px-4 py-3 text-left text-sm transition",
-                    mode === option.value ? "border-accent bg-accent-soft text-accent" : "border-border bg-surface hover:bg-surface-muted",
-                  )}
-                  onClick={() => setMode(option.value)}
-                >
-                  <span className="block font-semibold">{option.label}</span>
-                  <span className="mt-1 block text-muted-foreground">{option.description}</span>
-                </button>
-              ))}
-            </section>
-            <div className="grid gap-4 md:grid-cols-3">
+          <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
+            <div className="space-y-4">
+              <h2 className="text-sm font-semibold text-foreground">Question types</h2>
+              <div className="grid gap-3 md:grid-cols-3">
+                {questionTypeOptions.map((option) => (
+                  <label
+                    key={option.value}
+                    className={cx(
+                      "flex cursor-pointer items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 text-sm transition hover:bg-surface-muted",
+                      questionTypes.includes(option.value) ? "border-accent bg-accent-soft/60 text-accent" : "",
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      className="size-4 accent-[var(--accent)]"
+                      checked={questionTypes.includes(option.value)}
+                      onChange={() => toggleQuestionType(option.value)}
+                    />
+                    <span className="font-medium">{option.label}</span>
+                  </label>
+                ))}
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                {modeOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={cx(
+                      "rounded-lg border px-4 py-3 text-left text-sm transition",
+                      mode === option.value
+                        ? "border-accent bg-accent-soft text-accent"
+                        : "border-border bg-surface hover:bg-surface-muted",
+                    )}
+                    onClick={() => setMode(option.value)}
+                  >
+                    <span className="block font-semibold">{option.label}</span>
+                    <span className="mt-1 block text-muted-foreground">{option.description}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3 xl:grid-cols-1">
               <label className="space-y-2 text-sm font-medium text-foreground">
                 Difficulty
                 <Select value={difficulty} onChange={(event) => setDifficulty(event.target.value as QuizDifficulty)}>
@@ -803,134 +857,195 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
                 <Input min={1} max={240} type="number" disabled={mode !== "exam"} value={timeMinutes} onChange={(event) => setTimeMinutes(Number(event.target.value))} />
               </label>
             </div>
-            <section className="space-y-3">
-              <h2 className="text-sm font-medium text-foreground">Question types</h2>
-              <div className="grid gap-2 md:grid-cols-3">
-                {questionTypeOptions.map((option) => (
-                  <label key={option.value} className="flex items-center gap-3 rounded-lg border border-border bg-surface px-3 py-3 text-sm">
-                    <input
-                      type="checkbox"
-                      className="size-4 accent-[var(--accent)]"
-                      checked={questionTypes.includes(option.value)}
-                      onChange={() => toggleQuestionType(option.value)}
-                    />
-                    {option.label}
-                  </label>
-                ))}
-              </div>
-            </section>
-            <section className="space-y-3">
-              <h2 className="text-sm font-medium text-foreground">Selected context</h2>
-              {selectedNoteIds.length === 0 ? (
-                <p className="rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm text-muted-foreground">
-                  Select one or more embedding-ready notes.
-                </p>
-              ) : (
-                <div className="flex flex-wrap gap-2">
-                  {notes.filter((note) => selectedNoteIds.includes(note.id)).map((note) => (
-                    <Badge key={note.id} variant="accent">
-                      {note.title}
-                    </Badge>
-                  ))}
-                </div>
-              )}
-            </section>
-          </CardContent>
-        </Card>
-      </div>
+          </section>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              disabled={!canGenerate}
+              leadingIcon={isGenerating ? <Loader2 className="size-4 animate-spin" /> : <CheckCircle2 className="size-4" />}
+              onClick={() => void generatePreview()}
+            >
+              Generate preview
+            </Button>
+            <Button type="button" variant="outline" onClick={() => openLibrary()}>
+              Cancel
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     );
   }
 
   function renderPreview() {
     return (
-      <div className="grid gap-6 xl:grid-cols-[360px_minmax(0,1fr)]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Preview and edit</CardTitle>
-            <CardDescription>Generated questions are editable before saving or taking.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-5">
-            <label className="space-y-2 text-sm font-medium text-foreground">
-              Quiz title
-              <Input value={draftTitle} onChange={(event) => setDraftTitle(event.target.value)} />
-            </label>
-            <div className="grid grid-cols-2 gap-3 text-sm">
-              <div className="rounded-lg border border-border bg-surface-muted p-3">
-                <div className="text-xs text-muted-foreground">Mode</div>
-                <div className="font-semibold capitalize text-foreground">{mode}</div>
-              </div>
-              <div className="rounded-lg border border-border bg-surface-muted p-3">
-                <div className="text-xs text-muted-foreground">Questions</div>
-                <div className="font-semibold text-foreground">{draftQuestions.length}</div>
-              </div>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Button type="button" disabled={draftQuestions.length === 0 || !draftTitle.trim() || isSaving} leadingIcon={isSaving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />} onClick={() => void saveDraftQuiz()}>
-                Save quiz
-              </Button>
-              <Button type="button" variant="outline" onClick={() => setView(editingQuizId ? "library" : "create")}>
-                Back
-              </Button>
-              <Button type="button" variant="ghost" onClick={() => openLibrary(activeQuizId)}>
-                Cancel
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle className="text-xl">Preview Quiz</CardTitle>
+            <CardDescription>Edit before saving.</CardDescription>
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <StepPill>Context</StepPill>
+            <StepPill active>Preview</StepPill>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-7">
+          <label className="block space-y-2 text-sm font-medium text-foreground">
+            Quiz name
+            <Input value={draftTitle} onChange={(event) => setDraftTitle(event.target.value)} />
+          </label>
 
-        <section className="space-y-4">
-          {draftQuestions.map((question, index) => (
-            <Card key={question.id}>
-              <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <CardTitle>Question {index + 1}</CardTitle>
-                  <CardDescription>{question.type.replace("_", " ")}</CardDescription>
-                </div>
-                <Button type="button" size="sm" variant="destructive" leadingIcon={<Trash2 className="size-4" />} onClick={() => removeDraftQuestion(index)}>
-                  Remove
-                </Button>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <label className="space-y-2 text-sm font-medium text-foreground">
-                  Prompt
-                  <Textarea rows={3} value={question.prompt} onChange={(event) => updateDraftQuestion(index, { prompt: event.target.value })} />
-                </label>
-                {question.choices?.length ? (
-                  <div className="grid gap-3 md:grid-cols-2">
-                    {question.choices.map((choice, choiceIndex) => (
-                      <label key={`${question.id}-${choiceIndex}`} className="space-y-2 text-sm font-medium text-foreground">
-                        Choice {choiceIndex + 1}
-                        <Input value={choice} onChange={(event) => updateDraftChoice(index, choiceIndex, event.target.value)} />
+          <section className="grid gap-4 lg:grid-cols-4">
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              Mode
+              <Select value={mode} onChange={(event) => setMode(event.target.value as QuizMode)}>
+                {modeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </label>
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              Difficulty
+              <Select value={difficulty} onChange={(event) => setDifficulty(event.target.value as QuizDifficulty)}>
+                {difficultyOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </label>
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              Time limit
+              <Input min={1} max={240} type="number" disabled={mode !== "exam"} value={timeMinutes} onChange={(event) => setTimeMinutes(Number(event.target.value))} />
+            </label>
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              Question types
+              <Input
+                value={questionTypes.map((type) => type.replace("_", " ")).join(", ")}
+                readOnly
+                className="text-muted-foreground"
+              />
+            </label>
+          </section>
+
+          <section className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="text-base font-semibold text-foreground">Questions</h2>
+              <Button type="button" variant="outline" leadingIcon={<Plus className="size-4" />} onClick={addDraftQuestion}>
+                Add question
+              </Button>
+            </div>
+
+            {draftQuestions.length === 0 ? (
+              <div className="rounded-[var(--radius-xl)] border border-dashed border-border bg-surface-muted px-6 py-10 text-center">
+                <FileQuestion className="mx-auto mb-3 size-8 text-muted-foreground" />
+                <h3 className="font-semibold text-foreground">No questions in preview</h3>
+                <p className="mt-1 text-sm text-muted-foreground">Add a question or go back to generate from context.</p>
+              </div>
+            ) : (
+              <div className="space-y-5">
+                {draftQuestions.map((question, index) => (
+                  <div key={question.id} className="rounded-[var(--radius-xl)] border border-border bg-surface-muted/60 p-5">
+                    <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+                      <Badge variant="outline">Question {index + 1}</Badge>
+                      <Button type="button" size="sm" variant="ghost" leadingIcon={<Trash2 className="size-4" />} onClick={() => removeDraftQuestion(index)}>
+                        Remove
+                      </Button>
+                    </div>
+
+                    <div className="grid gap-4 lg:grid-cols-2">
+                      <label className="space-y-2 text-sm font-medium text-foreground">
+                        Prompt
+                        <Textarea rows={7} value={question.prompt} onChange={(event) => updateDraftQuestion(index, { prompt: event.target.value })} />
                       </label>
-                    ))}
+                      <label className="space-y-2 text-sm font-medium text-foreground">
+                        Correct answer
+                        <Textarea rows={7} value={question.correctAnswer} onChange={(event) => updateDraftQuestion(index, { correctAnswer: event.target.value })} />
+                      </label>
+                    </div>
+
+                    <div className="mt-4 grid gap-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+                      <label className="space-y-2 text-sm font-medium text-foreground">
+                        Type
+                        <Select
+                          value={question.type}
+                          onChange={(event) => updateDraftQuestionType(index, event.target.value as QuizQuestionType)}
+                        >
+                          {questionTypeOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </Select>
+                      </label>
+                      <label className="space-y-2 text-sm font-medium text-foreground">
+                        Source metadata
+                        <Input
+                          value={question.sourceNoteTitles.join(", ")}
+                          onChange={(event) =>
+                            updateDraftQuestion(index, {
+                              sourceNoteTitles: event.target.value
+                                .split(",")
+                                .map((item) => item.trim())
+                                .filter(Boolean),
+                            })
+                          }
+                        />
+                      </label>
+                    </div>
+
+                    {question.type === "multiple_choice" && question.choices?.length ? (
+                      <div className="mt-4 grid gap-3 md:grid-cols-2">
+                        {question.choices.map((choice, choiceIndex) => (
+                          <label key={`${question.id}-${choiceIndex}`} className="space-y-2 text-sm font-medium text-foreground">
+                            Choice {choiceIndex + 1}
+                            <Input value={choice} onChange={(event) => updateDraftChoice(index, choiceIndex, event.target.value)} />
+                          </label>
+                        ))}
+                      </div>
+                    ) : null}
+
+                    <label className="mt-4 block space-y-2 text-sm font-medium text-foreground">
+                      Explanation
+                      <Textarea rows={3} value={question.explanation} onChange={(event) => updateDraftQuestion(index, { explanation: event.target.value })} />
+                    </label>
+
+                    {question.sourceNoteTitles.length > 0 ? (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {question.sourceNoteTitles.map((title) => (
+                          <Badge key={title} variant="neutral">
+                            {title}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
-                ) : null}
-                <div className="grid gap-4 md:grid-cols-2">
-                  <label className="space-y-2 text-sm font-medium text-foreground">
-                    Correct answer
-                    <Input value={question.correctAnswer} onChange={(event) => updateDraftQuestion(index, { correctAnswer: event.target.value })} />
-                  </label>
-                  <label className="space-y-2 text-sm font-medium text-foreground">
-                    Source metadata
-                    <Input
-                      value={question.sourceNoteTitles.join(", ")}
-                      onChange={(event) =>
-                        updateDraftQuestion(index, {
-                          sourceNoteTitles: event.target.value.split(",").map((item) => item.trim()).filter(Boolean),
-                        })
-                      }
-                    />
-                  </label>
-                </div>
-                <label className="space-y-2 text-sm font-medium text-foreground">
-                  Explanation
-                  <Textarea rows={3} value={question.explanation} onChange={(event) => updateDraftQuestion(index, { explanation: event.target.value })} />
-                </label>
-              </CardContent>
-            </Card>
-          ))}
-        </section>
-      </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              disabled={draftQuestions.length === 0 || !draftTitle.trim() || isSaving}
+              leadingIcon={isSaving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+              onClick={() => void saveDraftQuiz()}
+            >
+              Save quiz
+            </Button>
+            <Button type="button" variant="outline" onClick={() => setView(editingQuizId ? "library" : "create")}>
+              Back
+            </Button>
+            <Button type="button" variant="ghost" onClick={() => openLibrary(activeQuizId)}>
+              Cancel
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     );
   }
 
@@ -1145,19 +1260,18 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
-      <PageHeader
-        eyebrow="Quizzing"
-        title="Quizzes"
-        description="Manage saved quizzes, generate from notes, edit before saving, take focused attempts, and review results."
-        actions={
-          view === "library" ? (
-            <Button type="button" leadingIcon={<Plus className="size-4" />} onClick={openCreate}>
-              Create quiz
-            </Button>
-          ) : null
-        }
-      />
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8">
+      <header className="space-y-4">
+        <div>
+          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.28em] text-muted-foreground">QUIZZES</p>
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground">
+            {view === "library" ? "My Quizzes" : "Quizzes"}
+          </h1>
+          <p className="mt-4 max-w-2xl text-base text-muted-foreground">
+            Focused quiz library, generation queue, and question editor.
+          </p>
+        </div>
+      </header>
 
       {error ? (
         <div className="rounded-lg border border-red-200 bg-danger-soft px-4 py-3 text-sm text-danger dark:border-red-950/70">
@@ -1170,12 +1284,7 @@ export function QuizzesClient({ notes, initialQuizzes, initialAttempts }: Quizze
           <Button type="button" variant="ghost" size="sm" onClick={() => openLibrary(activeQuizId)}>
             My Quizzes
           </Button>
-          {view === "take" && activeQuiz ? (
-            <Badge variant="outline">
-              <Edit3 className="size-3.5" />
-              Focus mode
-            </Badge>
-          ) : null}
+          {view === "take" && activeQuiz ? <Badge variant="outline">Focus mode</Badge> : null}
         </div>
       ) : null}
 

--- a/components/note-editor/code-block-view.tsx
+++ b/components/note-editor/code-block-view.tsx
@@ -8,6 +8,8 @@ type CodeBlockViewProps = {
 };
 
 export function CodeBlockView({ data }: CodeBlockViewProps) {
+  const highlighted = data.code.trim().length > 0 ? highlightCode(data.code) : null;
+
   return (
     <div className="note-code-block note-code-block--read">
       <pre className="note-code-block__surface">
@@ -15,8 +17,8 @@ export function CodeBlockView({ data }: CodeBlockViewProps) {
           className="hljs note-code-block__code"
           dangerouslySetInnerHTML={{
             __html:
-              data.code.trim().length > 0
-                ? highlightCode(data.code)
+              highlighted
+                ? highlighted.html
                 : "<span class=\"note-code-block__placeholder\">No code yet.</span>",
           }}
         />

--- a/components/note-editor/note-renderer.tsx
+++ b/components/note-editor/note-renderer.tsx
@@ -14,22 +14,65 @@ function omitNode<T extends { node?: unknown }>(props: T): Omit<T, "node"> {
   return rest;
 }
 
-function extractCode(children: ReactNode) {
-  if (!isValidElement<{ children?: ReactNode }>(children)) {
-    return "";
+function getTextContent(value: ReactNode): string {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
   }
 
-  const codeChildren = children.props.children;
-
-  if (typeof codeChildren === "string") {
-    return codeChildren.replace(/\n$/, "");
+  if (Array.isArray(value)) {
+    return value.map(getTextContent).join("");
   }
 
-  if (Array.isArray(codeChildren)) {
-    return codeChildren.join("").replace(/\n$/, "");
+  if (isValidElement<{ children?: ReactNode }>(value)) {
+    return getTextContent(value.props.children);
+  }
+
+  if (value && typeof value === "object") {
+    const candidate = value as {
+      children?: unknown;
+      props?: { children?: ReactNode };
+      value?: unknown;
+    };
+
+    if (candidate.props?.children) {
+      return getTextContent(candidate.props.children);
+    }
+
+    if (typeof candidate.value === "string" || typeof candidate.value === "number") {
+      return String(candidate.value);
+    }
+
+    if (candidate.children) {
+      return getNodeText(candidate.children);
+    }
   }
 
   return "";
+}
+
+function getNodeText(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(getNodeText).join("");
+  }
+
+  if (value && typeof value === "object") {
+    const candidate = value as { value?: unknown; children?: unknown };
+    if (typeof candidate.value === "string" || typeof candidate.value === "number") {
+      return String(candidate.value);
+    }
+
+    return getNodeText(candidate.children);
+  }
+
+  return "";
+}
+
+function extractCode(children: ReactNode) {
+  return getTextContent(children).replace(/\n$/, "");
 }
 
 export function NoteRenderer({ markdown }: { markdown: string }) {
@@ -63,8 +106,9 @@ export function NoteRenderer({ markdown }: { markdown: string }) {
             );
           },
           pre: (props) => {
-            const { children } = omitNode(props);
-            return <CodeBlockView data={{ code: extractCode(Children.only(children)) }} />;
+            const { children, node } = props;
+            const code = getNodeText(node) || extractCode(Children.only(children));
+            return <CodeBlockView data={{ code }} />;
           },
           code: (props) => {
             const { children, className, ...rest } = omitNode(props);

--- a/components/ui/theme-initializer.tsx
+++ b/components/ui/theme-initializer.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { applyTheme } from "@/components/ui/theme-toggle";
+import { THEME_STORAGE_KEY, type ThemePreference } from "@/lib/theme";
+
+function readStoredTheme(): ThemePreference {
+  const saved = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return saved === "light" || saved === "dark" || saved === "system"
+    ? saved
+    : "system";
+}
+
+export function ThemeInitializer() {
+  useEffect(() => {
+    applyTheme(readStoredTheme());
+  }, []);
+
+  return null;
+}

--- a/drizzle/0011_cynical_starbolt.sql
+++ b/drizzle/0011_cynical_starbolt.sql
@@ -1,0 +1,39 @@
+CREATE TABLE "quiz_attempts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"quiz_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"answers" jsonb NOT NULL,
+	"score" double precision NOT NULL,
+	"correct_count" integer NOT NULL,
+	"answered_count" integer NOT NULL,
+	"question_count" integer NOT NULL,
+	"completed_at" timestamp DEFAULT now() NOT NULL,
+	"time_spent_seconds" integer,
+	"mode" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quizzes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"title" text NOT NULL,
+	"source_note_ids" text[] DEFAULT ARRAY[]::text[] NOT NULL,
+	"source_note_titles" text[] DEFAULT ARRAY[]::text[] NOT NULL,
+	"questions" jsonb NOT NULL,
+	"question_count" integer NOT NULL,
+	"difficulty" text NOT NULL,
+	"mode" text NOT NULL,
+	"question_types" text[] DEFAULT ARRAY[]::text[] NOT NULL,
+	"time_limit_minutes" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "quiz_attempts" ADD CONSTRAINT "quiz_attempts_quiz_id_quizzes_id_fk" FOREIGN KEY ("quiz_id") REFERENCES "public"."quizzes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quiz_attempts" ADD CONSTRAINT "quiz_attempts_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "quiz_attempts_quiz_id_idx" ON "quiz_attempts" USING btree ("quiz_id");--> statement-breakpoint
+CREATE INDEX "quiz_attempts_user_id_idx" ON "quiz_attempts" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "quiz_attempts_created_at_idx" ON "quiz_attempts" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "quizzes_user_id_idx" ON "quizzes" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "quizzes_created_at_idx" ON "quizzes" USING btree ("created_at");

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1824 @@
+{
+  "id": "f3aeb9b8-b888-4419-81c2-1847e1ab4a5f",
+  "prevId": "4e40829a-dd3b-42db-af03-b7ef373e1dad",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flashcards": {
+      "name": "flashcards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_note_ids": {
+          "name": "source_note_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "cards": {
+          "name": "cards",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_count": {
+          "name": "card_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flashcards_user_id_idx": {
+          "name": "flashcards_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flashcards_created_at_idx": {
+          "name": "flashcards_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flashcards_user_id_user_id_fk": {
+          "name": "flashcards_user_id_user_id_fk",
+          "tableFrom": "flashcards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note": {
+      "name": "note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "note_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_userId_idx": {
+          "name": "note_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_class_id_idx": {
+          "name": "note_class_id_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_createdAt_idx": {
+          "name": "note_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_user_id_user_id_fk": {
+          "name": "note_user_id_user_id_fk",
+          "tableFrom": "note",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_class_id_parse_test_course_id_fk": {
+          "name": "note_class_id_parse_test_course_id_fk",
+          "tableFrom": "note",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_assignments": {
+      "name": "parse_test_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_text": {
+          "name": "date_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_text": {
+          "name": "time_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_percent": {
+          "name": "weight_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_assignments_course_id_idx": {
+          "name": "parse_test_assignments_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_assignments_due_at_idx": {
+          "name": "parse_test_assignments_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_assignments_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_assignments_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_assignments",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_concepts": {
+      "name": "parse_test_concepts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_concepts_course_id_idx": {
+          "name": "parse_test_concepts_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_concepts_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_concepts_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_concepts",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_contacts": {
+      "name": "parse_test_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_hours": {
+          "name": "office_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_contacts_course_id_idx": {
+          "name": "parse_test_contacts_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_contacts_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_contacts_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_contacts",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_course": {
+      "name": "parse_test_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_section": {
+          "name": "course_section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructor_name": {
+          "name": "instructor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_days": {
+          "name": "meeting_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_time": {
+          "name": "meeting_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_location": {
+          "name": "meeting_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_materials": {
+          "name": "required_materials",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "homework_tools": {
+          "name": "homework_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "catalog_description": {
+          "name": "catalog_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_summary": {
+          "name": "student_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_course_run_id_idx": {
+          "name": "parse_test_course_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_course_run_id_parse_test_runs_id_fk": {
+          "name": "parse_test_course_run_id_parse_test_runs_id_fk",
+          "tableFrom": "parse_test_course",
+          "tableTo": "parse_test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parse_test_course_run_id_unique": {
+          "name": "parse_test_course_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_events": {
+      "name": "parse_test_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_text": {
+          "name": "date_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_text": {
+          "name": "time_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_events_course_id_idx": {
+          "name": "parse_test_events_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_events_due_at_idx": {
+          "name": "parse_test_events_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_events_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_events_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_events",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_grading_items": {
+      "name": "parse_test_grading_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_percent": {
+          "name": "weight_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_grading_items_course_id_idx": {
+          "name": "parse_test_grading_items_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_grading_items_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_grading_items_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_grading_items",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_runs": {
+      "name": "parse_test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parse_status": {
+          "name": "parse_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "parse_model": {
+          "name": "parse_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gemini_file_uri": {
+          "name": "gemini_file_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_runs_user_id_idx": {
+          "name": "parse_test_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_runs_content_hash_idx": {
+          "name": "parse_test_runs_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_runs_status_idx": {
+          "name": "parse_test_runs_status_idx",
+          "columns": [
+            {
+              "expression": "parse_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_runs_user_id_user_id_fk": {
+          "name": "parse_test_runs_user_id_user_id_fk",
+          "tableFrom": "parse_test_runs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_attempts": {
+      "name": "quiz_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_count": {
+          "name": "answered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_spent_seconds": {
+          "name": "time_spent_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quiz_attempts_quiz_id_idx": {
+          "name": "quiz_attempts_quiz_id_idx",
+          "columns": [
+            {
+              "expression": "quiz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quiz_attempts_user_id_idx": {
+          "name": "quiz_attempts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quiz_attempts_created_at_idx": {
+          "name": "quiz_attempts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_attempts_quiz_id_quizzes_id_fk": {
+          "name": "quiz_attempts_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_user_id_user_id_fk": {
+          "name": "quiz_attempts_user_id_user_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quizzes": {
+      "name": "quizzes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_note_ids": {
+          "name": "source_note_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "source_note_titles": {
+          "name": "source_note_titles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_types": {
+          "name": "question_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quizzes_user_id_idx": {
+          "name": "quizzes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quizzes_created_at_idx": {
+          "name": "quizzes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quizzes_user_id_user_id_fk": {
+          "name": "quizzes_user_id_user_id_fk",
+          "tableFrom": "quizzes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.note_source": {
+      "name": "note_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "upload"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1779687807311,
       "tag": "0010_warm_squirrel_girl",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1779911691545,
+      "tag": "0011_cynical_starbolt",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -148,6 +148,74 @@ export const flashcards = pgTable(
   ],
 );
 
+export const quizzes = pgTable(
+  "quizzes",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    sourceNoteIds: text("source_note_ids")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+    sourceNoteTitles: text("source_note_titles")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+    questions: jsonb("questions").notNull(),
+    questionCount: integer("question_count").notNull(),
+    difficulty: text("difficulty").notNull(),
+    mode: text("mode").notNull(),
+    questionTypes: text("question_types")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+    timeLimitMinutes: integer("time_limit_minutes"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("quizzes_user_id_idx").on(table.userId),
+    index("quizzes_created_at_idx").on(table.createdAt),
+  ],
+);
+
+export const quizAttempts = pgTable(
+  "quiz_attempts",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    quizId: text("quiz_id")
+      .notNull()
+      .references(() => quizzes.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    answers: jsonb("answers").notNull(),
+    score: doublePrecision("score").notNull(),
+    correctCount: integer("correct_count").notNull(),
+    answeredCount: integer("answered_count").notNull(),
+    questionCount: integer("question_count").notNull(),
+    completedAt: timestamp("completed_at").defaultNow().notNull(),
+    timeSpentSeconds: integer("time_spent_seconds"),
+    mode: text("mode").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("quiz_attempts_quiz_id_idx").on(table.quizId),
+    index("quiz_attempts_user_id_idx").on(table.userId),
+    index("quiz_attempts_created_at_idx").on(table.createdAt),
+  ],
+);
+
 export const parseTestRun = pgTable(
   "parse_test_runs",
   {
@@ -346,6 +414,8 @@ export const userRelations = relations(user, ({ many }) => ({
   accounts: many(account),
   notes: many(note),
   flashcards: many(flashcards),
+  quizzes: many(quizzes),
+  quizAttempts: many(quizAttempts),
   parseTestRuns: many(parseTestRun),
 }));
 
@@ -378,6 +448,25 @@ export const flashcardsRelations = relations(flashcards, ({ one }) => ({
   user: one(user, {
     fields: [flashcards.userId],
     references: [user.id],
+  }),
+}));
+
+export const quizzesRelations = relations(quizzes, ({ one, many }) => ({
+  user: one(user, {
+    fields: [quizzes.userId],
+    references: [user.id],
+  }),
+  attempts: many(quizAttempts),
+}));
+
+export const quizAttemptsRelations = relations(quizAttempts, ({ one }) => ({
+  user: one(user, {
+    fields: [quizAttempts.userId],
+    references: [user.id],
+  }),
+  quiz: one(quizzes, {
+    fields: [quizAttempts.quizId],
+    references: [quizzes.id],
   }),
 }));
 

--- a/lib/quizzes/attempts.test.ts
+++ b/lib/quizzes/attempts.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { gradeObjectiveAnswer, summarizeAttempt } from "@/lib/quizzes/attempts";
+import type { QuizQuestion } from "@/lib/quizzes/gemini";
+
+const questions: QuizQuestion[] = [
+  {
+    id: "mc-1",
+    type: "multiple_choice",
+    prompt: "Which value is prime?",
+    choices: ["4", "6", "7", "9"],
+    correctAnswer: "7",
+    explanation: "7 is divisible only by 1 and itself.",
+    sourceNoteTitles: ["Number Theory"],
+  },
+  {
+    id: "tf-1",
+    type: "true_false",
+    prompt: "A derivative can describe instantaneous rate of change.",
+    choices: ["True", "False"],
+    correctAnswer: "True",
+    explanation: "That is the core interpretation of a derivative.",
+    sourceNoteTitles: ["Calculus"],
+  },
+  {
+    id: "fr-1",
+    type: "free_response",
+    prompt: "Define variance.",
+    correctAnswer: "Average squared distance from the mean.",
+    explanation: "Variance measures spread around the mean.",
+    sourceNoteTitles: ["Statistics"],
+  },
+];
+
+describe("quiz attempt grading helpers", () => {
+  it("grades multiple choice and true/false answers without calling AI", () => {
+    expect(gradeObjectiveAnswer(questions[0], "7")).toMatchObject({
+      correct: true,
+      score: 1,
+      idealAnswer: "7",
+    });
+    expect(gradeObjectiveAnswer(questions[1], "false")).toMatchObject({
+      correct: false,
+      score: 0,
+      idealAnswer: "True",
+    });
+  });
+
+  it("leaves free response grading to evaluator", () => {
+    expect(gradeObjectiveAnswer(questions[2], "spread around mean")).toBeNull();
+  });
+
+  it("summarizes completed, missed, and unanswered questions as results-review data", () => {
+    const summary = summarizeAttempt(questions, [
+      {
+        questionId: "mc-1",
+        answer: "7",
+      },
+      {
+        questionId: "tf-1",
+        answer: "False",
+      },
+    ]);
+
+    expect(summary).toMatchObject({
+      correctCount: 1,
+      answeredCount: 2,
+      questionCount: 3,
+      score: 1 / 3,
+    });
+    expect(summary.answers).toHaveLength(3);
+    expect(summary.answers[2]).toMatchObject({
+      questionId: "fr-1",
+      answer: "",
+      evaluation: {
+        correct: false,
+        score: 0,
+        idealAnswer: "Average squared distance from the mean.",
+      },
+    });
+  });
+});

--- a/lib/quizzes/attempts.ts
+++ b/lib/quizzes/attempts.ts
@@ -1,0 +1,69 @@
+import type { QuizQuestion } from "@/lib/quizzes/gemini";
+import type { QuizAttemptAnswer, QuizEvaluation } from "@/lib/quizzes/types";
+
+const unansweredEvaluation: QuizEvaluation = {
+  correct: false,
+  score: 0,
+  feedback: "No answer was submitted.",
+  idealAnswer: "",
+};
+
+function normalizeAnswer(value: string) {
+  return value.trim().toLocaleLowerCase();
+}
+
+export function gradeObjectiveAnswer(question: QuizQuestion, answer: string): QuizEvaluation | null {
+  if (question.type === "free_response") {
+    return null;
+  }
+
+  const correct = normalizeAnswer(answer) === normalizeAnswer(question.correctAnswer);
+  return {
+    correct,
+    score: correct ? 1 : 0,
+    feedback: correct ? "Correct." : "Incorrect.",
+    idealAnswer: question.correctAnswer,
+  };
+}
+
+export function createUnansweredEvaluation(question: QuizQuestion): QuizEvaluation {
+  return {
+    ...unansweredEvaluation,
+    idealAnswer: question.correctAnswer,
+  };
+}
+
+export function summarizeAttempt(questions: QuizQuestion[], answers: QuizAttemptAnswer[]) {
+  const byQuestionId = new Map(answers.map((answer) => [answer.questionId, answer]));
+  const normalizedAnswers = questions.map((question) => {
+    const answer = byQuestionId.get(question.id);
+    if (!answer?.answer.trim()) {
+      return {
+        questionId: question.id,
+        answer: "",
+        evaluation: createUnansweredEvaluation(question),
+      };
+    }
+
+    return {
+      ...answer,
+      evaluation: answer.evaluation ?? gradeObjectiveAnswer(question, answer.answer) ?? {
+        correct: false,
+        score: 0,
+        feedback: "Free response needs review.",
+        idealAnswer: question.correctAnswer,
+      },
+    };
+  });
+
+  const correctCount = normalizedAnswers.filter((answer) => answer.evaluation.correct).length;
+  const answeredCount = normalizedAnswers.filter((answer) => answer.answer.trim()).length;
+
+  return {
+    answers: normalizedAnswers,
+    score: questions.length === 0 ? 0 : correctCount / questions.length,
+    correctCount,
+    answeredCount,
+    questionCount: questions.length,
+  };
+}

--- a/lib/quizzes/records.ts
+++ b/lib/quizzes/records.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import {
+  quizDifficulties,
+  quizQuestionTypes,
+  type QuizDifficulty,
+  type QuizQuestion,
+  type QuizQuestionType,
+} from "@/lib/quizzes/gemini";
+import type { QuizAttempt, QuizAttemptAnswer, QuizMode, SavedQuiz } from "@/lib/quizzes/types";
+
+export const quizModes = ["practice", "exam"] as const;
+
+export const quizQuestionSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(quizQuestionTypes),
+  prompt: z.string().min(1),
+  choices: z.array(z.string().min(1)).optional(),
+  correctAnswer: z.string().min(1),
+  explanation: z.string().min(1),
+  sourceNoteTitles: z.array(z.string().min(1)).min(1),
+});
+
+export const quizAttemptAnswerSchema = z.object({
+  questionId: z.string().min(1),
+  answer: z.string(),
+  evaluation: z
+    .object({
+      correct: z.boolean(),
+      score: z.number().min(0).max(1),
+      feedback: z.string().min(1),
+      idealAnswer: z.string().min(1),
+    })
+    .optional(),
+});
+
+export const saveQuizSchema = z.object({
+  title: z.string().min(1).max(120),
+  sourceNoteIds: z.array(z.string().min(1)).min(1).max(12),
+  sourceNoteTitles: z.array(z.string().min(1)).min(1).max(24),
+  questions: z.array(quizQuestionSchema).min(1).max(50),
+  difficulty: z.enum(quizDifficulties),
+  mode: z.enum(quizModes),
+  questionTypes: z.array(z.enum(quizQuestionTypes)).min(1).max(3),
+  timeLimitMinutes: z.number().int().min(1).max(240).nullable(),
+});
+
+export const saveAttemptSchema = z.object({
+  answers: z.array(quizAttemptAnswerSchema),
+  score: z.number().min(0).max(1),
+  correctCount: z.number().int().min(0),
+  answeredCount: z.number().int().min(0),
+  questionCount: z.number().int().min(1),
+  timeSpentSeconds: z.number().int().min(0).nullable(),
+  mode: z.enum(quizModes),
+});
+
+function normalizeQuestions(value: unknown): QuizQuestion[] {
+  const parsed = z.array(quizQuestionSchema).safeParse(value);
+  return parsed.success ? parsed.data : [];
+}
+
+function normalizeQuestionTypes(value: string[]): QuizQuestionType[] {
+  return value.filter((item): item is QuizQuestionType =>
+    quizQuestionTypes.includes(item as QuizQuestionType),
+  );
+}
+
+function normalizeDifficulty(value: string): QuizDifficulty {
+  return quizDifficulties.includes(value as QuizDifficulty) ? (value as QuizDifficulty) : "medium";
+}
+
+function normalizeMode(value: string): QuizMode {
+  return quizModes.includes(value as QuizMode) ? (value as QuizMode) : "practice";
+}
+
+function normalizeAttemptAnswers(value: unknown): QuizAttemptAnswer[] {
+  const parsed = z.array(quizAttemptAnswerSchema).safeParse(value);
+  return parsed.success ? parsed.data : [];
+}
+
+export function rowToSavedQuiz(row: {
+  id: string;
+  title: string;
+  sourceNoteIds: string[];
+  sourceNoteTitles: string[];
+  questions: unknown;
+  questionCount: number;
+  difficulty: string;
+  mode: string;
+  questionTypes: string[];
+  timeLimitMinutes: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): SavedQuiz {
+  return {
+    id: row.id,
+    title: row.title,
+    sourceNoteIds: row.sourceNoteIds,
+    sourceNoteTitles: row.sourceNoteTitles,
+    questions: normalizeQuestions(row.questions),
+    questionCount: row.questionCount,
+    difficulty: normalizeDifficulty(row.difficulty),
+    mode: normalizeMode(row.mode),
+    questionTypes: normalizeQuestionTypes(row.questionTypes),
+    timeLimitMinutes: row.timeLimitMinutes,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export function rowToQuizAttempt(row: {
+  id: string;
+  quizId: string;
+  answers: unknown;
+  score: number;
+  correctCount: number;
+  answeredCount: number;
+  questionCount: number;
+  completedAt: Date;
+  timeSpentSeconds: number | null;
+  mode: string;
+  createdAt: Date;
+}): QuizAttempt {
+  return {
+    id: row.id,
+    quizId: row.quizId,
+    answers: normalizeAttemptAnswers(row.answers),
+    score: row.score,
+    correctCount: row.correctCount,
+    answeredCount: row.answeredCount,
+    questionCount: row.questionCount,
+    completedAt: row.completedAt.toISOString(),
+    timeSpentSeconds: row.timeSpentSeconds,
+    mode: normalizeMode(row.mode),
+    createdAt: row.createdAt.toISOString(),
+  };
+}

--- a/lib/quizzes/storage.ts
+++ b/lib/quizzes/storage.ts
@@ -1,0 +1,37 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+type StorageProbeRow = {
+  quizzes_exists: boolean;
+  quiz_attempts_exists: boolean;
+};
+
+function getRows(result: unknown): StorageProbeRow[] {
+  if (Array.isArray(result)) {
+    return result as StorageProbeRow[];
+  }
+
+  if (result && typeof result === "object" && Array.isArray((result as { rows?: unknown }).rows)) {
+    return (result as { rows: StorageProbeRow[] }).rows;
+  }
+
+  return [];
+}
+
+export async function hasQuizStorage() {
+  try {
+    const result = await db.execute(sql`
+      select
+        to_regclass('public.quizzes') is not null as "quizzes_exists",
+        to_regclass('public.quiz_attempts') is not null as "quiz_attempts_exists"
+    `);
+    const row = getRows(result)[0];
+
+    return Boolean(row?.quizzes_exists && row.quiz_attempts_exists);
+  } catch {
+    return false;
+  }
+}
+
+export const quizStorageUnavailableMessage =
+  "Quiz storage is not ready yet. Run the latest database migration before saving quizzes.";

--- a/lib/quizzes/types.ts
+++ b/lib/quizzes/types.ts
@@ -1,0 +1,45 @@
+import type { QuizDifficulty, QuizQuestion, QuizQuestionType } from "@/lib/quizzes/gemini";
+
+export type QuizMode = "practice" | "exam";
+
+export type SavedQuiz = {
+  id: string;
+  title: string;
+  sourceNoteIds: string[];
+  sourceNoteTitles: string[];
+  questions: QuizQuestion[];
+  questionCount: number;
+  difficulty: QuizDifficulty;
+  mode: QuizMode;
+  questionTypes: QuizQuestionType[];
+  timeLimitMinutes: number | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type QuizEvaluation = {
+  correct: boolean;
+  score: number;
+  feedback: string;
+  idealAnswer: string;
+};
+
+export type QuizAttemptAnswer = {
+  questionId: string;
+  answer: string;
+  evaluation?: QuizEvaluation;
+};
+
+export type QuizAttempt = {
+  id: string;
+  quizId: string;
+  answers: QuizAttemptAnswer[];
+  score: number;
+  correctCount: number;
+  answeredCount: number;
+  questionCount: number;
+  completedAt: string;
+  timeSpentSeconds: number | null;
+  mode: QuizMode;
+  createdAt: string;
+};


### PR DESCRIPTION
## Summary
- Adds persistent saved quizzes and quiz attempts with DB schema, migrations, and CRUD/attempt APIs.
- Splits quizzes into My Quizzes, Create Quiz, generated preview/edit, focused take, and results review flows.
- Preserves note-context generation, quiz settings, answer evaluation, exam timer state, practice checking, retakes, duplicate/delete/edit actions, and prior result review.
- Adds spec-style tests for objective grading, unanswered handling, and attempt summary behavior.

## Verification
- pnpm test
- pnpm lint
- pnpm build
- Playwright smoke: /quizzes redirects to login without session; no console warnings/errors observed.

Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
Closes #52