### PR TITLE
Simplify syllabus import flow

### DIFF
--- a/app/(app)/calendar/calendar-client.tsx
+++ b/app/(app)/calendar/calendar-client.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
-import { getButtonClassName } from "@/components/ui/button";
 import { cx } from "@/lib/utils";
 
 export type CalendarEvent = {
@@ -34,7 +32,6 @@ type CalendarDay = {
 type ClassColor = {
   chip: string;
   count: string;
-  row: string;
   stripe: string;
 };
 
@@ -43,37 +40,31 @@ const CLASS_COLOR_PALETTE: ClassColor[] = [
   {
     chip: "border-sky-200 bg-sky-50 text-sky-800 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-200",
     count: "bg-sky-50 text-sky-800 shadow-[inset_0_0_0_1px_rgb(186_230_253)] dark:bg-sky-950/40 dark:text-sky-200 dark:shadow-[inset_0_0_0_1px_rgb(12_74_110)]",
-    row: "border-sky-200 bg-sky-50/70 dark:border-sky-900/70 dark:bg-sky-950/30",
     stripe: "bg-sky-500",
   },
   {
     chip: "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900/70 dark:bg-emerald-950/40 dark:text-emerald-200",
     count: "bg-emerald-50 text-emerald-800 shadow-[inset_0_0_0_1px_rgb(167_243_208)] dark:bg-emerald-950/40 dark:text-emerald-200 dark:shadow-[inset_0_0_0_1px_rgb(6_78_59)]",
-    row: "border-emerald-200 bg-emerald-50/70 dark:border-emerald-900/70 dark:bg-emerald-950/30",
     stripe: "bg-emerald-500",
   },
   {
     chip: "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-200",
     count: "bg-amber-50 text-amber-900 shadow-[inset_0_0_0_1px_rgb(253_230_138)] dark:bg-amber-950/40 dark:text-amber-200 dark:shadow-[inset_0_0_0_1px_rgb(120_53_15)]",
-    row: "border-amber-200 bg-amber-50/70 dark:border-amber-900/70 dark:bg-amber-950/30",
     stripe: "bg-amber-500",
   },
   {
     chip: "border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-900/70 dark:bg-rose-950/40 dark:text-rose-200",
     count: "bg-rose-50 text-rose-800 shadow-[inset_0_0_0_1px_rgb(254_205_211)] dark:bg-rose-950/40 dark:text-rose-200 dark:shadow-[inset_0_0_0_1px_rgb(136_19_55)]",
-    row: "border-rose-200 bg-rose-50/70 dark:border-rose-900/70 dark:bg-rose-950/30",
     stripe: "bg-rose-500",
   },
   {
     chip: "border-violet-200 bg-violet-50 text-violet-800 dark:border-violet-900/70 dark:bg-violet-950/40 dark:text-violet-200",
     count: "bg-violet-50 text-violet-800 shadow-[inset_0_0_0_1px_rgb(221_214_254)] dark:bg-violet-950/40 dark:text-violet-200 dark:shadow-[inset_0_0_0_1px_rgb(76_29_149)]",
-    row: "border-violet-200 bg-violet-50/70 dark:border-violet-900/70 dark:bg-violet-950/30",
     stripe: "bg-violet-500",
   },
   {
     chip: "border-cyan-200 bg-cyan-50 text-cyan-800 dark:border-cyan-900/70 dark:bg-cyan-950/40 dark:text-cyan-200",
     count: "bg-cyan-50 text-cyan-800 shadow-[inset_0_0_0_1px_rgb(165_243_252)] dark:bg-cyan-950/40 dark:text-cyan-200 dark:shadow-[inset_0_0_0_1px_rgb(22_78_99)]",
-    row: "border-cyan-200 bg-cyan-50/70 dark:border-cyan-900/70 dark:bg-cyan-950/30",
     stripe: "bg-cyan-500",
   },
 ];
@@ -162,62 +153,9 @@ function buildCalendarDays(monthDate: Date, todayKey: string) {
   });
 }
 
-function getUpcomingEvents(events: CalendarEvent[], todayKey: string) {
-  return events
-    .filter((event) => {
-      const eventKey = getEventDateKey(event);
-      return !eventKey || eventKey >= todayKey;
-    })
-    .sort((first, second) => {
-      const firstKey = getEventDateKey(first) ?? "9999-12-31";
-      const secondKey = getEventDateKey(second) ?? "9999-12-31";
-      return firstKey.localeCompare(secondKey);
-    })
-    .slice(0, 8);
-}
-
 function isRecurringEvent(event: CalendarEvent) {
   return RECURRING_EVENT_PATTERN.test(
     [event.title, event.category, event.dateText].join(" "),
-  );
-}
-
-function getEventMeta(event: CalendarEvent) {
-  return [
-    formatEventDate(event),
-    event.timeText,
-    event.location,
-  ].filter(Boolean).join(" / ");
-}
-
-function EventRow({
-  event,
-  color,
-  onOpen,
-}: {
-  event: CalendarEvent;
-  color: ClassColor;
-  onOpen: (event: CalendarEvent) => void;
-}) {
-  return (
-    <article className={cx("rounded-[var(--radius-lg)] border px-4 py-3", color.row)}>
-      <div className="flex flex-wrap items-center gap-2">
-        <span className={cx("rounded-full border px-2 py-0.5 text-[0.7rem] font-semibold", color.chip)}>
-          {event.courseTitle}
-        </span>
-        <Badge variant="outline">{event.category}</Badge>
-      </div>
-      <button
-        type="button"
-        onClick={() => onOpen(event)}
-        className="mt-2 block w-full rounded-md text-left text-sm font-semibold leading-5 text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
-      >
-        {event.title}
-      </button>
-      <p className="mt-1 text-xs leading-5 text-muted-foreground">
-        {getEventMeta(event)}
-      </p>
-    </article>
   );
 }
 
@@ -350,13 +288,6 @@ export function CalendarClient({ events, initialDate }: CalendarClientProps) {
     }
     return grouped;
   }, [visibleEvents]);
-  const selectedDay = days.find((day) => day.key === selectedKey);
-  const selectedDate = selectedDay?.date ?? today;
-  const selectedEvents = eventsByDate.get(selectedKey) ?? [];
-  const upcomingEvents = useMemo(
-    () => getUpcomingEvents(visibleEvents, todayKey),
-    [todayKey, visibleEvents],
-  );
   const colorByCourseId = useMemo(() => {
     const courseIds = Array.from(new Set(events.map((event) => event.courseId))).sort();
     return new Map(
@@ -410,218 +341,148 @@ export function CalendarClient({ events, initialDate }: CalendarClientProps) {
   }, [activeEventId]);
 
   return (
-    <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_340px]">
-      <section className="overflow-x-auto rounded-[var(--radius-xl)] border border-border bg-surface shadow-[var(--shadow-card)]">
-        <div className="min-w-[720px]">
-          <div className="flex flex-col gap-4 border-b border-border px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                Month view
-              </p>
-              <h2 className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
-                {formatMonthLabel(visibleMonth)}
-              </h2>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-2">
-              <label className="inline-flex h-9 items-center gap-2 rounded-md border border-border bg-surface px-3 text-sm font-medium text-muted-foreground transition hover:border-border-strong hover:text-foreground">
-                <input
-                  type="checkbox"
-                  checked={showRecurring}
-                  onChange={(event) => setShowRecurring(event.currentTarget.checked)}
-                  className="h-3.5 w-3.5 accent-current"
-                />
-                Recurring
-                {recurringEventCount > 0 ? (
-                  <span className="text-xs text-muted-foreground">
-                    {recurringEventCount}
-                  </span>
-                ) : null}
-              </label>
-              <button
-                type="button"
-                onClick={() => moveVisibleMonth(-1)}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-muted-foreground transition hover:border-border-strong hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
-                aria-label="Previous month"
-              >
-                <Chevron direction="left" />
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const current = startOfMonth(new Date());
-                  setVisibleMonth(current);
-                  setSelectedKey(getLocalDateKey(new Date()));
-                }}
-                className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-surface-muted px-3 text-sm font-medium text-foreground transition hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
-              >
-                Today
-              </button>
-              <button
-                type="button"
-                onClick={() => moveVisibleMonth(1)}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-muted-foreground transition hover:border-border-strong hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
-                aria-label="Next month"
-              >
-                <Chevron direction="right" />
-              </button>
-            </div>
+    <div className="h-full min-h-0">
+      <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[var(--radius-xl)] border border-border bg-surface shadow-[var(--shadow-card)]">
+        <div className="shrink-0 flex flex-col gap-3 border-b border-border px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Month view
+            </p>
+            <h2 className="mt-0.5 text-xl font-semibold tracking-tight text-foreground">
+              {formatMonthLabel(visibleMonth)}
+            </h2>
           </div>
 
-          <div className="grid grid-cols-7 border-b border-border bg-surface-muted/55">
-            {WEEKDAYS.map((weekday) => (
-              <div
-                key={weekday}
-                className="px-2 py-3 text-center text-[0.7rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground"
-              >
-                {weekday}
-              </div>
-            ))}
-          </div>
-
-          <div className="grid grid-cols-7">
-            {days.map((day, index) => {
-              const dayEvents = eventsByDate.get(day.key) ?? [];
-              const selected = selectedKey === day.key;
-
-              return (
-                <div
-                  key={day.key}
-                  className={cx(
-                    "min-h-[7.4rem] border-b border-border p-2 transition",
-                    index % 7 !== 6 && "border-r",
-                    !day.isCurrentMonth && "bg-surface-muted/35 text-muted-foreground",
-                    selected && "bg-accent-soft",
-                  )}
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSelectedKey(day.key)}
-                    className="flex w-full items-center justify-between gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
-                    aria-pressed={selected}
-                    aria-label={`${formatLongDate(day.date)}, ${dayEvents.length} event${dayEvents.length === 1 ? "" : "s"}`}
-                  >
-                    <span
-                      className={cx(
-                        "inline-flex h-7 w-7 items-center justify-center rounded-md text-sm font-medium",
-                        day.isToday && "bg-foreground text-background",
-                        selected &&
-                          !day.isToday &&
-                          "bg-surface text-accent shadow-[inset_0_0_0_1px_var(--border)]",
-                      )}
-                    >
-                      {day.dayNumber}
-                    </span>
-                    {dayEvents.length > 0 ? (
-                      <span className={cx("rounded-full px-2 py-0.5 text-[0.68rem] font-semibold", getClassColor(dayEvents[0].courseId).count)}>
-                        {dayEvents.length}
-                      </span>
-                    ) : null}
-                  </button>
-
-                  <div className="mt-3 space-y-1">
-                    {dayEvents.slice(0, 2).map((event) => (
-                      <button
-                        key={event.id}
-                        type="button"
-                        onClick={() => openEvent(event)}
-                        className={cx(
-                          "block w-full truncate rounded-md border px-2 py-1 text-left text-[0.72rem] font-medium transition hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35",
-                          getClassColor(event.courseId).chip,
-                        )}
-                      >
-                        {event.title}
-                      </button>
-                    ))}
-                    {dayEvents.length > 2 ? (
-                      <div className="px-2 text-[0.7rem] font-medium text-muted-foreground">
-                        +{dayEvents.length - 2} more
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-4 text-sm text-muted-foreground">
-            <span>
-              {eventsThisMonth} event{eventsThisMonth === 1 ? "" : "s"} this month
-            </span>
-            <span>
-              {visibleEvents.length} visible of {events.length} parsed event{events.length === 1 ? "" : "s"}
-            </span>
+          <div className="flex flex-wrap items-center gap-2">
+            <label className="inline-flex h-9 items-center gap-2 rounded-md border border-border bg-surface px-3 text-sm font-medium text-muted-foreground transition hover:border-border-strong hover:text-foreground">
+              <input
+                type="checkbox"
+                checked={showRecurring}
+                onChange={(event) => setShowRecurring(event.currentTarget.checked)}
+                className="h-3.5 w-3.5 accent-current"
+              />
+              Recurring
+              {recurringEventCount > 0 ? (
+                <span className="text-xs text-muted-foreground">
+                  {recurringEventCount}
+                </span>
+              ) : null}
+            </label>
+            <button
+              type="button"
+              onClick={() => moveVisibleMonth(-1)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-muted-foreground transition hover:border-border-strong hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
+              aria-label="Previous month"
+            >
+              <Chevron direction="left" />
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const current = startOfMonth(new Date());
+                setVisibleMonth(current);
+                setSelectedKey(getLocalDateKey(new Date()));
+              }}
+              className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-surface-muted px-3 text-sm font-medium text-foreground transition hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
+            >
+              Today
+            </button>
+            <button
+              type="button"
+              onClick={() => moveVisibleMonth(1)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-muted-foreground transition hover:border-border-strong hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
+              aria-label="Next month"
+            >
+              <Chevron direction="right" />
+            </button>
           </div>
         </div>
-      </section>
 
-      <aside className="space-y-5">
-        <section className="rounded-[var(--radius-xl)] border border-border bg-surface p-5 shadow-[var(--shadow-card)]">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-            Selected day
-          </p>
-          <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground">
-            {formatLongDate(selectedDate)}
-          </h2>
-
-          <div className="mt-4 space-y-3">
-            {selectedEvents.length > 0 ? (
-              selectedEvents.map((event) => (
-                <EventRow
-                  key={event.id}
-                  event={event}
-                  color={getClassColor(event.courseId)}
-                  onOpen={openEvent}
-                />
-              ))
-            ) : (
-              <div className="rounded-[var(--radius-lg)] border border-dashed border-border bg-surface-muted px-4 py-6 text-sm leading-6 text-muted-foreground">
-                No parsed syllabus events are scheduled for this date.
-              </div>
-            )}
-          </div>
-        </section>
-
-        <section className="rounded-[var(--radius-xl)] border border-border bg-surface p-5 shadow-[var(--shadow-card)]">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                Upcoming
-              </p>
-              <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground">
-                Agenda
-              </h2>
+        <div className="shrink-0 grid grid-cols-7 border-b border-border bg-surface-muted/55">
+          {WEEKDAYS.map((weekday) => (
+            <div
+              key={weekday}
+              className="px-2 py-2 text-center text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground"
+            >
+              {weekday}
             </div>
-            {events.length === 0 ? (
-              <Link href="/parse-test" className={getButtonClassName("outline", "sm")}>
-                Upload
-              </Link>
-            ) : null}
-          </div>
+          ))}
+        </div>
 
-          <div className="mt-4 space-y-3">
-            {upcomingEvents.length > 0 ? (
-              upcomingEvents.map((event) => (
-                <EventRow
-                  key={event.id}
-                  event={event}
-                  color={getClassColor(event.courseId)}
-                  onOpen={openEvent}
-                />
-              ))
-            ) : (
-              <div className="rounded-[var(--radius-lg)] border border-dashed border-border bg-surface-muted px-4 py-6">
-                <p className="text-sm font-medium text-foreground">
-                  No upcoming parsed events yet.
-                </p>
-                <p className="mt-1 text-sm leading-6 text-muted-foreground">
-                  Upload a syllabus to populate this calendar with class dates.
-                </p>
+        <div className="grid min-h-0 flex-1 grid-cols-7 grid-rows-6">
+          {days.map((day, index) => {
+            const dayEvents = eventsByDate.get(day.key) ?? [];
+            const selected = selectedKey === day.key;
+
+            return (
+              <div
+                key={day.key}
+                className={cx(
+                  "min-h-0 overflow-hidden border-b border-border p-1.5 transition",
+                  index % 7 !== 6 && "border-r",
+                  !day.isCurrentMonth && "bg-surface-muted/35 text-muted-foreground",
+                  selected && "bg-accent-soft",
+                )}
+              >
+                <button
+                  type="button"
+                  onClick={() => setSelectedKey(day.key)}
+                  className="flex w-full items-center justify-between gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35"
+                  aria-pressed={selected}
+                  aria-label={`${formatLongDate(day.date)}, ${dayEvents.length} event${dayEvents.length === 1 ? "" : "s"}`}
+                >
+                  <span
+                    className={cx(
+                      "inline-flex h-6 w-6 items-center justify-center rounded-md text-xs font-medium",
+                      day.isToday && "bg-foreground text-background",
+                      selected &&
+                        !day.isToday &&
+                        "bg-surface text-accent shadow-[inset_0_0_0_1px_var(--border)]",
+                    )}
+                  >
+                    {day.dayNumber}
+                  </span>
+                  {dayEvents.length > 0 ? (
+                    <span className={cx("rounded-full px-2 py-0.5 text-[0.68rem] font-semibold", getClassColor(dayEvents[0].courseId).count)}>
+                      {dayEvents.length}
+                    </span>
+                  ) : null}
+                </button>
+
+                <div className="mt-1.5 space-y-1">
+                  {dayEvents.slice(0, 3).map((event) => (
+                    <button
+                      key={event.id}
+                      type="button"
+                      onClick={() => openEvent(event)}
+                      className={cx(
+                        "block w-full truncate rounded-md border px-1.5 py-0.5 text-left text-[0.65rem] font-medium transition hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35",
+                        getClassColor(event.courseId).chip,
+                      )}
+                    >
+                      {event.title}
+                    </button>
+                  ))}
+                  {dayEvents.length > 3 ? (
+                    <div className="px-1.5 text-[0.65rem] font-medium text-muted-foreground">
+                      +{dayEvents.length - 3} more
+                    </div>
+                  ) : null}
+                </div>
               </div>
-            )}
-          </div>
-        </section>
-      </aside>
+            );
+          })}
+        </div>
+
+        <div className="shrink-0 flex flex-wrap items-center justify-between gap-3 border-t border-border px-4 py-2 text-xs text-muted-foreground">
+          <span>
+            {eventsThisMonth} event{eventsThisMonth === 1 ? "" : "s"} this month
+          </span>
+          <span>
+            {visibleEvents.length} visible of {events.length} parsed event{events.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      </section>
       {activeEvent ? (
         <EventDialog
           event={activeEvent}

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -12,10 +12,8 @@ export default async function CalendarPage() {
   }));
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <CalendarClient events={calendarEvents} initialDate={initialDate} />
-      </div>
+    <div className="h-full overflow-hidden">
+      <CalendarClient events={calendarEvents} initialDate={initialDate} />
     </div>
   );
 }

--- a/app/(app)/classes/[runId]/delete-class-button.tsx
+++ b/app/(app)/classes/[runId]/delete-class-button.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+type DeleteClassButtonProps = {
+  runId: string;
+  classTitle: string;
+};
+
+export function DeleteClassButton({ runId, classTitle }: DeleteClassButtonProps) {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const isBusy = isDeleting || isPending;
+
+  async function deleteClass() {
+    setIsDeleting(true);
+
+    try {
+      const response = await fetch(`/api/parse-test?runId=${encodeURIComponent(runId)}`, {
+        method: "DELETE",
+      });
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+
+      if (!response.ok) {
+        throw new Error(payload?.error || "Could not delete this class.");
+      }
+
+      toast.success("Class deleted");
+      setIsOpen(false);
+      startTransition(() => {
+        router.replace("/classes");
+        router.refresh();
+      });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not delete this class.");
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="destructive"
+        onClick={() => setIsOpen(true)}
+        disabled={isBusy}
+        leadingIcon={<Trash2 className="h-4 w-4" aria-hidden />}
+      >
+        Delete class
+      </Button>
+
+      {isOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 px-4"
+          role="presentation"
+          onMouseDown={() => {
+            if (!isBusy) {
+              setIsOpen(false);
+            }
+          }}
+        >
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-class-title"
+            className="w-full max-w-md rounded-[var(--radius-xl)] border border-border bg-surface p-5 shadow-[var(--shadow-card)]"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-danger">
+                  Delete class
+                </p>
+                <h2 id="delete-class-title" className="mt-2 text-xl font-semibold tracking-tight text-foreground">
+                  Delete {classTitle}?
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                disabled={isBusy}
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-surface-muted text-muted-foreground transition hover:border-border-strong hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Close delete confirmation"
+              >
+                <X className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
+
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              This removes the class, syllabus details, assignments, and calendar events. Linked notes stay in your notes workspace.
+            </p>
+
+            <div className="mt-5 flex flex-wrap justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => setIsOpen(false)} disabled={isBusy}>
+                Cancel
+              </Button>
+              <Button type="button" variant="destructive" onClick={deleteClass} disabled={isBusy}>
+                {isDeleting ? "Deleting..." : "Delete class"}
+              </Button>
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/app/(app)/classes/[runId]/page.tsx
+++ b/app/(app)/classes/[runId]/page.tsx
@@ -9,6 +9,7 @@ import { requireServerSession } from "@/lib/auth-session";
 import { db } from "@/lib/db";
 import { note } from "@/lib/db/schema";
 import { getParseTestViewModelForRun } from "@/lib/parse-test/service";
+import { DeleteClassButton } from "./delete-class-button";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
@@ -123,6 +124,7 @@ export default async function ClassDetailPage(props: {
           <Link href={`/notes?classId=${preview.course.id}`} className={getButtonClassName("outline")}>
             Manage notes
           </Link>
+          <DeleteClassButton runId={runId} classTitle={preview.course.title} />
         </div>
       </div>
 

--- a/app/(app)/parse-test/page.tsx
+++ b/app/(app)/parse-test/page.tsx
@@ -1,15 +1,10 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
-import { Button, getButtonClassName } from "@/components/ui/button";
 import { requireServerSession } from "@/lib/auth-session";
 import { isParseTestEnabled } from "@/lib/parse-test/feature";
 import { getParseTestRunSummaries, getParseTestViewModelForRun } from "@/lib/parse-test/service";
 import { ParseTestClient } from "@/app/parse-test/parse-test-client";
-import { PreviewPane } from "@/app/parse-test/components/preview/preview-pane";
-import { EmptyPreviewState } from "@/app/parse-test/components/preview/empty-preview-state";
-import { TechnicalPanel } from "@/app/parse-test/components/technical-panel";
-import { getGradeDistributionStyle, getPreviewMetrics } from "@/app/parse-test/components/view-helpers";
+import { ReviewWizard } from "@/app/parse-test/components/review-wizard";
 
 export default async function ParseTestPage(props: {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
@@ -22,10 +17,8 @@ export default async function ParseTestPage(props: {
 
   const session = await requireServerSession("/parse-test");
   const searchParams = props.searchParams ? await props.searchParams : undefined;
-  const uploadStatusParam = Array.isArray(searchParams?.upload)
-    ? searchParams.upload[0]
-    : searchParams?.upload;
   const runParam = Array.isArray(searchParams?.run) ? searchParams.run[0] : searchParams?.run;
+  const reviewParam = Array.isArray(searchParams?.review) ? searchParams.review[0] : searchParams?.review;
   const runSummaries = await getParseTestRunSummaries(session.user.id);
   const selectedSummary =
     (runParam ? runSummaries.find((summary) => summary.runId === runParam) : null) ??
@@ -34,58 +27,17 @@ export default async function ParseTestPage(props: {
   const preview = selectedSummary
     ? await getParseTestViewModelForRun(session.user.id, selectedSummary.runId)
     : null;
-  const metrics = preview ? getPreviewMetrics(preview) : null;
-  const gradeDistributionStyle = preview ? getGradeDistributionStyle(preview.gradingItems) : null;
-  const currentIndex = selectedSummary
-    ? runSummaries.findIndex((summary) => summary.runId === selectedSummary.runId)
-    : -1;
-  const prevRunId = currentIndex > 0 ? runSummaries[currentIndex - 1]?.runId ?? null : null;
-  const nextRunId =
-    currentIndex >= 0 && currentIndex < runSummaries.length - 1
-      ? runSummaries[currentIndex + 1]?.runId ?? null
-      : null;
+  const showReview = reviewParam === "1" && Boolean(preview);
 
   return (
-    <div className="flex h-full flex-col gap-4">
-      <div className="shrink-0 flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold tracking-tight text-foreground">Upload syllabus</h1>
-        <div className="flex gap-2">
-          <Link href="/classes" className={getButtonClassName("outline")}>View classes</Link>
-          <Button type="button" disabled>AI pipeline live</Button>
+    <div className="h-full min-h-0 overflow-hidden">
+      {showReview && preview ? (
+        <div className="h-full overflow-y-auto p-3">
+          <ReviewWizard preview={preview} />
         </div>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="grid items-start gap-6 xl:grid-cols-[360px_minmax(0,1fr)]">
-        <ParseTestClient
-          hasPreview={Boolean(preview)}
-          courseTitle={preview?.course.title ?? null}
-          events={preview?.events ?? []}
-          savedAt={preview?.run.updatedAt ?? null}
-          totalSavedClasses={runSummaries.length}
-        />
-
-        {preview && metrics && gradeDistributionStyle ? (
-          <PreviewPane
-            preview={preview}
-            metrics={metrics}
-            gradeDistributionStyle={gradeDistributionStyle}
-            currentIndex={currentIndex}
-            totalCount={runSummaries.length}
-            prevRunId={prevRunId}
-            nextRunId={nextRunId}
-          />
-        ) : (
-          <EmptyPreviewState />
-        )}
-      </div>
-
-      <TechnicalPanel
-        preview={preview}
-        uploadStatusParam={uploadStatusParam}
-        displayName={session.user.name || session.user.email}
-      />
-      </div>
+      ) : (
+        <ParseTestClient />
+      )}
     </div>
   );
 }

--- a/app/api/parse-test/route.ts
+++ b/app/api/parse-test/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { MAX_PARSE_TEST_FILE_BYTES } from "@/lib/parse-test/contracts";
+import { MAX_PARSE_TEST_FILE_BYTES, parseTestReviewUpdateSchema } from "@/lib/parse-test/contracts";
 import { isParseTestEnabled } from "@/lib/parse-test/feature";
 import {
   deleteParseTestRun,
   getParseTestErrorResponse,
+  updateParseTestReview,
 } from "@/lib/parse-test/service";
 import { createParseTestUploadStream, jsonError } from "./streaming";
 
@@ -58,6 +59,39 @@ export async function POST(request: Request) {
         "Cache-Control": "no-cache, no-transform",
       },
     });
+  } catch (error) {
+    const { message, status, details } = getParseTestErrorResponse(error);
+    return jsonError(message, status, Array.isArray(details?.logs) ? (details.logs as string[]) : []);
+  }
+}
+
+export async function PATCH(request: Request) {
+  if (!isParseTestEnabled()) {
+    return jsonError("ParseTest is disabled.", 404);
+  }
+
+  try {
+    const session = await auth.api.getSession({
+      headers: request.headers,
+    });
+
+    if (!session) {
+      return jsonError("Sign in before updating a saved class.", 401);
+    }
+
+    const body = await request.json();
+    const parsed = parseTestReviewUpdateSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return jsonError("Review values could not be saved. Check required fields and try again.", 400);
+    }
+
+    const viewModel = await updateParseTestReview({
+      userId: session.user.id,
+      payload: parsed.data,
+    });
+
+    return NextResponse.json({ ok: true, viewModel });
   } catch (error) {
     const { message, status, details } = getParseTestErrorResponse(error);
     return jsonError(message, status, Array.isArray(details?.logs) ? (details.logs as string[]) : []);

--- a/app/parse-test/components/review-wizard.tsx
+++ b/app/parse-test/components/review-wizard.tsx
@@ -1,0 +1,496 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button, getButtonClassName } from "@/components/ui/button";
+import type { ParseTestViewModel } from "@/lib/parse-test/contracts";
+import { cx } from "@/lib/utils";
+
+type ReviewWizardProps = {
+  preview: ParseTestViewModel;
+};
+
+type ContactDraft = {
+  role: string;
+  name: string;
+  email: string;
+  officeHours: string;
+  location: string;
+  sourceSnippet: string;
+};
+
+type GradingDraft = {
+  label: string;
+  weightPercent: string;
+  sourceSnippet: string;
+};
+
+type AssignmentDraft = {
+  title: string;
+  category: string;
+  dateText: string;
+  dueAt: string;
+  timeText: string;
+  weightPercent: string;
+  sourceSnippet: string;
+};
+
+type EventDraft = {
+  title: string;
+  category: string;
+  dateText: string;
+  dueAt: string;
+  timeText: string;
+  location: string;
+  sourceSnippet: string;
+};
+
+type ReviewDraft = {
+  course: {
+    title: string;
+    courseCode: string;
+    courseSection: string;
+    term: string;
+    instructorName: string;
+    meetingDays: string;
+    meetingTime: string;
+    meetingLocation: string;
+    catalogDescription: string;
+    studentSummary: string;
+    descriptionSource: ParseTestViewModel["course"]["descriptionSource"];
+  };
+  materialsText: string;
+  toolsText: string;
+  conceptsText: string;
+  contacts: ContactDraft[];
+  gradingItems: GradingDraft[];
+  assignments: AssignmentDraft[];
+  events: EventDraft[];
+};
+
+const REVIEW_STEPS = ["Course", "Resources", "People", "Grading", "Schedule"] as const;
+const MANUAL_SOURCE = "Added during manual syllabus review.";
+
+function nullableText(value: string) {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function splitLines(value: string) {
+  return value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function toDateInput(value: string | null) {
+  return value ? value.slice(0, 10) : "";
+}
+
+function toPercent(value: string) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function createDraft(preview: ParseTestViewModel): ReviewDraft {
+  return {
+    course: {
+      title: preview.course.title,
+      courseCode: preview.course.courseCode ?? "",
+      courseSection: preview.course.courseSection ?? "",
+      term: preview.course.term ?? "",
+      instructorName: preview.course.instructorName ?? "",
+      meetingDays: preview.course.meetingDays ?? "",
+      meetingTime: preview.course.meetingTime ?? "",
+      meetingLocation: preview.course.meetingLocation ?? "",
+      catalogDescription: preview.course.catalogDescription ?? "",
+      studentSummary: preview.course.studentSummary,
+      descriptionSource: preview.course.descriptionSource,
+    },
+    materialsText: preview.course.requiredMaterials.join("\n"),
+    toolsText: preview.course.homeworkTools.join("\n"),
+    conceptsText: preview.concepts.map((concept) => concept.label).join("\n"),
+    contacts: preview.contacts.map((contact) => ({
+      role: contact.role,
+      name: contact.name,
+      email: contact.email ?? "",
+      officeHours: contact.officeHours ?? "",
+      location: contact.location ?? "",
+      sourceSnippet: contact.sourceSnippet || MANUAL_SOURCE,
+    })),
+    gradingItems: preview.gradingItems.map((item) => ({
+      label: item.label,
+      weightPercent: String(item.weightPercent),
+      sourceSnippet: item.sourceSnippet || MANUAL_SOURCE,
+    })),
+    assignments: preview.assignments.map((assignment) => ({
+      title: assignment.title,
+      category: assignment.category,
+      dateText: assignment.dateText,
+      dueAt: toDateInput(assignment.dueAt),
+      timeText: assignment.timeText ?? "",
+      weightPercent: assignment.weightPercent == null ? "" : String(assignment.weightPercent),
+      sourceSnippet: assignment.sourceSnippet || MANUAL_SOURCE,
+    })),
+    events: preview.events.map((event) => ({
+      title: event.title,
+      category: event.category,
+      dateText: event.dateText,
+      dueAt: toDateInput(event.dueAt),
+      timeText: event.timeText ?? "",
+      location: event.location ?? "",
+      sourceSnippet: event.sourceSnippet || MANUAL_SOURCE,
+    })),
+  };
+}
+
+function TextField({
+  label,
+  value,
+  onChange,
+  type = "text",
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: "text" | "number" | "date" | "email";
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </span>
+      <input
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        className="mt-1 h-10 w-full rounded-lg border border-border bg-surface px-3 text-sm text-foreground outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+      />
+    </label>
+  );
+}
+
+function TextArea({
+  label,
+  value,
+  onChange,
+  rows = 4,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  rows?: number;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </span>
+      <textarea
+        value={value}
+        rows={rows}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        className="mt-1 w-full resize-y rounded-lg border border-border bg-surface px-3 py-2 text-sm leading-6 text-foreground outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+      />
+    </label>
+  );
+}
+
+function removeAt<T>(items: T[], index: number) {
+  return items.filter((_, itemIndex) => itemIndex !== index);
+}
+
+function updateAt<T>(items: T[], index: number, next: Partial<T>) {
+  return items.map((item, itemIndex) => (itemIndex === index ? { ...item, ...next } : item));
+}
+
+export function ReviewWizard({ preview }: ReviewWizardProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [step, setStep] = useState(0);
+  const [draft, setDraft] = useState(() => createDraft(preview));
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const currentStep = REVIEW_STEPS[step];
+  const isLastStep = step === REVIEW_STEPS.length - 1;
+  const scheduleCount = draft.assignments.length + draft.events.length;
+  const summary = useMemo(
+    () => [
+      `${draft.contacts.length} contact${draft.contacts.length === 1 ? "" : "s"}`,
+      `${draft.gradingItems.length} grading item${draft.gradingItems.length === 1 ? "" : "s"}`,
+      `${scheduleCount} calendar item${scheduleCount === 1 ? "" : "s"}`,
+    ].join(" / "),
+    [draft.contacts.length, draft.gradingItems.length, scheduleCount],
+  );
+
+  function updateCourse(next: Partial<ReviewDraft["course"]>) {
+    setDraft((current) => ({ ...current, course: { ...current.course, ...next } }));
+  }
+
+  async function saveReview() {
+    setError(null);
+    setIsSaving(true);
+
+    const payload = {
+      runId: preview.run.id,
+      course: {
+        title: draft.course.title,
+        courseCode: nullableText(draft.course.courseCode),
+        courseSection: nullableText(draft.course.courseSection),
+        term: nullableText(draft.course.term),
+        instructorName: nullableText(draft.course.instructorName),
+        meetingDays: nullableText(draft.course.meetingDays),
+        meetingTime: nullableText(draft.course.meetingTime),
+        meetingLocation: nullableText(draft.course.meetingLocation),
+        requiredMaterials: splitLines(draft.materialsText),
+        homeworkTools: splitLines(draft.toolsText),
+        catalogDescription: nullableText(draft.course.catalogDescription),
+        studentSummary: draft.course.studentSummary.trim() || "Course details reviewed from the uploaded syllabus.",
+        descriptionSource: draft.course.descriptionSource,
+      },
+      concepts: splitLines(draft.conceptsText).map((label) => ({ label })),
+      contacts: draft.contacts
+        .filter((contact) => contact.name.trim())
+        .map((contact) => ({
+          role: contact.role.trim() || "Contact",
+          name: contact.name.trim(),
+          email: nullableText(contact.email),
+          officeHours: nullableText(contact.officeHours),
+          location: nullableText(contact.location),
+          sourceSnippet: contact.sourceSnippet.trim() || MANUAL_SOURCE,
+        })),
+      gradingItems: draft.gradingItems
+        .filter((item) => item.label.trim())
+        .map((item) => ({
+          label: item.label.trim(),
+          weightPercent: toPercent(item.weightPercent) ?? 0,
+          sourceSnippet: item.sourceSnippet.trim() || MANUAL_SOURCE,
+        })),
+      assignments: draft.assignments
+        .filter((assignment) => assignment.title.trim())
+        .map((assignment) => ({
+          title: assignment.title.trim(),
+          category: assignment.category.trim() || "Assignment",
+          dateText: assignment.dateText.trim() || assignment.dueAt || "Date pending",
+          dueAt: nullableText(assignment.dueAt),
+          timeText: nullableText(assignment.timeText),
+          weightPercent: assignment.weightPercent.trim() ? toPercent(assignment.weightPercent) : null,
+          sourceSnippet: assignment.sourceSnippet.trim() || MANUAL_SOURCE,
+        })),
+      events: draft.events
+        .filter((event) => event.title.trim())
+        .map((event) => ({
+          title: event.title.trim(),
+          category: event.category.trim() || "Event",
+          dateText: event.dateText.trim() || event.dueAt || "Date pending",
+          dueAt: nullableText(event.dueAt),
+          timeText: nullableText(event.timeText),
+          location: nullableText(event.location),
+          sourceSnippet: event.sourceSnippet.trim() || MANUAL_SOURCE,
+        })),
+    };
+
+    try {
+      const response = await fetch("/api/parse-test", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { error?: string } | null;
+        setError(body?.error ?? "Review values could not be saved.");
+        return;
+      }
+
+      startTransition(() => {
+        router.push(`/classes/${encodeURIComponent(preview.run.id)}`);
+        router.refresh();
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <section className="min-h-0 rounded-[var(--radius-xl)] border border-border bg-surface shadow-[var(--shadow-card)]">
+      <div className="border-b border-border px-5 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Review parsed values
+            </p>
+            <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground">
+              {draft.course.title || "Untitled course"}
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">{summary}</p>
+          </div>
+          <Link href={`/classes/${preview.run.id}`} className={getButtonClassName("outline", "sm")}>
+            Quick add
+          </Link>
+        </div>
+
+        <div className="mt-4 grid grid-cols-5 gap-2">
+          {REVIEW_STEPS.map((label, index) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => setStep(index)}
+              className={cx(
+                "h-2 rounded-full transition",
+                index <= step ? "bg-accent" : "bg-surface-elevated",
+              )}
+              aria-label={`Go to ${label} review step`}
+              aria-current={index === step ? "step" : undefined}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="max-h-[calc(100vh-15rem)] overflow-y-auto p-5">
+        {currentStep === "Course" ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            <TextField label="Class name" value={draft.course.title} onChange={(title) => updateCourse({ title })} />
+            <TextField label="Course number" value={draft.course.courseCode} onChange={(courseCode) => updateCourse({ courseCode })} />
+            <TextField label="Section" value={draft.course.courseSection} onChange={(courseSection) => updateCourse({ courseSection })} />
+            <TextField label="Term" value={draft.course.term} onChange={(term) => updateCourse({ term })} />
+            <TextField label="Instructor" value={draft.course.instructorName} onChange={(instructorName) => updateCourse({ instructorName })} />
+            <TextField label="Meeting days" value={draft.course.meetingDays} onChange={(meetingDays) => updateCourse({ meetingDays })} />
+            <TextField label="Meeting time" value={draft.course.meetingTime} onChange={(meetingTime) => updateCourse({ meetingTime })} />
+            <TextField label="Location" value={draft.course.meetingLocation} onChange={(meetingLocation) => updateCourse({ meetingLocation })} />
+            <div className="md:col-span-2">
+              <TextArea label="Student summary" value={draft.course.studentSummary} onChange={(studentSummary) => updateCourse({ studentSummary })} />
+            </div>
+            <div className="md:col-span-2">
+              <TextArea label="Catalog description" value={draft.course.catalogDescription} onChange={(catalogDescription) => updateCourse({ catalogDescription })} />
+            </div>
+          </div>
+        ) : null}
+
+        {currentStep === "Resources" ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            <TextArea label="Required materials" value={draft.materialsText} onChange={(value) => setDraft((current) => ({ ...current, materialsText: value }))} rows={8} />
+            <TextArea label="Homework tools" value={draft.toolsText} onChange={(value) => setDraft((current) => ({ ...current, toolsText: value }))} rows={8} />
+            <div className="md:col-span-2">
+              <TextArea label="Key concepts" value={draft.conceptsText} onChange={(value) => setDraft((current) => ({ ...current, conceptsText: value }))} rows={6} />
+            </div>
+          </div>
+        ) : null}
+
+        {currentStep === "People" ? (
+          <div className="space-y-3">
+            {draft.contacts.map((contact, index) => (
+              <div key={index} className="rounded-[var(--radius-lg)] border border-border bg-surface-muted p-4">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <TextField label="Role" value={contact.role} onChange={(role) => setDraft((current) => ({ ...current, contacts: updateAt(current.contacts, index, { role }) }))} />
+                  <TextField label="Name" value={contact.name} onChange={(name) => setDraft((current) => ({ ...current, contacts: updateAt(current.contacts, index, { name }) }))} />
+                  <TextField label="Email" type="email" value={contact.email} onChange={(email) => setDraft((current) => ({ ...current, contacts: updateAt(current.contacts, index, { email }) }))} />
+                  <TextField label="Location" value={contact.location} onChange={(location) => setDraft((current) => ({ ...current, contacts: updateAt(current.contacts, index, { location }) }))} />
+                  <div className="md:col-span-2">
+                    <TextField label="Office hours" value={contact.officeHours} onChange={(officeHours) => setDraft((current) => ({ ...current, contacts: updateAt(current.contacts, index, { officeHours }) }))} />
+                  </div>
+                </div>
+                <button type="button" className={cx(getButtonClassName("ghost", "sm"), "mt-3")} onClick={() => setDraft((current) => ({ ...current, contacts: removeAt(current.contacts, index) }))}>
+                  Remove contact
+                </button>
+              </div>
+            ))}
+            <Button type="button" variant="outline" onClick={() => setDraft((current) => ({ ...current, contacts: current.contacts.concat({ role: "Instructor", name: "", email: "", officeHours: "", location: "", sourceSnippet: MANUAL_SOURCE }) }))}>
+              Add contact
+            </Button>
+          </div>
+        ) : null}
+
+        {currentStep === "Grading" ? (
+          <div className="space-y-3">
+            {draft.gradingItems.map((item, index) => (
+              <div key={index} className="grid gap-3 rounded-[var(--radius-lg)] border border-border bg-surface-muted p-4 md:grid-cols-[minmax(0,1fr)_8rem_auto]">
+                <TextField label="Category" value={item.label} onChange={(label) => setDraft((current) => ({ ...current, gradingItems: updateAt(current.gradingItems, index, { label }) }))} />
+                <TextField label="Percent" type="number" value={item.weightPercent} onChange={(weightPercent) => setDraft((current) => ({ ...current, gradingItems: updateAt(current.gradingItems, index, { weightPercent }) }))} />
+                <button type="button" className={cx(getButtonClassName("ghost", "sm"), "self-end")} onClick={() => setDraft((current) => ({ ...current, gradingItems: removeAt(current.gradingItems, index) }))}>
+                  Remove
+                </button>
+              </div>
+            ))}
+            <Button type="button" variant="outline" onClick={() => setDraft((current) => ({ ...current, gradingItems: current.gradingItems.concat({ label: "", weightPercent: "0", sourceSnippet: MANUAL_SOURCE }) }))}>
+              Add grading item
+            </Button>
+          </div>
+        ) : null}
+
+        {currentStep === "Schedule" ? (
+          <div className="space-y-5">
+            <div>
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <h3 className="text-sm font-semibold text-foreground">Assignments</h3>
+                <Button type="button" variant="outline" size="sm" onClick={() => setDraft((current) => ({ ...current, assignments: current.assignments.concat({ title: "", category: "Assignment", dateText: "", dueAt: "", timeText: "", weightPercent: "", sourceSnippet: MANUAL_SOURCE }) }))}>
+                  Add assignment
+                </Button>
+              </div>
+              <div className="space-y-3">
+                {draft.assignments.map((assignment, index) => (
+                  <div key={index} className="grid gap-3 rounded-[var(--radius-lg)] border border-border bg-surface-muted p-4 md:grid-cols-2">
+                    <TextField label="Title" value={assignment.title} onChange={(title) => setDraft((current) => ({ ...current, assignments: updateAt(current.assignments, index, { title }) }))} />
+                    <TextField label="Category" value={assignment.category} onChange={(category) => setDraft((current) => ({ ...current, assignments: updateAt(current.assignments, index, { category }) }))} />
+                    <TextField label="Date text" value={assignment.dateText} onChange={(dateText) => setDraft((current) => ({ ...current, assignments: updateAt(current.assignments, index, { dateText }) }))} />
+                    <TextField label="Date" type="date" value={assignment.dueAt} onChange={(dueAt) => setDraft((current) => ({ ...current, assignments: updateAt(current.assignments, index, { dueAt }) }))} />
+                    <TextField label="Time" value={assignment.timeText} onChange={(timeText) => setDraft((current) => ({ ...current, assignments: updateAt(current.assignments, index, { timeText }) }))} />
+                    <TextField label="Weight" type="number" value={assignment.weightPercent} onChange={(weightPercent) => setDraft((current) => ({ ...current, assignments: updateAt(current.assignments, index, { weightPercent }) }))} />
+                    <button type="button" className={cx(getButtonClassName("ghost", "sm"), "md:col-span-2 justify-self-start")} onClick={() => setDraft((current) => ({ ...current, assignments: removeAt(current.assignments, index) }))}>
+                      Remove assignment
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <h3 className="text-sm font-semibold text-foreground">Calendar events</h3>
+                <Button type="button" variant="outline" size="sm" onClick={() => setDraft((current) => ({ ...current, events: current.events.concat({ title: "", category: "Event", dateText: "", dueAt: "", timeText: "", location: "", sourceSnippet: MANUAL_SOURCE }) }))}>
+                  Add event
+                </Button>
+              </div>
+              <div className="space-y-3">
+                {draft.events.map((event, index) => (
+                  <div key={index} className="grid gap-3 rounded-[var(--radius-lg)] border border-border bg-surface-muted p-4 md:grid-cols-2">
+                    <TextField label="Title" value={event.title} onChange={(title) => setDraft((current) => ({ ...current, events: updateAt(current.events, index, { title }) }))} />
+                    <TextField label="Category" value={event.category} onChange={(category) => setDraft((current) => ({ ...current, events: updateAt(current.events, index, { category }) }))} />
+                    <TextField label="Date text" value={event.dateText} onChange={(dateText) => setDraft((current) => ({ ...current, events: updateAt(current.events, index, { dateText }) }))} />
+                    <TextField label="Date" type="date" value={event.dueAt} onChange={(dueAt) => setDraft((current) => ({ ...current, events: updateAt(current.events, index, { dueAt }) }))} />
+                    <TextField label="Time" value={event.timeText} onChange={(timeText) => setDraft((current) => ({ ...current, events: updateAt(current.events, index, { timeText }) }))} />
+                    <TextField label="Location" value={event.location} onChange={(location) => setDraft((current) => ({ ...current, events: updateAt(current.events, index, { location }) }))} />
+                    <button type="button" className={cx(getButtonClassName("ghost", "sm"), "md:col-span-2 justify-self-start")} onClick={() => setDraft((current) => ({ ...current, events: removeAt(current.events, index) }))}>
+                      Remove event
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border px-5 py-4">
+        <div className="text-sm text-muted-foreground" aria-live="polite">
+          {error ?? `Step ${step + 1} of ${REVIEW_STEPS.length}: ${currentStep}`}
+        </div>
+        <div className="flex gap-2">
+          <Button type="button" variant="outline" disabled={step === 0 || isPending || isSaving} onClick={() => setStep((current) => Math.max(0, current - 1))}>
+            Back
+          </Button>
+          {isLastStep ? (
+            <Button type="button" disabled={isPending || isSaving} onClick={saveReview}>
+              {isPending || isSaving ? "Saving..." : "Add class"}
+            </Button>
+          ) : (
+            <Button type="button" disabled={isPending || isSaving} onClick={() => setStep((current) => Math.min(REVIEW_STEPS.length - 1, current + 1))}>
+              Next
+            </Button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/parse-test/components/upload-panel.tsx
+++ b/app/parse-test/components/upload-panel.tsx
@@ -1,64 +1,38 @@
 import type { ChangeEvent } from "react";
-import { ActivityLog } from "./activity-log";
+import { Upload } from "lucide-react";
+import { getButtonClassName } from "@/components/ui/button";
+import { cx } from "@/lib/utils";
 
 type UploadPanelProps = {
-  hasPreview: boolean;
-  totalSavedClasses: number;
   selectedFileName: string | null;
   isBusy: boolean;
-  message: string | null;
-  error: string | null;
-  activityLogs: string[];
+  statusText: string | null;
+  progress: number;
   onFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (formData: FormData) => Promise<void>;
 };
 
 export function UploadPanel({
-  hasPreview,
-  totalSavedClasses,
   selectedFileName,
   isBusy,
-  message,
-  error,
-  activityLogs,
+  statusText,
+  progress,
   onFileChange,
   onSubmit,
 }: UploadPanelProps) {
   return (
-    <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-950 lg:min-h-[420px]">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-zinc-500 dark:text-zinc-400">
-          ParseTest
-        </p>
-        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
-          Upload one syllabus and refresh your saved preview
-        </h2>
-        <p className="mt-3 text-sm leading-7 text-zinc-600 dark:text-zinc-400">
-          Upload a syllabus PDF, run Gemini, save the extracted data to SQL, and refresh the class
-          page preview from your saved record.
-        </p>
-        <p className="mt-3 text-xs font-medium uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-400">
-          {totalSavedClasses} saved class{totalSavedClasses === 1 ? "" : "es"}
-        </p>
-      </div>
-
-      <form action={onSubmit} className="mt-6 space-y-4">
-        <label className="block cursor-pointer rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 p-5 transition hover:border-zinc-400 hover:bg-zinc-100/70 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600 dark:hover:bg-zinc-900/80">
-          <div className="space-y-3">
-            <div className="inline-flex rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-zinc-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-400">
-              Syllabus PDF
-            </div>
-            <div className="text-lg font-semibold text-zinc-950 dark:text-zinc-50">
-              Choose a syllabus from your device
-            </div>
-            <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-              ParseTest accepts one PDF up to 20 MB and keeps each saved syllabus graph tied to
-              your account.
-            </p>
-            <div className="inline-flex rounded-full bg-zinc-950 px-4 py-2 text-sm font-medium text-white dark:bg-zinc-100 dark:text-zinc-950">
-              Browse files
-            </div>
-          </div>
+    <section className="w-full max-w-md rounded-[var(--radius-xl)] border border-border bg-surface p-5 shadow-[var(--shadow-card)]">
+      <form action={onSubmit} className="space-y-4">
+        <label className="flex min-h-44 cursor-pointer flex-col items-center justify-center rounded-[var(--radius-xl)] border border-dashed border-border bg-surface-muted px-5 py-8 text-center transition hover:border-border-strong">
+          <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-foreground text-background">
+            <Upload className="h-5 w-5" aria-hidden />
+          </span>
+          <span className="mt-4 text-base font-semibold text-foreground">
+            Upload syllabus
+          </span>
+          <span className="mt-1 max-w-72 text-sm leading-6 text-muted-foreground">
+            Choose a PDF to create your class.
+          </span>
           <input
             className="sr-only"
             type="file"
@@ -68,43 +42,32 @@ export function UploadPanel({
           />
         </label>
 
-        <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-400">
-            Selected file
+        {selectedFileName ? (
+          <div className="truncate rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm font-medium text-foreground">
+            {selectedFileName}
           </div>
-          <div className="mt-2 break-words text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            {selectedFileName || "No syllabus chosen yet"}
-          </div>
-          <p className="mt-2 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-            {hasPreview
-              ? "Uploading a different syllabus creates another saved class. Uploading the same PDF reuses the existing one."
-              : "The first successful upload will create your ParseTest preview in SQL."}
-          </p>
-        </div>
+        ) : null}
 
-        <div
-          aria-live="polite"
-          className="rounded-2xl border border-zinc-200 bg-white p-4 text-sm dark:border-zinc-800 dark:bg-zinc-950"
-        >
-          {error ? (
-            <div className="text-rose-600 dark:text-rose-400">{error}</div>
-          ) : message ? (
-            <div className="text-zinc-700 dark:text-zinc-300">{message}</div>
-          ) : (
-            <div className="text-zinc-500 dark:text-zinc-400">
-              Idle. Select a syllabus PDF to generate or refresh your saved preview.
+        {isBusy ? (
+          <div className="space-y-2" aria-live="polite">
+            <div className="h-2 overflow-hidden rounded-full bg-surface-elevated">
+              <div
+                className="h-full rounded-full bg-accent transition-all duration-500"
+                style={{ width: `${Math.max(8, Math.min(progress, 100))}%` }}
+              />
             </div>
-          )}
-
-          <ActivityLog logs={activityLogs} isBusy={isBusy} />
-        </div>
+            <p className="text-sm text-muted-foreground">
+              {statusText ?? "Processing syllabus..."}
+            </p>
+          </div>
+        ) : null}
 
         <button
           type="submit"
           disabled={isBusy}
-          className="inline-flex items-center justify-center rounded-full bg-zinc-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-zinc-300"
+          className={cx(getButtonClassName("primary"), "w-full")}
         >
-          {isBusy ? "Parsing and saving..." : "Parse and save preview"}
+          {isBusy ? "Uploading..." : "Upload syllabus"}
         </button>
       </form>
     </section>

--- a/app/parse-test/parse-test-client.tsx
+++ b/app/parse-test/parse-test-client.tsx
@@ -2,17 +2,9 @@
 
 import { useState, useTransition, type ChangeEvent } from "react";
 import { useRouter } from "next/navigation";
-import type { ParseTestViewModel } from "@/lib/parse-test/contracts";
-import { EventFeed } from "./components/event-feed";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { UploadPanel } from "./components/upload-panel";
-
-type ParseTestClientProps = {
-  hasPreview: boolean;
-  courseTitle: string | null;
-  events: ParseTestViewModel["events"];
-  savedAt: string | null;
-  totalSavedClasses: number;
-};
 
 type ParseStreamEvent =
   | { type: "start" }
@@ -20,74 +12,33 @@ type ParseStreamEvent =
   | { type: "result"; ok: true; isDuplicate?: boolean; runId?: string }
   | { type: "error"; error: string; status?: number };
 
-function formatDisplayDate(dueAt: string | null, dateText: string) {
-  if (!dueAt) {
-    return dateText;
-  }
+type ParsedUpload = {
+  isDuplicate: boolean;
+  runId: string;
+};
 
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(dueAt));
-}
-
-function formatSavedAt(value: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  return new Intl.DateTimeFormat("en-US", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(value));
-}
-
-function slugifyFilePart(value: string | null) {
-  const base = (value || "parse-test-events")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  return base || "parse-test-events";
-}
-
-export function ParseTestClient({
-  hasPreview,
-  courseTitle,
-  events,
-  savedAt,
-  totalSavedClasses,
-}: ParseTestClientProps) {
+export function ParseTestClient() {
   const router = useRouter();
   const [isNavigating, startTransition] = useTransition();
   const [isUploading, setIsUploading] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
-  const [message, setMessage] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [exportMessage, setExportMessage] = useState<string | null>(null);
-  const [activityLogs, setActivityLogs] = useState<string[]>([]);
+  const [statusText, setStatusText] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [parsedUpload, setParsedUpload] = useState<ParsedUpload | null>(null);
 
   async function handleSubmit(formData: FormData) {
-    setError(null);
-    setExportMessage(null);
-    setActivityLogs([]);
+    setParsedUpload(null);
 
     const file = formData.get("file");
     if (!(file instanceof File) || file.size === 0) {
-      setMessage(null);
-      setError("Choose a syllabus PDF before starting the parse.");
+      setStatusText(null);
+      toast.error("Choose a syllabus PDF before starting the parse.");
       return;
     }
 
     setIsUploading(true);
-    setMessage("Parsing the syllabus and saving your preview to SQL.");
-    setActivityLogs([
-      `Selected file: ${file.name}`,
-      "Submitting the upload to the ParseTest API.",
-      "Waiting for local validation, duplicate detection, Gemini, and SQL persistence.",
-    ]);
+    setProgress(12);
+    setStatusText("Uploading syllabus...");
 
     try {
       const response = await fetch("/api/parse-test", {
@@ -99,7 +50,7 @@ export function ParseTestClient({
         const payload = (await response.json().catch(() => null)) as
           | { error?: string; logs?: string[] }
           | null;
-        setActivityLogs(payload?.logs ?? []);
+        setStatusText(payload?.logs?.at(-1) ?? null);
         throw new Error(payload?.error || "ParseTest could not parse the uploaded syllabus.");
       }
 
@@ -133,7 +84,8 @@ export function ParseTestClient({
           const event = JSON.parse(trimmed) as ParseStreamEvent;
 
           if (event.type === "log") {
-            setActivityLogs((current) => current.concat(event.message));
+            setStatusText(event.message);
+            setProgress((current) => Math.min(92, current + 13));
             continue;
           }
 
@@ -150,7 +102,8 @@ export function ParseTestClient({
       if (buffer.trim()) {
         const event = JSON.parse(buffer.trim()) as ParseStreamEvent;
         if (event.type === "log") {
-          setActivityLogs((current) => current.concat(event.message));
+          setStatusText(event.message);
+          setProgress((current) => Math.min(92, current + 13));
         } else if (event.type === "error") {
           streamError = event.error;
         } else if (event.type === "result") {
@@ -166,24 +119,20 @@ export function ParseTestClient({
         throw new Error("ParseTest finished without a final result.");
       }
 
-      const uploadStatus = finalResult.isDuplicate ? "duplicate" : "parsed";
-      setMessage(
-        finalResult.isDuplicate
-          ? "This syllabus matches your current saved record. Reloading the SQL preview."
-          : "Syllabus parsed and saved to SQL. Reloading the preview from the database now.",
-      );
-      setActivityLogs((current) => current.concat("Refreshing the page with the saved SQL-backed preview."));
+      if (!finalResult.runId) {
+        throw new Error("ParseTest finished without a saved class id.");
+      }
 
-      startTransition(() => {
-        const nextUrl = finalResult.runId
-          ? `/parse-test?run=${encodeURIComponent(finalResult.runId)}&upload=${uploadStatus}`
-          : `/parse-test?upload=${uploadStatus}`;
-        router.replace(nextUrl);
-        router.refresh();
+      setProgress(100);
+      setStatusText("Syllabus parsed.");
+      setParsedUpload({
+        isDuplicate: Boolean(finalResult.isDuplicate),
+        runId: finalResult.runId,
       });
     } catch (submissionError) {
-      setMessage(null);
-      setError(
+      setProgress(0);
+      setStatusText(null);
+      toast.error(
         submissionError instanceof Error
           ? submissionError.message
           : "ParseTest hit an unexpected upload error.",
@@ -196,67 +145,78 @@ export function ParseTestClient({
   function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.currentTarget.files?.[0] ?? null;
     setSelectedFileName(file?.name ?? null);
-    setMessage(null);
-    setError(null);
-    setActivityLogs([]);
+    setStatusText(null);
+    setProgress(0);
+    setParsedUpload(null);
   }
 
-  function handleExport() {
-    if (events.length === 0) {
-      setExportMessage("No saved events are available to export yet.");
+  function openReview() {
+    if (!parsedUpload) {
       return;
     }
 
-    const payload = {
-      course: courseTitle,
-      exportedAt: new Date().toISOString(),
-      events: events.map((event) => ({
-        title: event.title,
-        category: event.category,
-        isoDate: event.dueAt,
-        dateText: event.dateText,
-        timeText: event.timeText,
-        location: event.location,
-        sourceSnippet: event.sourceSnippet,
-      })),
-    };
-
-    const blob = new Blob([JSON.stringify(payload, null, 2)], {
-      type: "application/json;charset=utf-8",
+    startTransition(() => {
+      router.push(`/parse-test?run=${encodeURIComponent(parsedUpload.runId)}&review=1`);
+      router.refresh();
     });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `${slugifyFilePart(courseTitle)}-events.json`;
-    anchor.click();
-    URL.revokeObjectURL(url);
+  }
 
-    setExportMessage("UTF-8 JSON export downloaded from the saved SQL event feed.");
+  function importClass() {
+    if (!parsedUpload) {
+      return;
+    }
+
+    startTransition(() => {
+      router.push(`/classes/${encodeURIComponent(parsedUpload.runId)}`);
+      router.refresh();
+    });
   }
 
   const isBusy = isUploading || isNavigating;
 
   return (
-    <div className="space-y-6">
+    <div className="flex min-h-full items-center justify-center px-4 py-10">
       <UploadPanel
-        hasPreview={hasPreview}
-        totalSavedClasses={totalSavedClasses}
         selectedFileName={selectedFileName}
         isBusy={isBusy}
-        message={message}
-        error={error}
-        activityLogs={activityLogs}
+        statusText={statusText}
+        progress={progress}
         onFileChange={handleFileChange}
         onSubmit={handleSubmit}
       />
-      <EventFeed
-        events={events}
-        savedAt={savedAt}
-        exportMessage={exportMessage}
-        onExport={handleExport}
-        formatDisplayDate={formatDisplayDate}
-        formatSavedAt={formatSavedAt}
-      />
+
+      {parsedUpload ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 px-4"
+          role="presentation"
+        >
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="syllabus-import-title"
+            className="w-full max-w-md rounded-[var(--radius-xl)] border border-border bg-surface p-5 shadow-[var(--shadow-card)]"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              {parsedUpload.isDuplicate ? "Syllabus already imported" : "Syllabus ready"}
+            </p>
+            <h2 id="syllabus-import-title" className="mt-2 text-xl font-semibold tracking-tight text-foreground">
+              Import this class?
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              You can review and edit the parsed class details first, or import it now and make
+              changes later from the class page.
+            </p>
+            <div className="mt-5 grid gap-2 sm:grid-cols-2">
+              <Button type="button" variant="outline" disabled={isNavigating} onClick={openReview}>
+                Review / edit
+              </Button>
+              <Button type="button" disabled={isNavigating} onClick={importClass}>
+                Import now
+              </Button>
+            </div>
+          </section>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/lib/parse-test/contracts.ts
+++ b/lib/parse-test/contracts.ts
@@ -73,11 +73,68 @@ export const parseTestPayloadSchema = z.object({
     .transform((warnings) => warnings.filter((warning): warning is string => Boolean(warning?.trim()))),
 });
 
+const reviewCourseSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  courseCode: z.string().trim().max(100).nullable(),
+  courseSection: z.string().trim().max(100).nullable(),
+  term: z.string().trim().max(120).nullable(),
+  instructorName: z.string().trim().max(160).nullable(),
+  meetingDays: z.string().trim().max(160).nullable(),
+  meetingTime: z.string().trim().max(160).nullable(),
+  meetingLocation: z.string().trim().max(200).nullable(),
+  requiredMaterials: z.array(z.string().trim().min(1).max(300)).max(30),
+  homeworkTools: z.array(z.string().trim().min(1).max(200)).max(20),
+  catalogDescription: z.string().trim().max(4000).nullable(),
+  studentSummary: z.string().trim().min(1).max(1000),
+  descriptionSource: z.enum(descriptionSourceValues),
+});
+
+const reviewConceptSchema = z.object({
+  label: z.string().trim().min(1).max(100),
+});
+
+const reviewGradingItemSchema = z.object({
+  label: z.string().trim().min(1).max(100),
+  weightPercent: z.number().min(0).max(100),
+  sourceSnippet: z.string().trim().min(1).max(500),
+});
+
+const reviewAssignmentSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  category: z.string().trim().min(1).max(100),
+  dateText: z.string().trim().min(1).max(200),
+  dueAt: z.string().trim().max(64).nullable(),
+  timeText: z.string().trim().max(100).nullable(),
+  weightPercent: z.number().min(0).max(100).nullable(),
+  sourceSnippet: z.string().trim().min(1).max(500),
+});
+
+const reviewEventSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  category: z.string().trim().min(1).max(100),
+  dateText: z.string().trim().min(1).max(200),
+  dueAt: z.string().trim().max(64).nullable(),
+  timeText: z.string().trim().max(100).nullable(),
+  location: z.string().trim().max(200).nullable(),
+  sourceSnippet: z.string().trim().min(1).max(500),
+});
+
+export const parseTestReviewUpdateSchema = z.object({
+  runId: z.string().trim().min(1),
+  course: reviewCourseSchema,
+  concepts: z.array(reviewConceptSchema).max(20),
+  contacts: z.array(contactSchema).max(20),
+  gradingItems: z.array(reviewGradingItemSchema).max(20),
+  assignments: z.array(reviewAssignmentSchema).max(100),
+  events: z.array(reviewEventSchema).max(200),
+});
+
 export type ParseTestPayload = z.infer<typeof parseTestPayloadSchema>;
 export type ParseTestAssignmentPayload = z.infer<typeof assignmentSchema>;
 export type ParseTestGradingItemPayload = z.infer<typeof gradingItemSchema>;
 export type ParseTestContactPayload = z.infer<typeof contactSchema>;
 export type ParseTestEventPayload = z.infer<typeof eventSchema>;
+export type ParseTestReviewUpdate = z.infer<typeof parseTestReviewUpdateSchema>;
 
 export type ParseTestViewModel = {
   run: {

--- a/lib/parse-test/data/repository.ts
+++ b/lib/parse-test/data/repository.ts
@@ -10,7 +10,7 @@ import {
   parseTestGradingItem,
   parseTestRun,
 } from "@/lib/db/schema";
-import type { ParseStatus, ParseTestPayload, ParseTestViewModel } from "../contracts";
+import type { ParseStatus, ParseTestPayload, ParseTestReviewUpdate, ParseTestViewModel } from "../contracts";
 import { getParseTestModel } from "../feature";
 import { isHighSignalWarning, normalisePercent, parseIsoDate } from "../normalize";
 
@@ -344,6 +344,141 @@ export async function getParseTestViewModelForRun(
       displayOrder: event.displayOrder,
     })),
   };
+}
+
+export async function updateParseTestReviewedValues(
+  userId: string,
+  payload: ParseTestReviewUpdate,
+) {
+  const run = await getRunById(userId, payload.runId);
+
+  if (!run) {
+    return null;
+  }
+
+  const courses = await db
+    .select()
+    .from(parseTestCourse)
+    .where(eq(parseTestCourse.runId, run.id))
+    .limit(1);
+  const course = courses[0];
+
+  if (!course) {
+    return null;
+  }
+
+  const now = new Date();
+
+  await db
+    .update(parseTestCourse)
+    .set({
+      title: payload.course.title,
+      courseCode: payload.course.courseCode,
+      courseSection: payload.course.courseSection,
+      term: payload.course.term,
+      instructorName: payload.course.instructorName,
+      meetingDays: payload.course.meetingDays,
+      meetingTime: payload.course.meetingTime,
+      meetingLocation: payload.course.meetingLocation,
+      requiredMaterials: payload.course.requiredMaterials,
+      homeworkTools: payload.course.homeworkTools,
+      catalogDescription: payload.course.catalogDescription,
+      studentSummary: payload.course.studentSummary,
+      descriptionSource: payload.course.descriptionSource,
+      updatedAt: now,
+    })
+    .where(eq(parseTestCourse.id, course.id));
+
+  await Promise.all([
+    db.delete(parseTestConcept).where(eq(parseTestConcept.courseId, course.id)),
+    db.delete(parseTestContact).where(eq(parseTestContact.courseId, course.id)),
+    db.delete(parseTestGradingItem).where(eq(parseTestGradingItem.courseId, course.id)),
+    db.delete(parseTestAssignment).where(eq(parseTestAssignment.courseId, course.id)),
+    db.delete(parseTestEvent).where(eq(parseTestEvent.courseId, course.id)),
+  ]);
+
+  if (payload.concepts.length > 0) {
+    await db.insert(parseTestConcept).values(
+      payload.concepts.map((concept, index) => ({
+        id: randomUUID(),
+        courseId: course.id,
+        label: concept.label,
+        displayOrder: index,
+      })),
+    );
+  }
+
+  if (payload.contacts.length > 0) {
+    await db.insert(parseTestContact).values(
+      payload.contacts.map((contact, index) => ({
+        id: randomUUID(),
+        courseId: course.id,
+        role: contact.role,
+        name: contact.name,
+        email: contact.email,
+        officeHours: contact.officeHours,
+        location: contact.location,
+        sourceSnippet: contact.sourceSnippet,
+        displayOrder: index,
+      })),
+    );
+  }
+
+  if (payload.gradingItems.length > 0) {
+    await db.insert(parseTestGradingItem).values(
+      payload.gradingItems.map((item, index) => ({
+        id: randomUUID(),
+        courseId: course.id,
+        label: item.label,
+        weightPercent: item.weightPercent,
+        sourceSnippet: item.sourceSnippet,
+        displayOrder: index,
+      })),
+    );
+  }
+
+  if (payload.assignments.length > 0) {
+    await db.insert(parseTestAssignment).values(
+      payload.assignments.map((assignment, index) => ({
+        id: randomUUID(),
+        courseId: course.id,
+        title: assignment.title,
+        category: assignment.category,
+        dateText: assignment.dateText,
+        dueAt: parseIsoDate(assignment.dueAt),
+        timeText: assignment.timeText,
+        weightPercent: assignment.weightPercent,
+        sourceSnippet: assignment.sourceSnippet,
+        displayOrder: index,
+      })),
+    );
+  }
+
+  if (payload.events.length > 0) {
+    await db.insert(parseTestEvent).values(
+      payload.events.map((event, index) => ({
+        id: randomUUID(),
+        courseId: course.id,
+        title: event.title,
+        category: event.category,
+        dateText: event.dateText,
+        dueAt: parseIsoDate(event.dueAt),
+        timeText: event.timeText,
+        location: event.location,
+        sourceSnippet: event.sourceSnippet,
+        displayOrder: index,
+      })),
+    );
+  }
+
+  await db
+    .update(parseTestRun)
+    .set({
+      updatedAt: now,
+    })
+    .where(eq(parseTestRun.id, run.id));
+
+  return getParseTestViewModelForRun(userId, run.id);
 }
 
 export async function deleteParseTestRunRecord(params: { userId: string; runId: string }) {

--- a/lib/parse-test/service.ts
+++ b/lib/parse-test/service.ts
@@ -1,5 +1,11 @@
-import { deleteParseTestRunRecord, getParseTestViewModel, getParseTestViewModelForRun } from "./data/repository";
+import {
+  deleteParseTestRunRecord,
+  getParseTestViewModel,
+  getParseTestViewModelForRun,
+  updateParseTestReviewedValues,
+} from "./data/repository";
 import { getNormalizedParseTestSchedule, getParseTestRunSummaries } from "./data/queries";
+import type { ParseTestReviewUpdate } from "./contracts";
 import { ParseTestError, toPublicParseTestError } from "./errors";
 import { replaceParseTestWithUpload } from "./upload/replace";
 
@@ -10,6 +16,16 @@ export {
   getNormalizedParseTestSchedule,
   replaceParseTestWithUpload,
 };
+
+export async function updateParseTestReview(params: { userId: string; payload: ParseTestReviewUpdate }) {
+  const viewModel = await updateParseTestReviewedValues(params.userId, params.payload);
+
+  if (!viewModel) {
+    throw new ParseTestError("That saved class could not be found.", 404);
+  }
+
+  return viewModel;
+}
 
 export async function deleteParseTestRun(params: { userId: string; runId: string }) {
   const result = await deleteParseTestRunRecord(params);


### PR DESCRIPTION
## Summary
- Simplifies the syllabus upload page to a single upload box with compact progress text.
- Adds a post-parse choice between manual review/edit and immediate import.
- Adds review persistence for edited course, contact, grading, assignment, and calendar values.
- Simplifies the calendar page to a single month grid without side panels.

## Validation
- `pnpm lint`
- `pnpm build`
- `git diff --check`
