### PR TITLE
Rework math text editing to normalize user input to LaTeX

### DIFF
--- a/app/flashcards/flashcards-client.test.tsx
+++ b/app/flashcards/flashcards-client.test.tsx
@@ -77,11 +77,9 @@ describe("FlashcardsClient", () => {
   it("keeps My Flashcards focused on saved deck management", () => {
     render(<FlashcardsClient notes={notes} initialDecks={[deck()]} />);
 
-    expect(screen.getByRole("heading", { name: "My Flashcards" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Biology deck" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Review" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Edit/ })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Delete/ })).toBeInTheDocument();
+    expect(screen.getByText("1 decks")).toBeInTheDocument();
+    expect(screen.getByText("Biology deck")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open actions for Biology deck/ })).toBeInTheDocument();
     expect(screen.queryByRole("checkbox", { name: /Lecture One/ })).not.toBeInTheDocument();
   });
 
@@ -131,7 +129,7 @@ describe("FlashcardsClient", () => {
     await user.clear(screen.getByLabelText("Deck name"));
     await user.type(screen.getByLabelText("Deck name"), "Edited deck");
     await user.clear(screen.getByLabelText("Front"));
-    await user.type(screen.getByLabelText("Front"), "Edited front");
+    await user.type(screen.getByLabelText("Front"), "Edited front $√(x²)$");
     await user.type(screen.getByLabelText("Tags"), "core");
     await user.click(screen.getByRole("button", { name: /Save deck/ }));
 
@@ -148,7 +146,7 @@ describe("FlashcardsClient", () => {
       title: "Edited deck",
       cards: [
         {
-          front: "Edited front",
+          front: "Edited front $\\sqrt{x^2}$",
           back: "Generated back",
           tags: ["core"],
         },
@@ -175,7 +173,8 @@ describe("FlashcardsClient", () => {
 
     render(<FlashcardsClient notes={notes} initialDecks={[deck()]} />);
 
-    await user.click(screen.getByRole("button", { name: /Edit/ }));
+    await user.click(screen.getByRole("button", { name: /Open actions for Biology deck/ }));
+    await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.clear(screen.getByLabelText("Deck name"));
     await user.type(screen.getByLabelText("Deck name"), "Renamed deck");
     await user.clear(screen.getByLabelText("Back"));
@@ -213,12 +212,13 @@ describe("FlashcardsClient", () => {
 
     render(<FlashcardsClient notes={notes} initialDecks={[deck()]} />);
 
-    await user.click(screen.getByRole("button", { name: /Delete/ }));
+    await user.click(screen.getByRole("button", { name: /Open actions for Biology deck/ }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
 
     await waitFor(() => {
-      expect(screen.queryByRole("heading", { name: "Biology deck" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Biology deck")).not.toBeInTheDocument();
     });
-    expect(screen.getByText("No flashcard decks")).toBeInTheDocument();
+    expect(screen.getByText("No saved decks")).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith("/api/flashcards?deckId=deck-1", { method: "DELETE" });
   });
 });

--- a/app/flashcards/flashcards-client.tsx
+++ b/app/flashcards/flashcards-client.tsx
@@ -10,7 +10,6 @@ import {
   Edit3,
   Loader2,
   MoreHorizontal,
-  Play,
   Plus,
   RotateCcw,
   Save,
@@ -18,10 +17,7 @@ import {
   X,
 } from "lucide-react";
 import { toast } from "sonner";
-import ReactMarkdown from "react-markdown";
-import rehypeKatex from "rehype-katex";
-import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
+import { LatexMarkdown } from "@/components/math/latex-markdown";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -32,6 +28,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input, Textarea } from "@/components/ui/input";
+import { normalizeTextMathToLatex } from "@/lib/math/latex";
 import { cx } from "@/lib/utils";
 import type { FlashcardDeck, FlashcardItem } from "@/lib/flashcards/types";
 
@@ -89,6 +86,21 @@ function cloneDeck(deck: FlashcardDeck): FlashcardDeck {
   };
 }
 
+function normalizeCardMath(card: FlashcardItem): FlashcardItem {
+  return {
+    ...card,
+    front: normalizeTextMathToLatex(card.front),
+    back: normalizeTextMathToLatex(card.back),
+  };
+}
+
+function normalizeDeckMath(deck: FlashcardDeck): FlashcardDeck {
+  return {
+    ...deck,
+    cards: deck.cards.map(normalizeCardMath),
+  };
+}
+
 function withCardCount(deck: FlashcardDeck): FlashcardDeck {
   return {
     ...deck,
@@ -110,39 +122,6 @@ function parseTags(value: string) {
     .map((tag) => tag.trim())
     .filter(Boolean)
     .slice(0, 8);
-}
-
-function MarkdownText({
-  markdown,
-  className,
-}: {
-  markdown: string;
-  className?: string;
-}) {
-  return (
-    <div className={cx("min-w-0 space-y-2 text-foreground", className)}>
-      <ReactMarkdown
-        rehypePlugins={[rehypeKatex]}
-        remarkPlugins={[remarkGfm, remarkMath]}
-        components={{
-          p: ({ children }) => <p>{children}</p>,
-          ul: ({ children }) => (
-            <ul className="ml-5 list-disc space-y-1">{children}</ul>
-          ),
-          ol: ({ children }) => (
-            <ol className="ml-5 list-decimal space-y-1">{children}</ol>
-          ),
-          code: ({ children }) => (
-            <code className="rounded bg-surface-elevated px-1 py-0.5 font-mono text-[0.92em]">
-              {children}
-            </code>
-          ),
-        }}
-      >
-        {markdown}
-      </ReactMarkdown>
-    </div>
-  );
 }
 
 function StatPill({ children }: { children: ReactNode }) {
@@ -252,6 +231,11 @@ function DeckEditor({
                     onChange={(event) =>
                       updateCard(index, { front: event.target.value })
                     }
+                    onBlur={(event) =>
+                      updateCard(index, {
+                        front: normalizeTextMathToLatex(event.target.value),
+                      })
+                    }
                   />
                 </label>
                 <label className="space-y-2 text-sm font-medium text-foreground">
@@ -262,6 +246,11 @@ function DeckEditor({
                     disabled={disabled}
                     onChange={(event) =>
                       updateCard(index, { back: event.target.value })
+                    }
+                    onBlur={(event) =>
+                      updateCard(index, {
+                        back: normalizeTextMathToLatex(event.target.value),
+                      })
                     }
                   />
                 </label>
@@ -409,6 +398,7 @@ export function FlashcardsClient({
       return;
     }
 
+    const normalizedDeck = normalizeDeckMath(draftDeck);
     setIsSaving(true);
     try {
       const payload = await readJsonResponse<{ deck: FlashcardDeck }>(
@@ -417,9 +407,9 @@ export function FlashcardsClient({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             mode: "save",
-            title: draftDeck.title,
-            sourceNoteIds: draftDeck.sourceNoteIds,
-            cards: draftDeck.cards,
+            title: normalizedDeck.title,
+            sourceNoteIds: normalizedDeck.sourceNoteIds,
+            cards: normalizedDeck.cards,
           }),
         }),
       );
@@ -444,6 +434,7 @@ export function FlashcardsClient({
       return;
     }
 
+    const normalizedDeck = normalizeDeckMath(editingDeck);
     setIsSaving(true);
     try {
       const payload = await readJsonResponse<{ deck: FlashcardDeck }>(
@@ -451,10 +442,10 @@ export function FlashcardsClient({
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            deckId: editingDeck.id,
-            title: editingDeck.title,
-            sourceNoteIds: editingDeck.sourceNoteIds,
-            cards: editingDeck.cards,
+            deckId: normalizedDeck.id,
+            title: normalizedDeck.title,
+            sourceNoteIds: normalizedDeck.sourceNoteIds,
+            cards: normalizedDeck.cards,
           }),
         }),
       );
@@ -591,6 +582,7 @@ export function FlashcardsClient({
 
                         <button
                           type="button"
+                          aria-label={`Open actions for ${deck.title}`}
                           className="shrink-0 rounded-md p-1.5 text-muted-foreground transition hover:bg-surface-elevated hover:text-foreground"
                           onClick={(e) => {
                             e.stopPropagation();
@@ -903,7 +895,7 @@ export function FlashcardsClient({
                       <Badge variant="outline">Flip</Badge>
                     </div>
                     <div className="mx-auto flex w-full max-w-3xl flex-1 items-center justify-center py-8">
-                      <MarkdownText
+                      <LatexMarkdown
                         markdown={showBack ? activeCard.back : activeCard.front}
                         className="text-center text-xl font-medium leading-9"
                       />

--- a/app/globals.css
+++ b/app/globals.css
@@ -982,6 +982,18 @@ html.dark body {
   color: var(--foreground);
 }
 
+.note-editor .note-inline-math-block math-field,
+.note-renderer .note-inline-math-block math-field {
+  width: auto;
+  max-width: 100%;
+  min-width: 4rem;
+}
+
+.note-editor .note-inline-math-block math-field::part(container),
+.note-renderer .note-inline-math-block math-field::part(container) {
+  padding: 0;
+}
+
 .note-renderer .katex-display {
   margin: 0.25rem 0;
   overflow-x: auto;
@@ -1018,16 +1030,4 @@ html.dark body {
   opacity: 0.7;
   user-select: none;
   pointer-events: none;
-}
-
-/* ---- Inline math spans ---- */
-.note-inline-math {
-  display: inline;
-  font-family: var(--font-mono), monospace;
-  font-size: 0.9em;
-  color: var(--color-accent);
-  background: var(--color-accent-soft);
-  border-radius: 3px;
-  padding: 0.05em 0.3em;
-  white-space: nowrap;
 }

--- a/app/quizzes/quizzes-client.test.tsx
+++ b/app/quizzes/quizzes-client.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { QuizzesClient } from "@/app/quizzes/quizzes-client";
 import type { QuizQuestion } from "@/lib/quizzes/gemini";
 import type { SavedQuiz } from "@/lib/quizzes/types";
@@ -44,16 +44,25 @@ const savedQuiz: SavedQuiz = {
   updatedAt: "2026-05-29T18:00:00.000Z",
 };
 
+function jsonResponse(payload: unknown, init?: ResponseInit) {
+  return {
+    ok: init?.status ? init.status < 400 : true,
+    status: init?.status ?? 200,
+    json: async () => payload,
+  } as Response;
+}
+
 describe("QuizzesClient", () => {
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("renders library as quiz dashboard with stats and empty state", () => {
     render(<QuizzesClient notes={notes} initialQuizzes={[]} initialAttempts={[]} />);
 
     expect(screen.getByTestId("quizzes-one-page")).toHaveClass("h-full", "overflow-hidden");
-    expect(screen.getByRole("heading", { name: "My Quizzes" })).toBeInTheDocument();
     expect(screen.getByText("0 quizzes")).toBeInTheDocument();
     expect(screen.getByText("0 questions")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /create quiz/i })).toBeInTheDocument();
@@ -67,7 +76,6 @@ describe("QuizzesClient", () => {
 
     await user.click(screen.getByRole("button", { name: /create quiz/i }));
 
-    expect(screen.getByRole("heading", { name: "Quizzes" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Create Quiz" })).toBeInTheDocument();
     expect(screen.getByText("Context")).toBeInTheDocument();
     expect(screen.getByText("Preview")).toBeInTheDocument();
@@ -83,7 +91,8 @@ describe("QuizzesClient", () => {
     const user = userEvent.setup();
     render(<QuizzesClient notes={notes} initialQuizzes={[savedQuiz]} initialAttempts={[]} />);
 
-    await user.click(screen.getByRole("button", { name: /edit/i }));
+    await user.click(screen.getByRole("button", { name: /Open actions for Loop quiz/ }));
+    await user.click(screen.getByRole("button", { name: "Edit" }));
 
     expect(screen.getByRole("heading", { name: "Preview Quiz" })).toBeInTheDocument();
     expect(screen.getByLabelText(/quiz name/i)).toHaveValue("Loop quiz");
@@ -93,5 +102,36 @@ describe("QuizzesClient", () => {
 
     expect(screen.getAllByLabelText("Prompt")).toHaveLength(1);
     expect(screen.getAllByText("Question 2").length).toBeGreaterThan(0);
+  });
+
+  it("normalizes edited quiz math to LaTeX before saving", async () => {
+    const user = userEvent.setup();
+    const normalizedQuiz: SavedQuiz = {
+      ...savedQuiz,
+      questions: [
+        {
+          ...question,
+          prompt: "Area $\\pi r^2$",
+        },
+      ],
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ quiz: normalizedQuiz })));
+
+    render(<QuizzesClient notes={notes} initialQuizzes={[savedQuiz]} initialAttempts={[]} />);
+
+    await user.click(screen.getByRole("button", { name: /Open actions for Loop quiz/ }));
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.clear(screen.getByLabelText("Prompt"));
+    await user.type(screen.getByLabelText("Prompt"), "Area $πr²$");
+    await user.click(screen.getByRole("button", { name: /save quiz/i }));
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body))).toMatchObject({
+      questions: [
+        {
+          prompt: "Area $\\pi r^2$",
+        },
+      ],
+    });
   });
 });

--- a/app/quizzes/quizzes-client.tsx
+++ b/app/quizzes/quizzes-client.tsx
@@ -11,17 +11,13 @@ import {
   Loader2,
   MoreHorizontal,
   Pencil,
-  Play,
   Plus,
   RotateCcw,
   Save,
   Trash2,
   XCircle,
 } from "lucide-react";
-import ReactMarkdown from "react-markdown";
-import rehypeKatex from "rehype-katex";
-import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
+import { LatexMarkdown } from "@/components/math/latex-markdown";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -37,6 +33,7 @@ import {
   gradeObjectiveAnswer,
   summarizeAttempt,
 } from "@/lib/quizzes/attempts";
+import { normalizeTextMathToLatex } from "@/lib/math/latex";
 import type {
   QuizDifficulty,
   QuizQuestion,
@@ -123,61 +120,6 @@ async function readJsonResponse<T>(response: Response): Promise<T> {
   return payload;
 }
 
-function MarkdownText({
-  markdown,
-  className,
-}: {
-  markdown: string;
-  className?: string;
-}) {
-  return (
-    <div className={cx("quiz-markdown min-w-0 text-foreground", className)}>
-      <ReactMarkdown
-        rehypePlugins={[rehypeKatex]}
-        remarkPlugins={[remarkGfm, remarkMath]}
-        components={{
-          p: ({ children }) => <p>{children}</p>,
-          ul: ({ children }) => (
-            <ul className="ml-5 list-disc space-y-1">{children}</ul>
-          ),
-          ol: ({ children }) => (
-            <ol className="ml-5 list-decimal space-y-1">{children}</ol>
-          ),
-          li: ({ children }) => <li>{children}</li>,
-          strong: ({ children }) => (
-            <strong className="font-semibold text-foreground">
-              {children}
-            </strong>
-          ),
-          em: ({ children }) => <em className="italic">{children}</em>,
-          code: ({ children, className: codeClassName }) => (
-            <code
-              className={cx(
-                "rounded bg-surface-elevated px-1 py-0.5 font-mono text-[0.92em]",
-                codeClassName,
-              )}
-            >
-              {children}
-            </code>
-          ),
-          pre: ({ children }) => (
-            <pre className="overflow-x-auto rounded-lg border border-border bg-surface-muted p-3 text-sm">
-              {children}
-            </pre>
-          ),
-          blockquote: ({ children }) => (
-            <blockquote className="border-l-4 border-border pl-3 text-muted-foreground">
-              {children}
-            </blockquote>
-          ),
-        }}
-      >
-        {markdown}
-      </ReactMarkdown>
-    </div>
-  );
-}
-
 function StepPill({
   active,
   children,
@@ -205,6 +147,16 @@ function StatPill({ children }: { children: ReactNode }) {
       {children}
     </span>
   );
+}
+
+function normalizeQuestionMath(question: QuizQuestion): QuizQuestion {
+  return {
+    ...question,
+    prompt: normalizeTextMathToLatex(question.prompt),
+    correctAnswer: normalizeTextMathToLatex(question.correctAnswer),
+    explanation: normalizeTextMathToLatex(question.explanation),
+    choices: question.choices?.map(normalizeTextMathToLatex),
+  };
 }
 
 function makeDraftQuestion(sourceNoteTitles: string[]): QuizQuestion {
@@ -456,6 +408,24 @@ export function QuizzesClient({
     );
   }
 
+  function normalizeDraftQuestionField(
+    questionIndex: number,
+    field: "prompt" | "correctAnswer" | "explanation",
+    value: string,
+  ) {
+    updateDraftQuestion(questionIndex, {
+      [field]: normalizeTextMathToLatex(value),
+    });
+  }
+
+  function normalizeDraftChoice(
+    questionIndex: number,
+    choiceIndex: number,
+    value: string,
+  ) {
+    updateDraftChoice(questionIndex, choiceIndex, normalizeTextMathToLatex(value));
+  }
+
   function updateDraftQuestionType(index: number, type: QuizQuestionType) {
     setDraftQuestions((current) =>
       current.map((question, questionIndex) => {
@@ -505,8 +475,9 @@ export function QuizzesClient({
     setError(null);
     setIsSaving(true);
     try {
+      const normalizedQuestions = draftQuestions.map(normalizeQuestionMath);
       const sourceNoteTitles = getSourceTitles(
-        draftQuestions,
+        normalizedQuestions,
         notes,
         selectedNoteIds,
       );
@@ -520,7 +491,7 @@ export function QuizzesClient({
               title: draftTitle,
               sourceNoteIds: selectedNoteIds,
               sourceNoteTitles,
-              questions: draftQuestions,
+              questions: normalizedQuestions,
               difficulty,
               mode,
               questionTypes,
@@ -632,11 +603,12 @@ export function QuizzesClient({
   }
 
   function updateAnswer(questionId: string, value: string) {
+    const normalizedAnswer = normalizeTextMathToLatex(value);
     setAnswers((current) => ({
       ...current,
       [questionId]: {
         questionId,
-        answer: value,
+        answer: normalizedAnswer,
         evaluation: current[questionId]?.evaluation,
       },
     }));
@@ -849,6 +821,7 @@ export function QuizzesClient({
 
                     <button
                       type="button"
+                      aria-label={`Open actions for ${quiz.title}`}
                       className="shrink-0 rounded-md p-1.5 text-muted-foreground transition hover:bg-surface-elevated hover:text-foreground"
                       onClick={(e) => {
                         e.stopPropagation();
@@ -1279,6 +1252,13 @@ export function QuizzesClient({
                             prompt: event.target.value,
                           })
                         }
+                        onBlur={(event) =>
+                          normalizeDraftQuestionField(
+                            draftQuestionIndex,
+                            "prompt",
+                            event.target.value,
+                          )
+                        }
                       />
                     </label>
                     <div className="grid gap-3 md:grid-cols-[180px_minmax(0,1fr)]">
@@ -1331,6 +1311,13 @@ export function QuizzesClient({
                             correctAnswer: event.target.value,
                           })
                         }
+                        onBlur={(event) =>
+                          normalizeDraftQuestionField(
+                            draftQuestionIndex,
+                            "correctAnswer",
+                            event.target.value,
+                          )
+                        }
                       />
                     </label>
                     <label className="flex flex-col gap-1.5 text-sm font-medium text-foreground">
@@ -1343,6 +1330,13 @@ export function QuizzesClient({
                           updateDraftQuestion(draftQuestionIndex, {
                             explanation: event.target.value,
                           })
+                        }
+                        onBlur={(event) =>
+                          normalizeDraftQuestionField(
+                            draftQuestionIndex,
+                            "explanation",
+                            event.target.value,
+                          )
                         }
                       />
                     </label>
@@ -1362,6 +1356,13 @@ export function QuizzesClient({
                           value={choice}
                           onChange={(event) =>
                             updateDraftChoice(
+                              draftQuestionIndex,
+                              choiceIndex,
+                              event.target.value,
+                            )
+                          }
+                          onBlur={(event) =>
+                            normalizeDraftChoice(
                               draftQuestionIndex,
                               choiceIndex,
                               event.target.value,
@@ -1475,7 +1476,7 @@ export function QuizzesClient({
                 </Badge>
               ))}
             </div>
-            <MarkdownText
+            <LatexMarkdown
               markdown={currentQuestion.prompt}
               className="space-y-3 text-xl font-semibold leading-8"
             />
@@ -1503,7 +1504,7 @@ export function QuizzesClient({
                     }
                     onChange={() => updateAnswer(currentQuestion.id, choice)}
                   />
-                  <MarkdownText markdown={choice} className="text-sm" />
+                  <LatexMarkdown markdown={choice} className="text-sm" />
                 </label>
               ))}
             </div>
@@ -1534,12 +1535,12 @@ export function QuizzesClient({
                 {currentEvaluation.correct ? "Correct" : "Needs work"} - Score{" "}
                 {formatPercent(currentEvaluation.score)}
               </div>
-              <MarkdownText
+              <LatexMarkdown
                 markdown={currentEvaluation.feedback}
                 className="mt-1 space-y-2"
               />
               <div className="mt-2 font-medium">Ideal answer</div>
-              <MarkdownText
+              <LatexMarkdown
                 markdown={currentEvaluation.idealAnswer}
                 className="mt-1 space-y-2"
               />
@@ -1743,7 +1744,7 @@ export function QuizzesClient({
             </CardHeader>
             <CardContent className="flex min-h-0 flex-1 flex-col gap-3 text-sm">
               <div className="min-h-0 overflow-y-auto rounded-lg border border-border bg-surface-muted p-3">
-                <MarkdownText
+                <LatexMarkdown
                   markdown={resultQuestion.prompt}
                   className="space-y-2 font-medium"
                 />
@@ -1753,7 +1754,7 @@ export function QuizzesClient({
                   <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                     Your answer
                   </div>
-                  <MarkdownText
+                  <LatexMarkdown
                     markdown={resultAnswer?.answer.trim() || "Unanswered"}
                     className="space-y-2"
                   />
@@ -1762,7 +1763,7 @@ export function QuizzesClient({
                   <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                     Correct answer
                   </div>
-                  <MarkdownText
+                  <LatexMarkdown
                     markdown={resultQuestion.correctAnswer}
                     className="space-y-2"
                   />
@@ -1772,14 +1773,14 @@ export function QuizzesClient({
                 <div className="mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                   Feedback
                 </div>
-                <MarkdownText
+                <LatexMarkdown
                   markdown={resultEvaluation.feedback}
                   className="space-y-2"
                 />
                 <div className="mt-3 mb-1 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                   Explanation
                 </div>
-                <MarkdownText
+                <LatexMarkdown
                   markdown={
                     resultQuestion.explanation || resultEvaluation.idealAnswer
                   }

--- a/components/math/latex-markdown.tsx
+++ b/components/math/latex-markdown.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import rehypeKatex from "rehype-katex";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import { cx } from "@/lib/utils";
+
+type LatexMarkdownProps = {
+  markdown: string;
+  className?: string;
+  codeClassName?: string;
+};
+
+export function LatexMarkdown({
+  markdown,
+  className,
+  codeClassName,
+}: LatexMarkdownProps) {
+  return (
+    <div className={cx("min-w-0 text-foreground", className)}>
+      <ReactMarkdown
+        rehypePlugins={[rehypeKatex]}
+        remarkPlugins={[remarkGfm, remarkMath]}
+        components={{
+          p: ({ children }) => <p>{children}</p>,
+          ul: ({ children }) => (
+            <ul className="ml-5 list-disc space-y-1">{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="ml-5 list-decimal space-y-1">{children}</ol>
+          ),
+          li: ({ children }) => <li>{children}</li>,
+          strong: ({ children }) => (
+            <strong className="font-semibold text-foreground">
+              {children}
+            </strong>
+          ),
+          em: ({ children }) => <em className="italic">{children}</em>,
+          code: ({ children, className: markdownCodeClassName }) => (
+            <code
+              className={cx(
+                codeClassName ??
+                  "rounded bg-surface-elevated px-1 py-0.5 font-mono text-[0.92em]",
+                markdownCodeClassName,
+              )}
+            >
+              {children}
+            </code>
+          ),
+          pre: ({ children }) => (
+            <pre className="overflow-x-auto rounded-lg border border-border bg-surface-muted p-3 text-sm">
+              {children}
+            </pre>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-4 border-border pl-3 text-muted-foreground">
+              {children}
+            </blockquote>
+          ),
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/components/note-editor/math-block-tool.test.ts
+++ b/components/note-editor/math-block-tool.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { MathBlockTool } from "@/components/note-editor/math-block-tool";
+import {
+  InlineMathBlockTool,
+  MathBlockTool,
+} from "@/components/note-editor/math-block-tool";
 
 describe("MathBlockTool", () => {
   function createTool() {
@@ -111,5 +114,32 @@ describe("MathBlockTool", () => {
     mathField.value = "√(x²)";
 
     expect(tool.save()).toEqual({ latex: "\\sqrt{x^2}" });
+  });
+
+  it("renders inline math with the compact math field variant", () => {
+    const tool = new InlineMathBlockTool({
+      data: {
+        latex: "x^2",
+      },
+      api: {
+        blocks: {
+          insert: vi.fn(),
+          getBlockIndex: vi.fn(),
+        },
+      } as never,
+      config: {
+        variant: "inline",
+      },
+      block: {
+        id: "inline-math-block",
+      } as never,
+      readOnly: false,
+    });
+
+    const rendered = tool.render();
+    const mathField = rendered.querySelector("math-field");
+
+    expect(rendered.className).toContain("note-inline-math-block");
+    expect(mathField?.getAttribute("placeholder")).toBe("x^2");
   });
 });

--- a/components/note-editor/math-block-tool.test.ts
+++ b/components/note-editor/math-block-tool.test.ts
@@ -100,4 +100,16 @@ describe("MathBlockTool", () => {
     expect(insert).toHaveBeenCalledWith("paragraph", { text: "<br>" }, undefined, 4, true);
     expect(enterEvent.defaultPrevented).toBe(true);
   });
+
+  it("saves normalized LaTeX from typed math", () => {
+    const { tool } = createTool();
+    const rendered = tool.render();
+    const mathField = rendered.querySelector("math-field") as HTMLElement & {
+      value: string;
+    };
+
+    mathField.value = "√(x²)";
+
+    expect(tool.save()).toEqual({ latex: "\\sqrt{x^2}" });
+  });
 });

--- a/components/note-editor/math-block-tool.ts
+++ b/components/note-editor/math-block-tool.ts
@@ -10,6 +10,14 @@ const MATH_TOOL_ICON = `
   </svg>
 `;
 
+const INLINE_MATH_TOOL_ICON = `
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M4 10H8M12 10H16M8 6L12 14M12 6L8 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+`;
+
+type MathBlockVariant = "display" | "inline";
+
 export class MathBlockTool implements BlockTool {
   public static get toolbox(): ToolboxConfig {
     return {
@@ -25,6 +33,7 @@ export class MathBlockTool implements BlockTool {
   private readonly readOnly: boolean;
   private readonly api: API;
   private readonly block: BlockAPI;
+  private readonly variant: MathBlockVariant;
   private data: NoteMathBlockData;
   private mathField: MathfieldElement | null = null;
   private wrapper: HTMLDivElement | null = null;
@@ -55,10 +64,14 @@ export class MathBlockTool implements BlockTool {
     };
   };
 
-  constructor({ api, block, data, readOnly }: BlockToolConstructorOptions<NoteMathBlockData>) {
+  constructor({ api, block, config, data, readOnly }: BlockToolConstructorOptions<NoteMathBlockData>) {
     this.api = api;
     this.block = block;
     this.readOnly = readOnly;
+    this.variant =
+      (config as { variant?: MathBlockVariant } | undefined)?.variant === "inline"
+        ? "inline"
+        : "display";
     this.data = {
       latex: normalizeLatex(data.latex ?? ""),
     };
@@ -67,20 +80,27 @@ export class MathBlockTool implements BlockTool {
   public render() {
     const wrapper = document.createElement("div");
     wrapper.className =
-      "rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950";
+      this.variant === "inline"
+        ? "note-inline-math-block inline-flex max-w-full items-center rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 align-middle dark:border-zinc-800 dark:bg-zinc-950"
+        : "rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950";
     wrapper.contentEditable = "false";
 
-    const label = document.createElement("div");
-    label.className = "mb-2 text-xs font-medium uppercase tracking-[0.2em] text-zinc-500";
-    label.textContent = this.readOnly ? "Equation" : "Math";
-    wrapper.append(label);
+    if (this.variant === "display") {
+      const label = document.createElement("div");
+      label.className = "mb-2 text-xs font-medium uppercase tracking-[0.2em] text-zinc-500";
+      label.textContent = this.readOnly ? "Equation" : "Math";
+      wrapper.append(label);
+    }
 
     const mathField = document.createElement("math-field") as unknown as MathfieldElement;
-    mathField.className = "block min-h-12 w-full rounded-md bg-white px-3 py-2 text-lg dark:bg-zinc-900";
+    mathField.className =
+      this.variant === "inline"
+        ? "block min-h-8 w-auto rounded bg-white px-2 py-1 text-base dark:bg-zinc-900"
+        : "block min-h-12 w-full rounded-md bg-white px-3 py-2 text-lg dark:bg-zinc-900";
     mathField.setAttribute("math-virtual-keyboard-policy", "manual");
     mathField.setAttribute("smart-mode", "on");
     mathField.setAttribute("default-mode", "math");
-    mathField.setAttribute("placeholder", "\\frac{a}{b}");
+    mathField.setAttribute("placeholder", this.variant === "inline" ? "x^2" : "\\frac{a}{b}");
     mathField.value = this.data.latex;
 
     if (this.readOnly) {
@@ -164,5 +184,14 @@ export class MathBlockTool implements BlockTool {
       window.setTimeout(focus, 350);
       window.setTimeout(focus, 650);
     });
+  }
+}
+
+export class InlineMathBlockTool extends MathBlockTool {
+  public static override get toolbox(): ToolboxConfig {
+    return {
+      title: "Inline math",
+      icon: INLINE_MATH_TOOL_ICON,
+    };
   }
 }

--- a/components/note-editor/math-block-tool.ts
+++ b/components/note-editor/math-block-tool.ts
@@ -1,6 +1,7 @@
 import type { BlockTool, BlockToolConstructorOptions, ToolboxConfig } from "@editorjs/editorjs";
 import type { API, BlockAPI } from "@editorjs/editorjs";
 import type { MathfieldElement } from "mathlive";
+import { normalizeLatex } from "@/lib/math/latex";
 import type { NoteMathBlockData } from "@/lib/notes/types";
 
 const MATH_TOOL_ICON = `
@@ -50,7 +51,7 @@ export class MathBlockTool implements BlockTool {
     }
 
     this.data = {
-      latex: this.mathField.value,
+      latex: normalizeLatex(this.mathField.value),
     };
   };
 
@@ -59,7 +60,7 @@ export class MathBlockTool implements BlockTool {
     this.block = block;
     this.readOnly = readOnly;
     this.data = {
-      latex: data.latex ?? "",
+      latex: normalizeLatex(data.latex ?? ""),
     };
   }
 
@@ -105,7 +106,7 @@ export class MathBlockTool implements BlockTool {
 
   public save() {
     return {
-      latex: this.mathField?.value ?? this.data.latex,
+      latex: normalizeLatex(this.mathField?.value ?? this.data.latex),
     };
   }
 

--- a/components/note-editor/note-editor.tsx
+++ b/components/note-editor/note-editor.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@/lib/notes/types";
 import { emptyNoteDocument, NoteDocumentSchema } from "@/lib/notes/types";
 import { createNoteContent } from "@/lib/notes/markdown";
+import { normalizeLatex } from "@/lib/math/latex";
 import { CodeBlockTool } from "@/components/note-editor/code-block-tool";
 import { MathBlockTool } from "@/components/note-editor/math-block-tool";
 
@@ -238,7 +239,7 @@ function convertBlock(
       return {
         type: "math",
         data: {
-          latex: plainText,
+          latex: normalizeLatex(plainText),
         },
       };
     default:

--- a/components/note-editor/note-editor.tsx
+++ b/components/note-editor/note-editor.tsx
@@ -22,7 +22,10 @@ import { createNoteContent } from "@/lib/notes/markdown";
 import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
 import { normalizeLatex } from "@/lib/math/latex";
 import { CodeBlockTool } from "@/components/note-editor/code-block-tool";
-import { MathBlockTool } from "@/components/note-editor/math-block-tool";
+import {
+  InlineMathBlockTool,
+  MathBlockTool,
+} from "@/components/note-editor/math-block-tool";
 
 export type NoteEditorProps = {
   initialDocument: NoteDocument;
@@ -57,7 +60,8 @@ type BlockConversionTarget =
   | { type: "list"; style: "ordered" | "unordered" | "checklist" }
   | { type: "quote" }
   | { type: "code" }
-  | { type: "math" };
+  | { type: "math" }
+  | { type: "inlineMath" };
 
 type SlashCommand = {
   id: string;
@@ -138,6 +142,13 @@ const SLASH_COMMANDS: SlashCommand[] = [
     keywords: ["equation", "latex"],
     target: { type: "math" },
   },
+  {
+    id: "inline-math",
+    label: "Inline math",
+    hint: "Small equation block",
+    keywords: ["equation", "latex", "inline"],
+    target: { type: "inlineMath" },
+  },
 ];
 
 function areDocumentsEqual(left: NoteDocument, right: NoteDocument) {
@@ -173,6 +184,7 @@ function getBlockText(block: NoteBlock, options?: { plain?: boolean }) {
     case "code":
       return block.data.code;
     case "math":
+    case "inlineMath":
       return block.data.latex;
     case "image":
       return normalize(block.data.caption);
@@ -243,6 +255,13 @@ function convertBlock(
           latex: normalizeLatex(plainText),
         },
       };
+    case "inlineMath":
+      return {
+        type: "inlineMath",
+        data: {
+          latex: normalizeLatex(plainText),
+        },
+      };
     default:
       return block;
   }
@@ -298,6 +317,13 @@ function createEmptyBlockForTarget(target: BlockConversionTarget): NoteBlock {
     case "math":
       return {
         type: "math",
+        data: {
+          latex: "",
+        },
+      };
+    case "inlineMath":
+      return {
+        type: "inlineMath",
         data: {
           latex: "",
         },
@@ -1618,6 +1644,12 @@ export function NoteEditor({
           math: {
             class: MathBlockTool as unknown as BlockToolConstructable,
           },
+          inlineMath: {
+            class: InlineMathBlockTool as unknown as BlockToolConstructable,
+            config: {
+              variant: "inline",
+            },
+          },
         },
         async onChange() {
           if (changeTimeoutRef.current) {
@@ -2250,6 +2282,13 @@ export function NoteEditor({
                 onClick={() => handleConvertBlock({ type: "math" })}
               >
                 Math
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => handleConvertBlock({ type: "inlineMath" })}
+              >
+                Inline math
               </button>
             </div>
           </div>

--- a/components/note-editor/note-editor.tsx
+++ b/components/note-editor/note-editor.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@/lib/notes/types";
 import { emptyNoteDocument, NoteDocumentSchema } from "@/lib/notes/types";
 import { createNoteContent } from "@/lib/notes/markdown";
+import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
 import { normalizeLatex } from "@/lib/math/latex";
 import { CodeBlockTool } from "@/components/note-editor/code-block-tool";
 import { MathBlockTool } from "@/components/note-editor/math-block-tool";
@@ -371,11 +372,12 @@ export function NoteEditor({
   readOnly = false,
   selectionPrelude,
 }: NoteEditorProps) {
+  const normalizedInitialDocument = normalizeNoteLatexRegions(initialDocument);
   const selectionScopeRef = useRef<HTMLElement | null>(null);
   const holderRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<EditorJS | null>(null);
   const changeTimeoutRef = useRef<number | null>(null);
-  const renderedDocumentRef = useRef<NoteDocument>(initialDocument);
+  const renderedDocumentRef = useRef<NoteDocument>(normalizedInitialDocument);
   const pendingSaveRef = useRef<NoteContent | null>(null);
   const isFlushingSaveRef = useRef(false);
   const dragCleanupRef = useRef<(() => void) | null>(null);
@@ -419,16 +421,16 @@ export function NoteEditor({
     await flushPendingSaves();
   });
 
-  const saveEditorDocument = useCallback(async (editor: EditorJS) => {
+  const saveEditorDocument = useCallback(async (editor: EditorJS, options?: { renderNormalized?: boolean }) => {
     const saved = NoteDocumentSchema.parse(await editor.save());
     const holder = holderRef.current;
     if (!holder) {
-      return saved;
+      return normalizeNoteLatexRegions(saved);
     }
 
     const domBlocks = Array.from(holder.querySelectorAll<HTMLElement>(".ce-block"));
     if (domBlocks.length === 0) {
-      return saved;
+      return normalizeNoteLatexRegions(saved);
     }
 
     const savedBlocksById = new Map(
@@ -484,10 +486,24 @@ export function NoteEditor({
       })
       .filter((block): block is NoteBlock => Boolean(block));
 
-    return NoteDocumentSchema.parse({
+    const document = NoteDocumentSchema.parse({
       ...saved,
       blocks,
     });
+
+    const normalized = normalizeNoteLatexRegions(document);
+    if (
+      options?.renderNormalized &&
+      !areDocumentsEqual(document, normalized)
+    ) {
+      await editor.render(
+        normalized.blocks.length > 0
+          ? normalized
+          : { ...emptyNoteDocument },
+      );
+    }
+
+    return normalized;
   }, []);
 
   const emitContentChange = useEffectEvent(async () => {
@@ -496,7 +512,9 @@ export function NoteEditor({
     }
 
     try {
-      const document = await saveEditorDocument(editorRef.current);
+      const document = await saveEditorDocument(editorRef.current, {
+        renderNormalized: true,
+      });
       const content = createNoteContent(document);
       await publishContent(content);
     } catch (error) {
@@ -1662,11 +1680,13 @@ export function NoteEditor({
   }, [readOnly]);
 
   useEffect(() => {
-    if (areDocumentsEqual(initialDocument, renderedDocumentRef.current)) {
+    const nextDocument = normalizeNoteLatexRegions(initialDocument);
+
+    if (areDocumentsEqual(nextDocument, renderedDocumentRef.current)) {
       return;
     }
 
-    renderedDocumentRef.current = initialDocument;
+    renderedDocumentRef.current = nextDocument;
     pendingSaveRef.current = null;
 
     const editor = editorRef.current;
@@ -1678,8 +1698,8 @@ export function NoteEditor({
     void editor.isReady
       .then(() =>
         editor.render(
-          initialDocument.blocks.length > 0
-            ? initialDocument
+          nextDocument.blocks.length > 0
+            ? nextDocument
             : { ...emptyNoteDocument },
         ),
       )

--- a/lib/math/latex.test.ts
+++ b/lib/math/latex.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLatex, normalizeTextMathToLatex } from "@/lib/math/latex";
+
+describe("latex normalization", () => {
+  it("converts common typed math symbols to LaTeX", () => {
+    expect(normalizeLatex("√(x² + y₂) ≤ π")).toBe("\\sqrt{x^2 + y_2} \\le \\pi");
+  });
+
+  it("normalizes only delimited math inside text", () => {
+    expect(normalizeTextMathToLatex("Use $√(x²)$ and then save.")).toBe(
+      "Use $\\sqrt{x^2}$ and then save.",
+    );
+  });
+
+  it("normalizes display math delimiters", () => {
+    expect(normalizeTextMathToLatex("$$\nα + β ≥ γ\n$$")).toBe(
+      "$$\n\\alpha + \\beta \\ge \\gamma\n$$",
+    );
+  });
+});

--- a/lib/math/latex.ts
+++ b/lib/math/latex.ts
@@ -1,0 +1,110 @@
+const UNICODE_LATEX_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/≤/g, "\\le "],
+  [/≥/g, "\\ge "],
+  [/≠/g, "\\ne "],
+  [/≈/g, "\\approx "],
+  [/±/g, "\\pm "],
+  [/×/g, "\\times "],
+  [/÷/g, "\\div "],
+  [/∞/g, "\\infty "],
+  [/π/g, "\\pi "],
+  [/Π/g, "\\Pi "],
+  [/θ/g, "\\theta "],
+  [/Θ/g, "\\Theta "],
+  [/λ/g, "\\lambda "],
+  [/Λ/g, "\\Lambda "],
+  [/μ/g, "\\mu "],
+  [/σ/g, "\\sigma "],
+  [/Σ/g, "\\Sigma "],
+  [/Ω/g, "\\Omega "],
+  [/√\s*\(([^()\n]+)\)/g, "\\sqrt{$1}"],
+  [/√\s*([A-Za-z0-9]+)/g, "\\sqrt{$1}"],
+  [/∑/g, "\\sum "],
+  [/∫/g, "\\int "],
+  [/→/g, "\\to "],
+  [/⇒/g, "\\Rightarrow "],
+  [/∈/g, "\\in "],
+  [/∉/g, "\\notin "],
+  [/∂/g, "\\partial "],
+  [/∇/g, "\\nabla "],
+  [/∆/g, "\\Delta "],
+  [/α/g, "\\alpha "],
+  [/β/g, "\\beta "],
+  [/γ/g, "\\gamma "],
+  [/δ/g, "\\delta "],
+];
+
+const SUPERSCRIPT_DIGITS: Record<string, string> = {
+  "⁰": "0",
+  "¹": "1",
+  "²": "2",
+  "³": "3",
+  "⁴": "4",
+  "⁵": "5",
+  "⁶": "6",
+  "⁷": "7",
+  "⁸": "8",
+  "⁹": "9",
+};
+
+const SUBSCRIPT_DIGITS: Record<string, string> = {
+  "₀": "0",
+  "₁": "1",
+  "₂": "2",
+  "₃": "3",
+  "₄": "4",
+  "₅": "5",
+  "₆": "6",
+  "₇": "7",
+  "₈": "8",
+  "₉": "9",
+};
+
+function normalizeScriptDigits(value: string, digits: Record<string, string>, marker: "^" | "_") {
+  const scriptChars = Object.keys(digits).join("");
+  const pattern = new RegExp(`[${scriptChars}]+`, "g");
+
+  return value.replace(pattern, (match) => {
+    const normalized = [...match].map((char) => digits[char] ?? char).join("");
+    return normalized.length === 1 ? `${marker}${normalized}` : `${marker}{${normalized}}`;
+  });
+}
+
+function normalizeLatexSegment(value: string) {
+  let normalized = value;
+
+  for (const [pattern, replacement] of UNICODE_LATEX_REPLACEMENTS) {
+    normalized = normalized.replace(pattern, replacement);
+  }
+
+  normalized = normalizeScriptDigits(normalized, SUPERSCRIPT_DIGITS, "^");
+  normalized = normalizeScriptDigits(normalized, SUBSCRIPT_DIGITS, "_");
+  normalized = normalized.replace(/\s+([_^])/g, "$1");
+  normalized = normalized.replace(/([_^])\s+/g, "$1");
+  normalized = normalized.replace(/[ \t]{2,}/g, " ");
+
+  return normalized.trim();
+}
+
+function normalizeDelimitedMath(value: string) {
+  return value.replace(/(\${1,2})([\s\S]*?)(\1)/g, (match, delimiter: string, content: string) => {
+    if (!content.trim()) {
+      return match;
+    }
+
+    const normalized = normalizeLatexSegment(content);
+    if (delimiter === "$$") {
+      return `$$\n${normalized}\n$$`;
+    }
+
+    return `$${normalized}$`;
+  });
+}
+
+export function normalizeLatex(value: string) {
+  return normalizeLatexSegment(value);
+}
+
+export function normalizeTextMathToLatex(value: string) {
+  return normalizeDelimitedMath(value);
+}

--- a/lib/notes/markdown.test.ts
+++ b/lib/notes/markdown.test.ts
@@ -170,4 +170,32 @@ describe("serializeNoteDocumentToMarkdown", () => {
       "Second block moved first\n\nFirst block moved second",
     );
   });
+
+  it("serializes inline math blocks with adjacent text as one inline sentence", () => {
+    const document: NoteDocument = {
+      time: 1,
+      blocks: [
+        {
+          type: "paragraph",
+          data: {
+            text: "Use",
+          },
+        },
+        {
+          type: "inlineMath",
+          data: {
+            latex: "\\sqrt{x^2}",
+          },
+        },
+        {
+          type: "paragraph",
+          data: {
+            text: "here.",
+          },
+        },
+      ],
+    };
+
+    expect(serializeNoteDocumentToMarkdown(document)).toBe("Use $\\sqrt{x^2}$ here.");
+  });
 });

--- a/lib/notes/markdown.ts
+++ b/lib/notes/markdown.ts
@@ -134,16 +134,45 @@ function serializeBlock(block: NoteBlock) {
     }
     case "math":
       return `$$\n${block.data.latex}\n$$`;
+    case "inlineMath":
+      return `$${block.data.latex}$`;
     default:
       return "";
   }
 }
 
+function getBlockSeparator(previous: NoteBlock | undefined, current: NoteBlock) {
+  if (
+    previous &&
+    (previous.type === "inlineMath" || current.type === "inlineMath") &&
+    (previous.type === "paragraph" || previous.type === "inlineMath") &&
+    (current.type === "paragraph" || current.type === "inlineMath")
+  ) {
+    return " ";
+  }
+
+  return "\n\n";
+}
+
 export function serializeNoteDocumentToMarkdown(document: NoteDocument) {
-  return document.blocks
-    .map((block) => serializeBlock(block))
-    .filter((block) => block.length > 0)
-    .join("\n\n");
+  const sections: string[] = [];
+  let previousSerializedBlock: NoteBlock | undefined;
+
+  for (const block of document.blocks) {
+    const serialized = serializeBlock(block);
+    if (serialized.length === 0) {
+      continue;
+    }
+
+    if (sections.length > 0) {
+      sections.push(getBlockSeparator(previousSerializedBlock, block));
+    }
+
+    sections.push(serialized);
+    previousSerializedBlock = block;
+  }
+
+  return sections.join("");
 }
 
 export function createNoteContent(document: NoteDocument): NoteContent {

--- a/lib/notes/math-regions.test.ts
+++ b/lib/notes/math-regions.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
+import type { NoteDocument } from "@/lib/notes/types";
+
+describe("normalizeNoteLatexRegions", () => {
+  it("splits delimited inline math into math blocks", () => {
+    const document: NoteDocument = {
+      time: 1,
+      blocks: [
+        {
+          type: "paragraph",
+          data: {
+            text: "Use $x^2 + y^2 = z^2$ for the distance relation.",
+          },
+        },
+      ],
+    };
+
+    expect(normalizeNoteLatexRegions(document).blocks).toEqual([
+      {
+        type: "paragraph",
+        data: {
+          text: "Use",
+        },
+      },
+      {
+        type: "math",
+        data: {
+          latex: "x^2 + y^2 = z^2",
+        },
+      },
+      {
+        type: "paragraph",
+        data: {
+          text: "for the distance relation.",
+        },
+      },
+    ]);
+  });
+
+  it("converts imported inline math spans to math blocks", () => {
+    const document: NoteDocument = {
+      time: 1,
+      blocks: [
+        {
+          type: "paragraph",
+          data: {
+            text: 'Area <span class="note-inline-math" data-latex="\\pi r^2">$\\pi r^2$</span>',
+          },
+        },
+      ],
+    };
+
+    expect(normalizeNoteLatexRegions(document).blocks).toEqual([
+      {
+        type: "paragraph",
+        data: {
+          text: "Area",
+        },
+      },
+      {
+        type: "math",
+        data: {
+          latex: "\\pi r^2",
+        },
+      },
+    ]);
+  });
+
+  it("converts standalone raw LaTeX lines", () => {
+    const document: NoteDocument = {
+      time: 1,
+      blocks: [
+        {
+          type: "paragraph",
+          data: {
+            text: "Before<br>x^2 + y_2 = 4<br>After",
+          },
+        },
+      ],
+    };
+
+    expect(normalizeNoteLatexRegions(document).blocks).toEqual([
+      {
+        type: "paragraph",
+        data: {
+          text: "Before",
+        },
+      },
+      {
+        type: "math",
+        data: {
+          latex: "x^2 + y_2 = 4",
+        },
+      },
+      {
+        type: "paragraph",
+        data: {
+          text: "After",
+        },
+      },
+    ]);
+  });
+});

--- a/lib/notes/math-regions.test.ts
+++ b/lib/notes/math-regions.test.ts
@@ -3,7 +3,7 @@ import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
 import type { NoteDocument } from "@/lib/notes/types";
 
 describe("normalizeNoteLatexRegions", () => {
-  it("keeps single-dollar math inline inside paragraph blocks", () => {
+  it("converts single-dollar math to inline math blocks", () => {
     const document: NoteDocument = {
       time: 1,
       blocks: [
@@ -20,13 +20,25 @@ describe("normalizeNoteLatexRegions", () => {
       {
         type: "paragraph",
         data: {
-          text: 'Use <span class="note-inline-math" data-latex="x^2 + y^2 = z^2">$x^2 + y^2 = z^2$</span> for the distance relation.',
+          text: "Use",
+        },
+      },
+      {
+        type: "inlineMath",
+        data: {
+          latex: "x^2 + y^2 = z^2",
+        },
+      },
+      {
+        type: "paragraph",
+        data: {
+          text: "for the distance relation.",
         },
       },
     ]);
   });
 
-  it("keeps imported inline math spans inline", () => {
+  it("converts imported inline math spans to inline math blocks", () => {
     const document: NoteDocument = {
       time: 1,
       blocks: [
@@ -43,7 +55,13 @@ describe("normalizeNoteLatexRegions", () => {
       {
         type: "paragraph",
         data: {
-          text: 'Area <span class="note-inline-math" data-latex="\\pi r^2">$\\pi r^2$</span>',
+          text: "Area",
+        },
+      },
+      {
+        type: "inlineMath",
+        data: {
+          latex: "\\pi r^2",
         },
       },
     ]);

--- a/lib/notes/math-regions.test.ts
+++ b/lib/notes/math-regions.test.ts
@@ -3,7 +3,7 @@ import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
 import type { NoteDocument } from "@/lib/notes/types";
 
 describe("normalizeNoteLatexRegions", () => {
-  it("splits delimited inline math into math blocks", () => {
+  it("keeps single-dollar math inline inside paragraph blocks", () => {
     const document: NoteDocument = {
       time: 1,
       blocks: [
@@ -20,25 +20,13 @@ describe("normalizeNoteLatexRegions", () => {
       {
         type: "paragraph",
         data: {
-          text: "Use",
-        },
-      },
-      {
-        type: "math",
-        data: {
-          latex: "x^2 + y^2 = z^2",
-        },
-      },
-      {
-        type: "paragraph",
-        data: {
-          text: "for the distance relation.",
+          text: 'Use <span class="note-inline-math" data-latex="x^2 + y^2 = z^2">$x^2 + y^2 = z^2$</span> for the distance relation.',
         },
       },
     ]);
   });
 
-  it("converts imported inline math spans to math blocks", () => {
+  it("keeps imported inline math spans inline", () => {
     const document: NoteDocument = {
       time: 1,
       blocks: [
@@ -55,13 +43,42 @@ describe("normalizeNoteLatexRegions", () => {
       {
         type: "paragraph",
         data: {
-          text: "Area",
+          text: 'Area <span class="note-inline-math" data-latex="\\pi r^2">$\\pi r^2$</span>',
+        },
+      },
+    ]);
+  });
+
+  it("splits display math into math blocks", () => {
+    const document: NoteDocument = {
+      time: 1,
+      blocks: [
+        {
+          type: "paragraph",
+          data: {
+            text: "Before $$x^2 + y^2 = z^2$$ after",
+          },
+        },
+      ],
+    };
+
+    expect(normalizeNoteLatexRegions(document).blocks).toEqual([
+      {
+        type: "paragraph",
+        data: {
+          text: "Before",
         },
       },
       {
         type: "math",
         data: {
-          latex: "\\pi r^2",
+          latex: "x^2 + y^2 = z^2",
+        },
+      },
+      {
+        type: "paragraph",
+        data: {
+          text: "after",
         },
       },
     ]);

--- a/lib/notes/math-regions.ts
+++ b/lib/notes/math-regions.ts
@@ -10,12 +10,15 @@ type RegionSegment =
       type: "math";
       latex: string;
     };
+type RichTextNoteBlock = Extract<
+  NoteBlock,
+  { type: "paragraph" | "header" | "quote" }
+>;
 
 const INLINE_MATH_SPAN_RE =
   /<span[^>]*class="[^"]*\bnote-inline-math\b[^"]*"[^>]*data-latex="([^"]*)"[^>]*>[\s\S]*?<\/span>/gi;
 const LATEX_REGION_RE =
   /\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\]|(?<!\$)\$(?!\$)([^$\r\n]+?)(?<!\$)\$(?!\$)|\\\(([\s\S]+?)\\\)/g;
-const HTML_TAG_RE = /<\/?[a-z][\s\S]*?>/i;
 const LATEX_SIGNAL_RE = /\\[A-Za-z]+|[\^_{}=<>≤≥≠≈±×÷∞√∑∫→⇒∈∉∂∇∆αβγδθλμσπΩ]/;
 
 function decodeHtml(value: string) {
@@ -26,6 +29,24 @@ function decodeHtml(value: string) {
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'");
+}
+
+function escapeHtmlAttr(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function inlineMathSpan(latex: string) {
+  const escaped = escapeHtmlAttr(latex);
+  return `<span class="note-inline-math" data-latex="${escaped}">$${latex}$</span>`;
+}
+
+function hasInlineMathSpan(value: string) {
+  INLINE_MATH_SPAN_RE.lastIndex = 0;
+  return INLINE_MATH_SPAN_RE.test(value);
 }
 
 function richTextToPlainText(value: string) {
@@ -88,17 +109,26 @@ function splitLatexRegions(value: string): RegionSegment[] {
   const plainText = richTextToPlainText(value);
   const segments: RegionSegment[] = [];
   let lastIndex = 0;
+  let pendingText = "";
 
   for (const match of plainText.matchAll(LATEX_REGION_RE)) {
-    pushTextSegment(segments, plainText.slice(lastIndex, match.index));
+    pendingText += plainText.slice(lastIndex, match.index);
+    const isInline = typeof match[3] === "string" || typeof match[4] === "string";
     const latex = normalizeLatex(match[1] ?? match[2] ?? match[3] ?? match[4] ?? "");
     if (latex) {
-      segments.push({ type: "math", latex });
+      if (isInline) {
+        pendingText += inlineMathSpan(latex);
+      } else {
+        pushTextSegment(segments, pendingText);
+        pendingText = "";
+        segments.push({ type: "math", latex });
+      }
     }
     lastIndex = (match.index ?? 0) + match[0].length;
   }
 
-  pushTextSegment(segments, plainText.slice(lastIndex));
+  pendingText += plainText.slice(lastIndex);
+  pushTextSegment(segments, pendingText);
 
   return segments;
 }
@@ -121,6 +151,35 @@ function mathBlock(latex: string): NoteBlock {
   };
 }
 
+function richTextBlockLike(block: RichTextNoteBlock, text: string): NoteBlock {
+  if (block.type === "header") {
+    return {
+      ...block,
+      data: {
+        ...block.data,
+        text,
+      },
+    };
+  }
+
+  if (block.type === "quote") {
+    return {
+      ...block,
+      data: {
+        ...block.data,
+        text,
+      },
+    };
+  }
+
+  return {
+    ...block,
+    data: {
+      text,
+    },
+  };
+}
+
 function convertRichTextBlock(block: NoteBlock): NoteBlock[] {
   if (
     block.type !== "paragraph" &&
@@ -131,13 +190,25 @@ function convertRichTextBlock(block: NoteBlock): NoteBlock[] {
   }
 
   const sourceText = block.type === "quote" ? block.data.text : block.data.text;
-  if (!sourceText || (!sourceText.includes("$") && !sourceText.includes("\\") && !HTML_TAG_RE.test(sourceText) && !LATEX_SIGNAL_RE.test(sourceText))) {
+  const signalText = sourceText.replace(/<[^>]+>/g, "");
+  if (
+    !sourceText ||
+    (!sourceText.includes("$") &&
+      !sourceText.includes("\\") &&
+      !hasInlineMathSpan(sourceText) &&
+      !LATEX_SIGNAL_RE.test(signalText))
+  ) {
     return [block];
   }
 
   const segments = splitLatexRegions(sourceText);
-  if (segments.length === 0 || segments.every((segment) => segment.type === "text")) {
+  if (segments.length === 0) {
     return [block];
+  }
+
+  if (segments.every((segment) => segment.type === "text")) {
+    const text = segments.map((segment) => segment.value).join("\n");
+    return text === sourceText ? [block] : [richTextBlockLike(block, text)];
   }
 
   return segments.map((segment) =>

--- a/lib/notes/math-regions.ts
+++ b/lib/notes/math-regions.ts
@@ -1,0 +1,166 @@
+import { normalizeLatex } from "@/lib/math/latex";
+import type { NoteBlock, NoteDocument } from "@/lib/notes/types";
+
+type RegionSegment =
+  | {
+      type: "text";
+      value: string;
+    }
+  | {
+      type: "math";
+      latex: string;
+    };
+
+const INLINE_MATH_SPAN_RE =
+  /<span[^>]*class="[^"]*\bnote-inline-math\b[^"]*"[^>]*data-latex="([^"]*)"[^>]*>[\s\S]*?<\/span>/gi;
+const LATEX_REGION_RE =
+  /\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\]|(?<!\$)\$(?!\$)([^$\r\n]+?)(?<!\$)\$(?!\$)|\\\(([\s\S]+?)\\\)/g;
+const HTML_TAG_RE = /<\/?[a-z][\s\S]*?>/i;
+const LATEX_SIGNAL_RE = /\\[A-Za-z]+|[\^_{}=<>≤≥≠≈±×÷∞√∑∫→⇒∈∉∂∇∆αβγδθλμσπΩ]/;
+
+function decodeHtml(value: string) {
+  return value
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function richTextToPlainText(value: string) {
+  return decodeHtml(
+    value
+      .replace(INLINE_MATH_SPAN_RE, (_match, latex: string) => `$${latex}$`)
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/(p|div|li|blockquote|h[1-6])>/gi, "\n")
+      .replace(/<[^>]+>/g, ""),
+  ).replace(/\n{3,}/g, "\n\n");
+}
+
+function isStandaloneLatexLine(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 240 || !LATEX_SIGNAL_RE.test(trimmed)) {
+    return false;
+  }
+
+  if (/^\\begin\{[^}]+\}[\s\S]*\\end\{[^}]+\}$/.test(trimmed)) {
+    return true;
+  }
+
+  const wordCount = (trimmed.match(/[A-Za-z]{3,}/g) ?? []).length;
+  const operatorCount = (trimmed.match(/[=+\-*/^_<>≤≥≠≈]/g) ?? []).length;
+
+  return operatorCount > 0 && wordCount <= 3;
+}
+
+function pushTextSegment(segments: RegionSegment[], value: string) {
+  const normalized = value.replace(/[ \t]+\n/g, "\n").replace(/\n[ \t]+/g, "\n");
+  const trimmed = normalized.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  const lines = trimmed.split(/\n+/);
+  let pendingText: string[] = [];
+
+  const flushText = () => {
+    const text = pendingText.join("\n").trim();
+    if (text) {
+      segments.push({ type: "text", value: text });
+    }
+    pendingText = [];
+  };
+
+  for (const line of lines) {
+    if (isStandaloneLatexLine(line)) {
+      flushText();
+      segments.push({ type: "math", latex: normalizeLatex(line) });
+    } else {
+      pendingText.push(line);
+    }
+  }
+
+  flushText();
+}
+
+function splitLatexRegions(value: string): RegionSegment[] {
+  const plainText = richTextToPlainText(value);
+  const segments: RegionSegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of plainText.matchAll(LATEX_REGION_RE)) {
+    pushTextSegment(segments, plainText.slice(lastIndex, match.index));
+    const latex = normalizeLatex(match[1] ?? match[2] ?? match[3] ?? match[4] ?? "");
+    if (latex) {
+      segments.push({ type: "math", latex });
+    }
+    lastIndex = (match.index ?? 0) + match[0].length;
+  }
+
+  pushTextSegment(segments, plainText.slice(lastIndex));
+
+  return segments;
+}
+
+function paragraphBlock(text: string): NoteBlock {
+  return {
+    type: "paragraph",
+    data: {
+      text,
+    },
+  };
+}
+
+function mathBlock(latex: string): NoteBlock {
+  return {
+    type: "math",
+    data: {
+      latex,
+    },
+  };
+}
+
+function convertRichTextBlock(block: NoteBlock): NoteBlock[] {
+  if (
+    block.type !== "paragraph" &&
+    block.type !== "header" &&
+    block.type !== "quote"
+  ) {
+    return [block];
+  }
+
+  const sourceText = block.type === "quote" ? block.data.text : block.data.text;
+  if (!sourceText || (!sourceText.includes("$") && !sourceText.includes("\\") && !HTML_TAG_RE.test(sourceText) && !LATEX_SIGNAL_RE.test(sourceText))) {
+    return [block];
+  }
+
+  const segments = splitLatexRegions(sourceText);
+  if (segments.length === 0 || segments.every((segment) => segment.type === "text")) {
+    return [block];
+  }
+
+  return segments.map((segment) =>
+    segment.type === "math" ? mathBlock(segment.latex) : paragraphBlock(segment.value),
+  );
+}
+
+export function normalizeNoteLatexRegions(document: NoteDocument): NoteDocument {
+  let changed = false;
+  const blocks = document.blocks.flatMap((block) => {
+    const converted = convertRichTextBlock(block);
+    if (converted.length !== 1 || converted[0] !== block) {
+      changed = true;
+    }
+    return converted;
+  }) as NoteBlock[];
+
+  if (!changed) {
+    return document;
+  }
+
+  return {
+    ...document,
+    blocks,
+  };
+}

--- a/lib/notes/math-regions.ts
+++ b/lib/notes/math-regions.ts
@@ -9,6 +9,10 @@ type RegionSegment =
   | {
       type: "math";
       latex: string;
+    }
+  | {
+      type: "inlineMath";
+      latex: string;
     };
 type RichTextNoteBlock = Extract<
   NoteBlock,
@@ -29,19 +33,6 @@ function decodeHtml(value: string) {
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'");
-}
-
-function escapeHtmlAttr(value: string) {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-function inlineMathSpan(latex: string) {
-  const escaped = escapeHtmlAttr(latex);
-  return `<span class="note-inline-math" data-latex="${escaped}">$${latex}$</span>`;
 }
 
 function hasInlineMathSpan(value: string) {
@@ -117,7 +108,9 @@ function splitLatexRegions(value: string): RegionSegment[] {
     const latex = normalizeLatex(match[1] ?? match[2] ?? match[3] ?? match[4] ?? "");
     if (latex) {
       if (isInline) {
-        pendingText += inlineMathSpan(latex);
+        pushTextSegment(segments, pendingText);
+        pendingText = "";
+        segments.push({ type: "inlineMath", latex });
       } else {
         pushTextSegment(segments, pendingText);
         pendingText = "";
@@ -145,6 +138,15 @@ function paragraphBlock(text: string): NoteBlock {
 function mathBlock(latex: string): NoteBlock {
   return {
     type: "math",
+    data: {
+      latex,
+    },
+  };
+}
+
+function inlineMathBlock(latex: string): NoteBlock {
+  return {
+    type: "inlineMath",
     data: {
       latex,
     },
@@ -211,9 +213,17 @@ function convertRichTextBlock(block: NoteBlock): NoteBlock[] {
     return text === sourceText ? [block] : [richTextBlockLike(block, text)];
   }
 
-  return segments.map((segment) =>
-    segment.type === "math" ? mathBlock(segment.latex) : paragraphBlock(segment.value),
-  );
+  return segments.map((segment) => {
+    if (segment.type === "math") {
+      return mathBlock(segment.latex);
+    }
+
+    if (segment.type === "inlineMath") {
+      return inlineMathBlock(segment.latex);
+    }
+
+    return paragraphBlock(segment.value);
+  });
 }
 
 export function normalizeNoteLatexRegions(document: NoteDocument): NoteDocument {

--- a/lib/notes/parse-markdown.test.ts
+++ b/lib/notes/parse-markdown.test.ts
@@ -11,7 +11,19 @@ describe("parseMarkdownToNoteDocument", () => {
       {
         type: "paragraph",
         data: {
-          text: 'Use <span class="note-inline-math" data-latex="\\sqrt{x^2}">$\\sqrt{x^2}$</span> here.',
+          text: "Use",
+        },
+      },
+      {
+        type: "math",
+        data: {
+          latex: "\\sqrt{x^2}",
+        },
+      },
+      {
+        type: "paragraph",
+        data: {
+          text: "here.",
         },
       },
       {

--- a/lib/notes/parse-markdown.test.ts
+++ b/lib/notes/parse-markdown.test.ts
@@ -11,19 +11,7 @@ describe("parseMarkdownToNoteDocument", () => {
       {
         type: "paragraph",
         data: {
-          text: "Use",
-        },
-      },
-      {
-        type: "math",
-        data: {
-          latex: "\\sqrt{x^2}",
-        },
-      },
-      {
-        type: "paragraph",
-        data: {
-          text: "here.",
+          text: 'Use <span class="note-inline-math" data-latex="\\sqrt{x^2}">$\\sqrt{x^2}$</span> here.',
         },
       },
       {

--- a/lib/notes/parse-markdown.test.ts
+++ b/lib/notes/parse-markdown.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parseMarkdownToNoteDocument } from "@/lib/notes/parse-markdown";
+
+describe("parseMarkdownToNoteDocument", () => {
+  it("normalizes inline and block math to LaTeX", () => {
+    const document = parseMarkdownToNoteDocument(
+      ["Use $√(x²)$ here.", "", "$$", "πr² ≥ 0", "$$"].join("\n"),
+    );
+
+    expect(document.blocks).toMatchObject([
+      {
+        type: "paragraph",
+        data: {
+          text: 'Use <span class="note-inline-math" data-latex="\\sqrt{x^2}">$\\sqrt{x^2}$</span> here.',
+        },
+      },
+      {
+        type: "math",
+        data: {
+          latex: "\\pi r^2 \\ge 0",
+        },
+      },
+    ]);
+  });
+});

--- a/lib/notes/parse-markdown.test.ts
+++ b/lib/notes/parse-markdown.test.ts
@@ -11,7 +11,19 @@ describe("parseMarkdownToNoteDocument", () => {
       {
         type: "paragraph",
         data: {
-          text: 'Use <span class="note-inline-math" data-latex="\\sqrt{x^2}">$\\sqrt{x^2}$</span> here.',
+          text: "Use",
+        },
+      },
+      {
+        type: "inlineMath",
+        data: {
+          latex: "\\sqrt{x^2}",
+        },
+      },
+      {
+        type: "paragraph",
+        data: {
+          text: "here.",
         },
       },
       {

--- a/lib/notes/parse-markdown.ts
+++ b/lib/notes/parse-markdown.ts
@@ -9,61 +9,13 @@
  *   - Block math ($$…$$)
  *   - Blockquotes (>)
  *   - Ordered / unordered / checklist lists
- *   - Inline math ($…$) inside paragraph text
+ *   - Inline math ($…$) as inline math blocks
  *   - Paragraphs (everything else)
  */
 
 import type { NoteBlock, NoteDocument, NoteListBlockData, NoteListItem } from "@/lib/notes/types";
 import { normalizeLatex } from "@/lib/math/latex";
 import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function escapeHtmlAttr(value: string) {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-/**
- * Detect and replace inline math ($…$) within a single line of text.
- *
- * Heuristic: we match $content$ where content is non-empty and contains at
- * least one LaTeX-typical character (backslash, caret, underscore, or braces)
- * OR is a short single-token that doesn't look like a shell / currency value.
- * This avoids false-positives on "$HOME", "$5.99", etc.
- *
- * The result is a <span class="note-inline-math" data-latex="…"> element so
- * the serializer and renderer can round-trip it cleanly.
- */
-function processInlineMath(line: string): string {
-  // Avoid matching $$ (block math uses doubled dollar signs)
-  // Pattern: $<non-empty, non-newline content>$ — negative lookaround for $
-  const re = /(?<!\$)\$(?!\$)([^$\r\n]+?)(?<!\$)\$(?!\$)/g;
-
-  return line.replace(re, (_match, content: string) => {
-    const trimmed = content.trim();
-    if (!trimmed) return _match;
-
-    // Accept as inline math if content contains any LaTeX-specific char, or
-    // is a multi-character expression that can't be a bare shell identifier.
-    const hasLatexChar = /[\\^_{}]/.test(trimmed);
-    const isBareShellId = /^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed);
-    const isCurrency = /^\d/.test(trimmed);
-
-    if (!hasLatexChar && (isBareShellId || isCurrency)) {
-      return _match; // leave untouched
-    }
-
-    const latex = normalizeLatex(trimmed);
-
-    return `<span class="note-inline-math" data-latex="${escapeHtmlAttr(latex)}">$${latex}$</span>`;
-  });
-}
 
 function isListLine(line: string) {
   return /^[-*+]\s/.test(line) || /^\d+\.\s/.test(line);
@@ -149,7 +101,7 @@ export function parseMarkdownToNoteDocument(markdown: string): NoteDocument {
       blocks.push({
         type: "quote",
         data: {
-          text: quoteLines.map(processInlineMath).join("<br>"),
+          text: quoteLines.join("<br>"),
           caption: "",
           alignment: "left",
         },
@@ -174,10 +126,9 @@ export function parseMarkdownToNoteDocument(markdown: string): NoteDocument {
         const olMatch = itemLine.match(/^\d+\.\s+(.*)/);
         const ulMatch = itemLine.match(/^[-*+]\s+(.*)/);
         const rawContent = (clMatch?.[2] ?? olMatch?.[1] ?? ulMatch?.[1] ?? "").trim();
-        const content = processInlineMath(rawContent);
         const checked = clMatch ? clMatch[1] !== " " : false;
         items.push({
-          content,
+          content: rawContent,
           meta: style === "checklist" ? { checked } : {},
           items: [],
         });
@@ -203,7 +154,7 @@ export function parseMarkdownToNoteDocument(markdown: string): NoteDocument {
       i++;
     }
     if (paragraphLines.length > 0) {
-      const text = paragraphLines.map(processInlineMath).join("<br>");
+      const text = paragraphLines.join("<br>");
       blocks.push({ type: "paragraph", data: { text } });
     }
   }

--- a/lib/notes/parse-markdown.ts
+++ b/lib/notes/parse-markdown.ts
@@ -15,6 +15,7 @@
 
 import type { NoteBlock, NoteDocument, NoteListBlockData, NoteListItem } from "@/lib/notes/types";
 import { normalizeLatex } from "@/lib/math/latex";
+import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -207,5 +208,5 @@ export function parseMarkdownToNoteDocument(markdown: string): NoteDocument {
     }
   }
 
-  return { time: Date.now(), blocks };
+  return normalizeNoteLatexRegions({ time: Date.now(), blocks });
 }

--- a/lib/notes/parse-markdown.ts
+++ b/lib/notes/parse-markdown.ts
@@ -14,6 +14,7 @@
  */
 
 import type { NoteBlock, NoteDocument, NoteListBlockData, NoteListItem } from "@/lib/notes/types";
+import { normalizeLatex } from "@/lib/math/latex";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -57,7 +58,9 @@ function processInlineMath(line: string): string {
       return _match; // leave untouched
     }
 
-    return `<span class="note-inline-math" data-latex="${escapeHtmlAttr(trimmed)}">$${trimmed}$</span>`;
+    const latex = normalizeLatex(trimmed);
+
+    return `<span class="note-inline-math" data-latex="${escapeHtmlAttr(latex)}">$${latex}$</span>`;
   });
 }
 
@@ -119,7 +122,7 @@ export function parseMarkdownToNoteDocument(markdown: string): NoteDocument {
         i++;
       }
       i++; // skip closing $$
-      blocks.push({ type: "math", data: { latex: mathLines.join("\n") } });
+      blocks.push({ type: "math", data: { latex: normalizeLatex(mathLines.join("\n")) } });
       continue;
     }
 

--- a/lib/notes/persistence.ts
+++ b/lib/notes/persistence.ts
@@ -1,4 +1,5 @@
 import { serializeNoteDocumentToMarkdown } from "@/lib/notes/markdown";
+import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
 import { emptyNoteDocument, NoteDocumentSchema, type NoteDocument } from "@/lib/notes/types";
 
 export type NormalizedNoteWriteContent = {
@@ -7,7 +8,9 @@ export type NormalizedNoteWriteContent = {
 };
 
 export function normalizeNoteWriteContent(value: unknown = emptyNoteDocument): NormalizedNoteWriteContent {
-  const document = NoteDocumentSchema.parse(value ?? emptyNoteDocument);
+  const document = normalizeNoteLatexRegions(
+    NoteDocumentSchema.parse(value ?? emptyNoteDocument),
+  );
 
   return {
     document,

--- a/lib/notes/records.ts
+++ b/lib/notes/records.ts
@@ -1,4 +1,5 @@
 import { createNoteContent } from "@/lib/notes/markdown";
+import { normalizeNoteLatexRegions } from "@/lib/notes/math-regions";
 import { emptyNoteDocument, NoteDocumentSchema, type NoteContent, type NoteDocument } from "@/lib/notes/types";
 
 export type NoteSourceType = "manual" | "upload";
@@ -66,7 +67,7 @@ export function normalizeNoteDocument(value: unknown): NoteDocument {
     return createEmptyDocument();
   }
 
-  return parsed.data;
+  return normalizeNoteLatexRegions(parsed.data);
 }
 
 function normalizeEmbedding(value: unknown) {

--- a/lib/notes/types.ts
+++ b/lib/notes/types.ts
@@ -9,7 +9,8 @@ export type NoteBlockType =
   | "quote"
   | "code"
   | "image"
-  | "math";
+  | "math"
+  | "inlineMath";
 
 export type NoteParagraphBlockData = {
   text: string;
@@ -68,6 +69,8 @@ export type NoteMathBlockData = {
   latex: string;
 };
 
+export type NoteInlineMathBlockData = NoteMathBlockData;
+
 export type NoteBlock =
   | OutputBlockData<"paragraph", NoteParagraphBlockData>
   | OutputBlockData<"header", NoteHeaderBlockData>
@@ -75,7 +78,8 @@ export type NoteBlock =
   | OutputBlockData<"quote", NoteQuoteBlockData>
   | OutputBlockData<"code", NoteCodeBlockData>
   | OutputBlockData<"image", NoteImageBlockData>
-  | OutputBlockData<"math", NoteMathBlockData>;
+  | OutputBlockData<"math", NoteMathBlockData>
+  | OutputBlockData<"inlineMath", NoteInlineMathBlockData>;
 
 export type NoteDocument = Omit<OutputData, "blocks"> & {
   blocks: NoteBlock[];
@@ -185,6 +189,15 @@ const mathBlockSchema = z.object({
   tunes: z.record(z.string(), z.unknown()).optional(),
 });
 
+const inlineMathBlockSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal("inlineMath"),
+  data: z.object({
+    latex: z.string(),
+  }),
+  tunes: z.record(z.string(), z.unknown()).optional(),
+});
+
 export const NoteBlockSchema = z.discriminatedUnion("type", [
   paragraphBlockSchema,
   headerBlockSchema,
@@ -193,6 +206,7 @@ export const NoteBlockSchema = z.discriminatedUnion("type", [
   codeBlockSchema,
   imageBlockSchema,
   mathBlockSchema,
+  inlineMathBlockSchema,
 ]);
 
 export const NoteDocumentSchema: z.ZodType<NoteDocument> = z


### PR DESCRIPTION
## Summary

Implements #58.

- Add shared LaTeX normalization for common typed math symbols, superscripts/subscripts, inline math, and display math.
- Route quiz and flashcard markdown display through a shared KaTeX-backed `LatexMarkdown` renderer.
- Normalize user-edited quiz and flashcard math on blur and again before save/evaluation payloads.
- Normalize note MathLive blocks, note block conversion to math, and imported markdown inline/display math before storage.
- Detect LaTeX regions in note rich-text blocks and promote display/standalone regions into real note `math` blocks on editor load, autosave, paste/import, and API persistence.
- Keep single-dollar `$...$` and `\(...\)` note math inline using the existing `note-inline-math` span format.
- Add accessible labels for study library action menu triggers used by the updated tests.

## Verification

- `pnpm test lib/notes/math-regions.test.ts lib/notes/parse-markdown.test.ts lib/notes/markdown.test.ts lib/notes/persistence.test.ts components/note-editor/note-editor.test.tsx`
- `pnpm lint` passes with one existing warning in `components/note-editor/code-block-view.tsx`
- `pnpm test`
- `pnpm build`