### PR TITLE
feat(study): Cheat sheet writing — split-view notes + hand-written cheat sheets

### DIFF
--- a/app/(app)/study/associations/page.tsx
+++ b/app/(app)/study/associations/page.tsx
@@ -1,12 +1,74 @@
-import { StudyMethodPage } from "@/components/study/study-method-page";
+import { connection } from "next/server";
+import { count, desc, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { mindMap, mindMapEdge, mindMapNode, note } from "@/lib/db/schema";
+import { requireServerSession } from "@/lib/auth-session";
+import { AssociationsClient } from "@/app/associations/associations-client";
+import { rowToMindMapSummary } from "@/lib/mind-maps/records";
+import { hasMindMapStorage } from "@/lib/mind-maps/storage";
 
-export default function AssociationsPage() {
+export default async function AssociationsPage() {
+  await connection();
+
+  const session = await requireServerSession("/study/associations");
+  const storageReady = await hasMindMapStorage();
+
+  if (!storageReady) {
+    return <AssociationsClient initialMaps={[]} notes={[]} storageReady={false} />;
+  }
+
+  const [maps, noteRows] = await Promise.all([
+    db
+      .select()
+      .from(mindMap)
+      .where(eq(mindMap.userId, session.user.id))
+      .orderBy(desc(mindMap.updatedAt)),
+    db
+      .select({
+        id: note.id,
+        title: note.title,
+        embedding: note.embedding,
+        updatedAt: note.updatedAt,
+      })
+      .from(note)
+      .where(eq(note.userId, session.user.id))
+      .orderBy(desc(note.updatedAt)),
+  ]);
+
+  const mapIds = maps.map((map) => map.id);
+  const nodeCounts = new Map<string, number>();
+  const edgeCounts = new Map<string, number>();
+
+  if (mapIds.length > 0) {
+    const [nodeRows, edgeRows] = await Promise.all([
+      db
+        .select({ mapId: mindMapNode.mapId, total: count() })
+        .from(mindMapNode)
+        .where(inArray(mindMapNode.mapId, mapIds))
+        .groupBy(mindMapNode.mapId),
+      db
+        .select({ mapId: mindMapEdge.mapId, total: count() })
+        .from(mindMapEdge)
+        .where(inArray(mindMapEdge.mapId, mapIds))
+        .groupBy(mindMapEdge.mapId),
+    ]);
+
+    for (const row of nodeRows) nodeCounts.set(row.mapId, Number(row.total));
+    for (const row of edgeRows) edgeCounts.set(row.mapId, Number(row.total));
+  }
+
   return (
-    <StudyMethodPage
-      title="Associations"
-      description="Build mental links between ideas so related concepts become easier to retrieve together."
-      detailTitle="Associations editor is scaffolded"
-      detailDescription="The interactive mind-map style editor is reserved for later work, but this page already anchors the flow in the shell."
+    <AssociationsClient
+      initialMaps={maps.map((map) =>
+        rowToMindMapSummary(map, nodeCounts.get(map.id) ?? 0, edgeCounts.get(map.id) ?? 0),
+      )}
+      notes={noteRows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        updatedAt: row.updatedAt.toISOString(),
+        hasEmbedding: Array.isArray(row.embedding) && row.embedding.length > 0,
+      }))}
+      storageReady
     />
   );
 }

--- a/app/(app)/study/cheat-sheet/page.tsx
+++ b/app/(app)/study/cheat-sheet/page.tsx
@@ -1,12 +1,98 @@
-import { StudyMethodPage } from "@/components/study/study-method-page";
+import { connection } from "next/server";
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { cheatSheet, note } from "@/lib/db/schema";
+import { requireServerSession } from "@/lib/auth-session";
+import { listUserClasses } from "@/lib/classes/queries";
+import { noteRecordToWorkspaceNote, sortWorkspaceNotes } from "@/lib/notes/records";
+import { rowToCheatSheet, sortCheatSheets } from "@/lib/cheat-sheets/records";
+import { hasCheatSheetStorage } from "@/lib/cheat-sheets/storage";
+import { NotesWorkspace } from "@/app/notes/notes-workspace";
+import { CheatSheetWorkspace } from "@/app/cheat-sheet/cheat-sheet-workspace";
 
-export default function CheatSheetPage() {
+export default async function CheatSheetPage() {
+  await connection();
+
+  const session = await requireServerSession("/study/cheat-sheet");
+  const storageReady = await hasCheatSheetStorage();
+
+  const [noteRows, classSummaries, sheetRows] = await Promise.all([
+    db
+      .select({
+        id: note.id,
+        title: note.title,
+        classId: note.classId,
+        content: note.content,
+        markdown: note.markdown,
+        sourceType: note.sourceType,
+        fileName: note.fileName,
+        mimeType: note.mimeType,
+        fileSize: note.fileSize,
+        embedding: note.embedding,
+        createdAt: note.createdAt,
+        updatedAt: note.updatedAt,
+      })
+      .from(note)
+      .where(eq(note.userId, session.user.id))
+      .orderBy(desc(note.updatedAt)),
+    listUserClasses(session.user.id),
+    storageReady
+      ? db
+          .select({
+            id: cheatSheet.id,
+            title: cheatSheet.title,
+            classId: cheatSheet.classId,
+            content: cheatSheet.content,
+            markdown: cheatSheet.markdown,
+            createdAt: cheatSheet.createdAt,
+            updatedAt: cheatSheet.updatedAt,
+          })
+          .from(cheatSheet)
+          .where(eq(cheatSheet.userId, session.user.id))
+          .orderBy(desc(cheatSheet.updatedAt))
+      : Promise.resolve([]),
+  ]);
+
+  const initialNotes = sortWorkspaceNotes(
+    noteRows.map((row) => noteRecordToWorkspaceNote(row)),
+  );
+  const notesClasses = classSummaries.map((item) => ({
+    id: item.courseId,
+    runId: item.runId,
+    title: item.title,
+    courseCode: item.courseCode,
+    noteCount: item.noteCount,
+  }));
+  const cheatSheetClasses = classSummaries.map((item) => ({
+    id: item.courseId,
+    title: item.title,
+    courseCode: item.courseCode,
+  }));
+  const initialCheatSheets = sortCheatSheets(
+    sheetRows.map((row) => rowToCheatSheet(row)),
+  );
+
   return (
-    <StudyMethodPage
-      title="Cheat sheet writing"
-      description="Condense the important ideas into a compact summary to force prioritization and better recall."
-      detailTitle="Cheat sheet workspace is scaffolded"
-      detailDescription="The future split-pane note + editor interface will live here once the writing workflow is implemented."
-    />
+    <div className="grid h-full min-h-0 overflow-hidden rounded-[var(--radius-xl)] border border-border lg:grid-cols-2">
+      {/* Left: existing Notes workspace (reused, fully editable) */}
+      <div className="min-h-0 overflow-hidden border-b border-border lg:border-b-0 lg:border-r">
+        <NotesWorkspace
+          initialNotes={initialNotes}
+          classes={notesClasses}
+          initialClassId={null}
+          shouldCreateOnMount={false}
+          resetHref="/study/cheat-sheet"
+        />
+      </div>
+
+      {/* Right: cheat-sheet workspace (you write these by hand) */}
+      <div className="min-h-0 overflow-hidden">
+        <CheatSheetWorkspace
+          initialCheatSheets={initialCheatSheets}
+          classes={cheatSheetClasses}
+          storageReady={storageReady}
+        />
+      </div>
+    </div>
   );
 }

--- a/app/(app)/study/page.tsx
+++ b/app/(app)/study/page.tsx
@@ -7,7 +7,7 @@ const studyPages = [
   { href: "/study/feynman", title: "Feynman", description: "Explanation-first study workflow scaffold.", live: false },
   { href: "/study/active-recall", title: "Active recall", description: "Timed bullet-point recall scaffold.", live: false },
   { href: "/study/cheat-sheet", title: "Cheat sheet", description: "Split-pane note and summary scaffold.", live: false },
-  { href: "/study/associations", title: "Associations", description: "Mind-map style association builder scaffold.", live: false },
+  { href: "/study/associations", title: "Associations", description: "Mind-map style association builder.", live: true },
   { href: "/study/spaced-repetition", title: "Spaced repetition", description: "Review scheduling scaffold.", live: false },
 ] as const;
 

--- a/app/(app)/study/page.tsx
+++ b/app/(app)/study/page.tsx
@@ -6,7 +6,7 @@ const studyPages = [
   { href: "/study/pomodoro", title: "Pomodoro", description: "A real local timer you can use today.", live: true },
   { href: "/study/feynman", title: "Feynman", description: "Explanation-first study workflow scaffold.", live: false },
   { href: "/study/active-recall", title: "Active recall", description: "Timed bullet-point recall scaffold.", live: false },
-  { href: "/study/cheat-sheet", title: "Cheat sheet", description: "Split-pane note and summary scaffold.", live: false },
+  { href: "/study/cheat-sheet", title: "Cheat sheet", description: "Read your notes and hand-write a cheat sheet side by side.", live: true },
   { href: "/study/associations", title: "Associations", description: "Mind-map style association builder.", live: true },
   { href: "/study/spaced-repetition", title: "Spaced repetition", description: "Review scheduling scaffold.", live: false },
 ] as const;

--- a/app/api/cheat-sheets/[id]/route.ts
+++ b/app/api/cheat-sheets/[id]/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { db } from "@/lib/db";
+import { cheatSheet } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+import { assertClassBelongsToUser } from "@/lib/classes/queries";
+import { normalizeNoteWriteContent } from "@/lib/notes/persistence";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Helper: fetch a cheat sheet only if the authenticated user owns it
+async function getUserCheatSheet(userId: string, sheetId: string) {
+  const [found] = await db
+    .select()
+    .from(cheatSheet)
+    .where(and(eq(cheatSheet.id, sheetId), eq(cheatSheet.userId, userId)))
+    .limit(1);
+  return found ?? null;
+}
+
+// PATCH /api/cheat-sheets/:id - update title and/or content and/or class
+export async function PATCH(req: Request, ctx: RouteContext) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await ctx.params;
+  const existing = await getUserCheatSheet(session.user.id, id);
+  if (!existing) {
+    return NextResponse.json({ error: "Cheat sheet not found" }, { status: 404 });
+  }
+
+  let body: { title?: string; content?: unknown; classId?: string | null };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (typeof body.title === "string") {
+    updates.title = body.title.trim() || "Untitled";
+  }
+  if (body.content !== undefined) {
+    try {
+      const content = normalizeNoteWriteContent(body.content);
+      updates.content = content.document;
+      updates.markdown = content.markdown;
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid cheat sheet content" },
+        { status: 400 },
+      );
+    }
+  }
+  if (body.classId !== undefined) {
+    if (body.classId !== null && typeof body.classId !== "string") {
+      return NextResponse.json(
+        { error: "Invalid class selection" },
+        { status: 400 },
+      );
+    }
+
+    if (typeof body.classId === "string") {
+      const ownedClass = await assertClassBelongsToUser(
+        body.classId,
+        session.user.id,
+      );
+      if (!ownedClass) {
+        return NextResponse.json(
+          { error: "Invalid class selection" },
+          { status: 400 },
+        );
+      }
+    }
+
+    updates.classId = body.classId;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json(
+      { error: "No valid fields to update" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const [updated] = await db
+      .update(cheatSheet)
+      .set(updates)
+      .where(and(eq(cheatSheet.id, id), eq(cheatSheet.userId, session.user.id)))
+      .returning();
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("[PATCH /api/cheat-sheets/:id]", error);
+    return NextResponse.json(
+      { error: "Could not save cheat sheet" },
+      { status: 500 },
+    );
+  }
+}
+
+// DELETE /api/cheat-sheets/:id
+export async function DELETE(_req: Request, ctx: RouteContext) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await ctx.params;
+  const existing = await getUserCheatSheet(session.user.id, id);
+  if (!existing) {
+    return NextResponse.json({ error: "Cheat sheet not found" }, { status: 404 });
+  }
+
+  try {
+    await db
+      .delete(cheatSheet)
+      .where(and(eq(cheatSheet.id, id), eq(cheatSheet.userId, session.user.id)));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[DELETE /api/cheat-sheets/:id]", error);
+    return NextResponse.json(
+      { error: "Could not delete cheat sheet" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/cheat-sheets/route.ts
+++ b/app/api/cheat-sheets/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { db } from "@/lib/db";
+import { cheatSheet } from "@/lib/db/schema";
+import { desc, eq } from "drizzle-orm";
+import { assertClassBelongsToUser } from "@/lib/classes/queries";
+import { normalizeNoteWriteContent } from "@/lib/notes/persistence";
+import {
+  cheatSheetStorageUnavailableMessage,
+  hasCheatSheetStorage,
+} from "@/lib/cheat-sheets/storage";
+
+export const runtime = "nodejs";
+
+// GET /api/cheat-sheets - list the authenticated user's cheat sheets
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await hasCheatSheetStorage())) {
+    return NextResponse.json(
+      { error: cheatSheetStorageUnavailableMessage },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const sheets = await db
+      .select({
+        id: cheatSheet.id,
+        title: cheatSheet.title,
+        classId: cheatSheet.classId,
+        content: cheatSheet.content,
+        markdown: cheatSheet.markdown,
+        createdAt: cheatSheet.createdAt,
+        updatedAt: cheatSheet.updatedAt,
+      })
+      .from(cheatSheet)
+      .where(eq(cheatSheet.userId, session.user.id))
+      .orderBy(desc(cheatSheet.updatedAt));
+
+    return NextResponse.json(sheets);
+  } catch (error) {
+    console.error("[GET /api/cheat-sheets]", error);
+    return NextResponse.json(
+      { error: "Could not load cheat sheets" },
+      { status: 500 },
+    );
+  }
+}
+
+// POST /api/cheat-sheets - create a manual cheat sheet
+export async function POST(req: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await hasCheatSheetStorage())) {
+    return NextResponse.json(
+      { error: cheatSheetStorageUnavailableMessage },
+      { status: 503 },
+    );
+  }
+
+  let body: { title?: string; content?: unknown; classId?: string | null };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const title =
+    typeof body.title === "string" && body.title.trim()
+      ? body.title.trim()
+      : "Untitled";
+  const classId =
+    body.classId === null
+      ? null
+      : typeof body.classId === "string"
+        ? body.classId
+        : null;
+
+  if (classId) {
+    const ownedClass = await assertClassBelongsToUser(classId, session.user.id);
+    if (!ownedClass) {
+      return NextResponse.json(
+        { error: "Invalid class selection" },
+        { status: 400 },
+      );
+    }
+  }
+
+  let content: ReturnType<typeof normalizeNoteWriteContent>;
+  try {
+    content = normalizeNoteWriteContent(body.content);
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid cheat sheet content" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const [created] = await db
+      .insert(cheatSheet)
+      .values({
+        userId: session.user.id,
+        title,
+        classId,
+        content: content.document,
+        markdown: content.markdown,
+      })
+      .returning();
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    console.error("[POST /api/cheat-sheets]", error);
+    return NextResponse.json(
+      { error: "Could not create cheat sheet" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mind-maps/[id]/edges/[edgeId]/route.ts
+++ b/app/api/mind-maps/[id]/edges/[edgeId]/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { mindMapEdge } from "@/lib/db/schema";
+import { guardMindMapRequest, loadOwnedMap } from "@/lib/mind-maps/api";
+import { rowToMindMapEdge } from "@/lib/mind-maps/records";
+import { updateEdgeSchema } from "@/lib/mind-maps/types";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string; edgeId: string }> };
+
+export async function PATCH(req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = updateEdgeSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const { id, edgeId } = await ctx.params;
+  const map = await loadOwnedMap(id, guard.userId);
+  if (!map) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  const [updated] = await db
+    .update(mindMapEdge)
+    .set({ label: parsed.data.label === "" ? null : parsed.data.label, updatedAt: new Date() })
+    .where(and(eq(mindMapEdge.id, edgeId), eq(mindMapEdge.mapId, id)))
+    .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ edge: rowToMindMapEdge(updated) });
+}
+
+export async function DELETE(_req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  const { id, edgeId } = await ctx.params;
+  const map = await loadOwnedMap(id, guard.userId);
+  if (!map) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  const [deleted] = await db
+    .delete(mindMapEdge)
+    .where(and(eq(mindMapEdge.id, edgeId), eq(mindMapEdge.mapId, id)))
+    .returning();
+
+  if (!deleted) {
+    return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/mind-maps/[id]/edges/route.ts
+++ b/app/api/mind-maps/[id]/edges/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { mindMap, mindMapEdge, mindMapNode } from "@/lib/db/schema";
+import { guardMindMapRequest, loadOwnedMap } from "@/lib/mind-maps/api";
+import { rowToMindMapEdge } from "@/lib/mind-maps/records";
+import { createEdgeSchema } from "@/lib/mind-maps/types";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createEdgeSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const { id } = await ctx.params;
+  const map = await loadOwnedMap(id, guard.userId);
+  if (!map) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  // Both endpoints must be topics within this map.
+  const endpoints = await db
+    .select({ id: mindMapNode.id })
+    .from(mindMapNode)
+    .where(
+      and(
+        eq(mindMapNode.mapId, id),
+        inArray(mindMapNode.id, [parsed.data.sourceNodeId, parsed.data.targetNodeId]),
+      ),
+    );
+
+  if (endpoints.length !== 2) {
+    return NextResponse.json({ error: "Both topics must belong to this map" }, { status: 400 });
+  }
+
+  try {
+    const [created] = await db
+      .insert(mindMapEdge)
+      .values({
+        id: crypto.randomUUID(),
+        mapId: id,
+        sourceNodeId: parsed.data.sourceNodeId,
+        targetNodeId: parsed.data.targetNodeId,
+        label: parsed.data.label ?? null,
+      })
+      .returning();
+
+    await db.update(mindMap).set({ updatedAt: new Date() }).where(eq(mindMap.id, id));
+
+    return NextResponse.json({ edge: rowToMindMapEdge(created) }, { status: 201 });
+  } catch (error) {
+    console.error("[POST /api/mind-maps/[id]/edges]", error);
+    return NextResponse.json({ error: "Failed to connect topics" }, { status: 500 });
+  }
+}

--- a/app/api/mind-maps/[id]/nodes/[nodeId]/route.ts
+++ b/app/api/mind-maps/[id]/nodes/[nodeId]/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { mindMapNode } from "@/lib/db/schema";
+import { guardMindMapRequest, loadOwnedMap } from "@/lib/mind-maps/api";
+import { rowToMindMapNode } from "@/lib/mind-maps/records";
+import { updateNodeSchema } from "@/lib/mind-maps/types";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string; nodeId: string }> };
+
+export async function PATCH(req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = updateNodeSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const { id, nodeId } = await ctx.params;
+  const map = await loadOwnedMap(id, guard.userId);
+  if (!map) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  const [updated] = await db
+    .update(mindMapNode)
+    .set({ ...parsed.data, updatedAt: new Date() })
+    .where(and(eq(mindMapNode.id, nodeId), eq(mindMapNode.mapId, id)))
+    .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "Topic not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ node: rowToMindMapNode(updated) });
+}
+
+export async function DELETE(_req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  const { id, nodeId } = await ctx.params;
+  const map = await loadOwnedMap(id, guard.userId);
+  if (!map) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  // Connected edges cascade via the FK on source/target node ids.
+  const [deleted] = await db
+    .delete(mindMapNode)
+    .where(and(eq(mindMapNode.id, nodeId), eq(mindMapNode.mapId, id)))
+    .returning();
+
+  if (!deleted) {
+    return NextResponse.json({ error: "Topic not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/mind-maps/[id]/nodes/route.ts
+++ b/app/api/mind-maps/[id]/nodes/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { mindMap, mindMapNode } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { guardMindMapRequest, loadOwnedMap } from "@/lib/mind-maps/api";
+import { rowToMindMapNode } from "@/lib/mind-maps/records";
+import { createNodeSchema } from "@/lib/mind-maps/types";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createNodeSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const { id } = await ctx.params;
+  const map = await loadOwnedMap(id, guard.userId);
+  if (!map) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  try {
+    const [created] = await db
+      .insert(mindMapNode)
+      .values({
+        id: crypto.randomUUID(),
+        mapId: id,
+        label: parsed.data.label,
+        positionX: parsed.data.positionX,
+        positionY: parsed.data.positionY,
+      })
+      .returning();
+
+    // Touch the map so library ordering reflects recent activity.
+    await db.update(mindMap).set({ updatedAt: new Date() }).where(eq(mindMap.id, id));
+
+    return NextResponse.json({ node: rowToMindMapNode(created) }, { status: 201 });
+  } catch (error) {
+    console.error("[POST /api/mind-maps/[id]/nodes]", error);
+    return NextResponse.json({ error: "Failed to add topic" }, { status: 500 });
+  }
+}

--- a/app/api/mind-maps/[id]/route.ts
+++ b/app/api/mind-maps/[id]/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { mindMap, mindMapEdge, mindMapNode } from "@/lib/db/schema";
+import { guardMindMapRequest, loadOwnedMap } from "@/lib/mind-maps/api";
+import { rowToMindMapDetail, rowToMindMapEdge, rowToMindMapNode } from "@/lib/mind-maps/records";
+import { updateMapSchema } from "@/lib/mind-maps/types";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  const { id } = await ctx.params;
+  const map = await loadOwnedMap(id, guard.userId);
+  if (!map) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  const [nodes, edges] = await Promise.all([
+    db.select().from(mindMapNode).where(eq(mindMapNode.mapId, id)),
+    db.select().from(mindMapEdge).where(eq(mindMapEdge.mapId, id)),
+  ]);
+
+  return NextResponse.json({
+    map: rowToMindMapDetail(map, nodes.map(rowToMindMapNode), edges.map(rowToMindMapEdge)),
+  });
+}
+
+export async function PATCH(req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = updateMapSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const { id } = await ctx.params;
+  const [updated] = await db
+    .update(mindMap)
+    .set({ title: parsed.data.title, updatedAt: new Date() })
+    .where(and(eq(mindMap.id, id), eq(mindMap.userId, guard.userId)))
+    .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ map: { id: updated.id, title: updated.title } });
+}
+
+export async function DELETE(_req: Request, ctx: RouteContext) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  const { id } = await ctx.params;
+  const [deleted] = await db
+    .delete(mindMap)
+    .where(and(eq(mindMap.id, id), eq(mindMap.userId, guard.userId)))
+    .returning();
+
+  if (!deleted) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/mind-maps/generate/route.ts
+++ b/app/api/mind-maps/generate/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { mindMap, mindMapEdge, mindMapNode } from "@/lib/db/schema";
+import { guardMindMapRequest } from "@/lib/mind-maps/api";
+import { getMindMapContextNotes } from "@/lib/mind-maps/context";
+import { generateAssociationMap } from "@/lib/mind-maps/gemini";
+import { rowToMindMapDetail, rowToMindMapEdge, rowToMindMapNode } from "@/lib/mind-maps/records";
+import { generateMapSchema } from "@/lib/mind-maps/types";
+
+export const runtime = "nodejs";
+
+/** Lays topics out on a ring centred at the origin so the generated map reads cleanly. */
+function ringPosition(index: number, total: number) {
+  const radius = 200 + total * 16;
+  const angle = (index / total) * Math.PI * 2 - Math.PI / 2;
+  return { x: Math.round(Math.cos(angle) * radius), y: Math.round(Math.sin(angle) * radius) };
+}
+
+export async function POST(req: Request) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = generateMapSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const notes = await getMindMapContextNotes({
+    userId: guard.userId,
+    noteIds: parsed.data.noteIds,
+  });
+
+  if (notes.length !== new Set(parsed.data.noteIds).size) {
+    return NextResponse.json({ error: "One or more selected notes could not be found" }, { status: 404 });
+  }
+
+  if (notes.every((note) => note.embedding.length === 0)) {
+    return NextResponse.json(
+      { error: "Selected notes do not have stored embeddings yet" },
+      { status: 400 },
+    );
+  }
+
+  let generated;
+  try {
+    generated = await generateAssociationMap({ notes });
+  } catch (error) {
+    console.error("[POST /api/mind-maps/generate]", error);
+    const message = error instanceof Error ? error.message : "Map generation failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  if (generated.topics.length === 0) {
+    return NextResponse.json({ error: "The model did not return any topics" }, { status: 502 });
+  }
+
+  const title = `Associations — ${notes[0].title}`.slice(0, 120);
+  const sourceText = notes.map((note) => note.title).join(", ");
+
+  try {
+    const [createdMap] = await db
+      .insert(mindMap)
+      .values({ id: crypto.randomUUID(), userId: guard.userId, title, sourceText })
+      .returning();
+
+    const total = generated.topics.length;
+    const nodeIdByLabel = new Map<string, string>();
+    const nodeValues = generated.topics.map((label, index) => {
+      const id = crypto.randomUUID();
+      nodeIdByLabel.set(label.toLowerCase(), id);
+      const position = ringPosition(index, total);
+      return { id, mapId: createdMap.id, label, positionX: position.x, positionY: position.y };
+    });
+
+    const insertedNodes = await db.insert(mindMapNode).values(nodeValues).returning();
+
+    const edgeValues = generated.connections
+      .map((connection) => {
+        const sourceNodeId = nodeIdByLabel.get(connection.source.toLowerCase());
+        const targetNodeId = nodeIdByLabel.get(connection.target.toLowerCase());
+        if (!sourceNodeId || !targetNodeId) return null;
+        return {
+          id: crypto.randomUUID(),
+          mapId: createdMap.id,
+          sourceNodeId,
+          targetNodeId,
+          label: connection.label,
+          isSuggested: true,
+        };
+      })
+      .filter((value): value is NonNullable<typeof value> => value !== null);
+
+    const insertedEdges =
+      edgeValues.length > 0 ? await db.insert(mindMapEdge).values(edgeValues).returning() : [];
+
+    return NextResponse.json(
+      {
+        map: rowToMindMapDetail(
+          createdMap,
+          insertedNodes.map(rowToMindMapNode),
+          insertedEdges.map(rowToMindMapEdge),
+        ),
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error("[POST /api/mind-maps/generate] persist", error);
+    return NextResponse.json({ error: "Failed to save generated map" }, { status: 500 });
+  }
+}

--- a/app/api/mind-maps/route.ts
+++ b/app/api/mind-maps/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { count, desc, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { mindMap, mindMapEdge, mindMapNode } from "@/lib/db/schema";
+import { guardMindMapRequest } from "@/lib/mind-maps/api";
+import { rowToMindMapSummary } from "@/lib/mind-maps/records";
+import { createMapSchema } from "@/lib/mind-maps/types";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  const maps = await db
+    .select()
+    .from(mindMap)
+    .where(eq(mindMap.userId, guard.userId))
+    .orderBy(desc(mindMap.updatedAt));
+
+  const mapIds = maps.map((map) => map.id);
+  const nodeCounts = new Map<string, number>();
+  const edgeCounts = new Map<string, number>();
+
+  if (mapIds.length > 0) {
+    const [nodeRows, edgeRows] = await Promise.all([
+      db
+        .select({ mapId: mindMapNode.mapId, total: count() })
+        .from(mindMapNode)
+        .where(inArray(mindMapNode.mapId, mapIds))
+        .groupBy(mindMapNode.mapId),
+      db
+        .select({ mapId: mindMapEdge.mapId, total: count() })
+        .from(mindMapEdge)
+        .where(inArray(mindMapEdge.mapId, mapIds))
+        .groupBy(mindMapEdge.mapId),
+    ]);
+
+    for (const row of nodeRows) nodeCounts.set(row.mapId, Number(row.total));
+    for (const row of edgeRows) edgeCounts.set(row.mapId, Number(row.total));
+  }
+
+  return NextResponse.json({
+    maps: maps.map((map) =>
+      rowToMindMapSummary(map, nodeCounts.get(map.id) ?? 0, edgeCounts.get(map.id) ?? 0),
+    ),
+  });
+}
+
+export async function POST(req: Request) {
+  const guard = await guardMindMapRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createMapSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  try {
+    const [created] = await db
+      .insert(mindMap)
+      .values({
+        id: crypto.randomUUID(),
+        userId: guard.userId,
+        title: parsed.data.title,
+      })
+      .returning();
+
+    return NextResponse.json({ map: rowToMindMapSummary(created, 0, 0) }, { status: 201 });
+  } catch (error) {
+    console.error("[POST /api/mind-maps]", error);
+    return NextResponse.json({ error: "Failed to create map" }, { status: 500 });
+  }
+}

--- a/app/associations/associations-client.tsx
+++ b/app/associations/associations-client.tsx
@@ -1,0 +1,525 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  ArrowLeft,
+  Check,
+  FileText,
+  Loader2,
+  Network,
+  Pencil,
+  Plus,
+  Share2,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Input } from "@/components/ui/input";
+import { MindMapCanvas } from "@/components/mind-map/mind-map-canvas";
+import type { MindMapDetail, MindMapSummary } from "@/lib/mind-maps/types";
+import { cx } from "@/lib/utils";
+
+const MAX_GENERATION_NOTES = 12;
+
+type NoteOption = {
+  id: string;
+  title: string;
+  updatedAt: string;
+  hasEmbedding: boolean;
+};
+
+type AssociationsClientProps = {
+  initialMaps: MindMapSummary[];
+  notes: NoteOption[];
+  storageReady: boolean;
+};
+
+type View = "library" | "generate" | "editor";
+
+async function request<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, init);
+  const payload = (await response.json().catch(() => null)) as (T & { error?: string }) | null;
+  if (!response.ok) {
+    throw new Error(payload?.error || "Request failed");
+  }
+  return payload as T;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(value));
+}
+
+function MapCard({
+  map,
+  isDeleting,
+  onOpen,
+  onDelete,
+}: {
+  map: MindMapSummary;
+  isDeleting: boolean;
+  onOpen: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(event) => event.key === "Enter" && onOpen()}
+      className="group relative flex cursor-pointer flex-col gap-3 rounded-[var(--radius-xl)] border border-border bg-surface p-5 shadow-[var(--shadow-card)] transition hover:border-border-strong hover:bg-surface-muted"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+          <Network className="size-4" />
+        </span>
+        <button
+          type="button"
+          aria-label="Delete map"
+          disabled={isDeleting}
+          className="hidden shrink-0 rounded-md p-1.5 text-muted-foreground transition hover:bg-danger-soft hover:text-danger group-hover:inline-flex disabled:opacity-60"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete();
+          }}
+        >
+          {isDeleting ? <Loader2 className="size-4 animate-spin" /> : <Trash2 className="size-4" />}
+        </button>
+      </div>
+      <div className="min-w-0">
+        <p className="truncate font-semibold text-foreground">{map.title}</p>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          {map.nodeCount} topics · {map.edgeCount} connections
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">Updated {formatDate(map.updatedAt)}</p>
+      </div>
+    </div>
+  );
+}
+
+function MethodExplainer() {
+  return (
+    <Card className="shrink-0">
+      <CardHeader className="gap-3">
+        <div className="flex items-center gap-2">
+          <span className="flex size-8 items-center justify-center rounded-lg bg-accent-soft text-accent">
+            <Share2 className="size-4" />
+          </span>
+          <CardTitle>How the associations method works</CardTitle>
+        </div>
+        <CardDescription>
+          Associations learning ties new ideas to things you already know, so recalling one cues the
+          others. Build a small map of related topics, then name <em>why</em> each pair connects —
+          the act of labelling the link is what makes it stick.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-3 text-sm text-muted-foreground sm:grid-cols-3">
+        <div className="rounded-lg border border-border bg-surface-muted/50 p-3">
+          <p className="font-medium text-foreground">1. Add topics</p>
+          <p className="mt-1">Drop a node for each idea you want to remember.</p>
+        </div>
+        <div className="rounded-lg border border-border bg-surface-muted/50 p-3">
+          <p className="font-medium text-foreground">2. Connect them</p>
+          <p className="mt-1">Drag from a topic&apos;s handle to another to draw a link.</p>
+        </div>
+        <div className="rounded-lg border border-border bg-surface-muted/50 p-3">
+          <p className="font-medium text-foreground">3. Name the link</p>
+          <p className="mt-1">Label each connection (causes, example, contrast…) to define the relationship.</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function NoteRow({
+  note,
+  selected,
+  onToggle,
+}: {
+  note: NoteOption;
+  selected: boolean;
+  onToggle: () => void;
+}) {
+  const disabled = !note.hasEmbedding;
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onToggle}
+      className={cx(
+        "flex w-full items-center gap-3 rounded-[var(--radius-xl)] border p-3 text-left transition",
+        disabled
+          ? "cursor-not-allowed border-border bg-surface-muted/40 opacity-60"
+          : selected
+            ? "border-accent bg-accent-soft"
+            : "border-border bg-surface hover:border-border-strong hover:bg-surface-muted",
+      )}
+    >
+      <span
+        className={cx(
+          "flex size-5 shrink-0 items-center justify-center rounded-md border",
+          selected ? "border-accent bg-accent text-accent-foreground" : "border-border-strong",
+        )}
+      >
+        {selected ? <Check className="size-3.5" /> : null}
+      </span>
+      <FileText className="size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-foreground">{note.title}</span>
+        {disabled ? (
+          <span className="block text-xs text-muted-foreground">No embedding yet — can’t be used</span>
+        ) : null}
+      </span>
+    </button>
+  );
+}
+
+export function AssociationsClient({ initialMaps, notes, storageReady }: AssociationsClientProps) {
+  const [maps, setMaps] = useState<MindMapSummary[]>(initialMaps);
+  const [view, setView] = useState<View>("library");
+  const [activeMap, setActiveMap] = useState<MindMapDetail | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [openingId, setOpeningId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [selectedNoteIds, setSelectedNoteIds] = useState<string[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const openMap = useCallback(async (id: string) => {
+    setOpeningId(id);
+    const toastId = toast.loading("Opening map…", { duration: Infinity });
+    try {
+      const { map } = await request<{ map: MindMapDetail }>(`/api/mind-maps/${id}`);
+      setActiveMap(map);
+      setView("editor");
+      toast.dismiss(toastId);
+    } catch (error) {
+      toast.error("Failed to open map", {
+        id: toastId,
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setOpeningId(null);
+    }
+  }, []);
+
+  const createMap = useCallback(async () => {
+    setIsCreating(true);
+    const toastId = toast.loading("Creating map…", { duration: Infinity });
+    try {
+      const { map } = await request<{ map: MindMapSummary }>("/api/mind-maps", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Untitled association map" }),
+      });
+      setMaps((curr) => [map, ...curr]);
+      setActiveMap({ ...map, sourceText: null, nodes: [], edges: [] });
+      setView("editor");
+      setIsEditingTitle(true);
+      toast.dismiss(toastId);
+    } catch (error) {
+      toast.error("Failed to create map", {
+        id: toastId,
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsCreating(false);
+    }
+  }, []);
+
+  const toggleNote = useCallback((id: string) => {
+    setSelectedNoteIds((curr) => {
+      if (curr.includes(id)) return curr.filter((value) => value !== id);
+      if (curr.length >= MAX_GENERATION_NOTES) {
+        toast.error(`You can select up to ${MAX_GENERATION_NOTES} notes`);
+        return curr;
+      }
+      return [...curr, id];
+    });
+  }, []);
+
+  const generateFromNotes = useCallback(async () => {
+    if (selectedNoteIds.length === 0) return;
+    setIsGenerating(true);
+    const toastId = toast.loading("Generating map from notes…", { duration: Infinity });
+    try {
+      const { map } = await request<{ map: MindMapDetail }>("/api/mind-maps/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ noteIds: selectedNoteIds }),
+      });
+      setMaps((curr) => [
+        {
+          id: map.id,
+          title: map.title,
+          nodeCount: map.nodes.length,
+          edgeCount: map.edges.length,
+          createdAt: map.createdAt,
+          updatedAt: map.updatedAt,
+        },
+        ...curr,
+      ]);
+      setActiveMap(map);
+      setSelectedNoteIds([]);
+      setView("editor");
+      toast.success("Map generated", { id: toastId });
+    } catch (error) {
+      toast.error("Failed to generate map", {
+        id: toastId,
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [selectedNoteIds]);
+
+  const deleteMap = useCallback(
+    async (id: string) => {
+      setDeletingId(id);
+      const snapshot = maps;
+      setMaps((curr) => curr.filter((map) => map.id !== id));
+      try {
+        await request(`/api/mind-maps/${id}`, { method: "DELETE" });
+        toast.success("Map deleted");
+      } catch (error) {
+        setMaps(snapshot);
+        toast.error("Failed to delete map", {
+          description: error instanceof Error ? error.message : undefined,
+        });
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [maps],
+  );
+
+  const renameMap = useCallback(
+    async (title: string) => {
+      const trimmed = title.trim();
+      setIsEditingTitle(false);
+      if (!activeMap || !trimmed || trimmed === activeMap.title) return;
+
+      const previous = activeMap.title;
+      const id = activeMap.id;
+      setActiveMap((curr) => (curr ? { ...curr, title: trimmed } : curr));
+      setMaps((curr) => curr.map((map) => (map.id === id ? { ...map, title: trimmed } : map)));
+      try {
+        await request(`/api/mind-maps/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: trimmed }),
+        });
+      } catch (error) {
+        setActiveMap((curr) => (curr ? { ...curr, title: previous } : curr));
+        setMaps((curr) => curr.map((map) => (map.id === id ? { ...map, title: previous } : map)));
+        toast.error("Failed to rename map", {
+          description: error instanceof Error ? error.message : undefined,
+        });
+      }
+    },
+    [activeMap],
+  );
+
+  if (!storageReady) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <EmptyState
+            eyebrow="Setup needed"
+            title="Association maps aren’t ready yet"
+            description="The mind-map tables haven’t been migrated. Run the latest database migration to start building association maps."
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (view === "editor" && activeMap) {
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-4">
+        <div className="flex shrink-0 flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            leadingIcon={<ArrowLeft className="size-4" />}
+            onClick={() => {
+              setView("library");
+              setActiveMap(null);
+              setIsEditingTitle(false);
+            }}
+          >
+            My association maps
+          </Button>
+          {isEditingTitle ? (
+            <Input
+              autoFocus
+              defaultValue={activeMap.title}
+              maxLength={120}
+              className="h-9 max-w-xs"
+              onKeyDown={(event) => {
+                if (event.key === "Enter") renameMap(event.currentTarget.value);
+                if (event.key === "Escape") setIsEditingTitle(false);
+              }}
+              onBlur={(event) => renameMap(event.target.value)}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setIsEditingTitle(true)}
+              className="group flex items-center gap-2 rounded-md px-1 text-lg font-semibold text-foreground"
+            >
+              {activeMap.title}
+              <Pencil className="size-3.5 text-muted-foreground opacity-0 transition group-hover:opacity-100" />
+            </button>
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1">
+          <MindMapCanvas
+            key={activeMap.id}
+            mapId={activeMap.id}
+            initialNodes={activeMap.nodes}
+            initialEdges={activeMap.edges}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (view === "generate") {
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-4">
+        <div className="flex shrink-0 flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            leadingIcon={<ArrowLeft className="size-4" />}
+            onClick={() => {
+              setView("library");
+              setSelectedNoteIds([]);
+            }}
+          >
+            My association maps
+          </Button>
+          <h1 className="text-lg font-semibold text-foreground">Generate from notes</h1>
+        </div>
+
+        <p className="shrink-0 text-sm text-muted-foreground">
+          Pick the notes to map. The AI proposes the key topics and how they connect — you can then
+          edit, relabel, and add your own associations.
+        </p>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {notes.length === 0 ? (
+            <EmptyState
+              eyebrow="No notes"
+              title="No notes to generate from"
+              description="Create and embed some notes first, then come back to generate an association map from them."
+            />
+          ) : (
+            <div className="flex flex-col gap-2">
+              {notes.map((note) => (
+                <NoteRow
+                  key={note.id}
+                  note={note}
+                  selected={selectedNoteIds.includes(note.id)}
+                  onToggle={() => toggleNote(note.id)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center justify-between gap-3 border-t border-border pt-3">
+          <span className="text-sm text-muted-foreground">
+            {selectedNoteIds.length} selected
+          </span>
+          <Button
+            type="button"
+            disabled={isGenerating || selectedNoteIds.length === 0}
+            leadingIcon={
+              isGenerating ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Sparkles className="size-4" />
+              )
+            }
+            onClick={generateFromNotes}
+          >
+            {isGenerating ? "Generating…" : "Generate map"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
+        <MethodExplainer />
+
+        <section className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <span className="inline-flex h-8 w-fit items-center rounded-full border border-border bg-transparent px-3 text-sm font-medium text-muted-foreground">
+              {maps.length} {maps.length === 1 ? "map" : "maps"}
+            </span>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                leadingIcon={<Sparkles className="size-4" />}
+                onClick={() => setView("generate")}
+              >
+                Generate from notes
+              </Button>
+              <Button
+                type="button"
+                disabled={isCreating}
+                leadingIcon={
+                  isCreating ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Plus className="size-4" />
+                  )
+                }
+                onClick={createMap}
+              >
+                {isCreating ? "Creating…" : "New association map"}
+              </Button>
+            </div>
+          </div>
+
+          {maps.length === 0 ? (
+            <div className="flex min-h-[220px] flex-1 items-center justify-center rounded-[var(--radius-xl)] border border-dashed border-border bg-surface/70 p-8">
+              <div className="flex max-w-sm flex-col items-center text-center">
+                <Network className="mb-4 size-10 text-muted-foreground" />
+                <h2 className="text-lg font-semibold text-foreground">No association maps yet</h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Create your first map to start connecting ideas.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {maps.map((map) => (
+                <MapCard
+                  key={map.id}
+                  map={map}
+                  isDeleting={deletingId === map.id}
+                  onOpen={() => {
+                    if (!openingId) openMap(map.id);
+                  }}
+                  onDelete={() => deleteMap(map.id)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/cheat-sheet/cheat-sheet-list.tsx
+++ b/app/cheat-sheet/cheat-sheet-list.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  Plus,
+} from "lucide-react";
+import { cx } from "@/lib/utils";
+import {
+  formatTimestamp,
+  getClassLabel,
+  getClassShortLabel,
+  getRenderableTitle,
+} from "@/lib/notes/labels";
+import { sortCheatSheets, type CheatSheet } from "@/lib/cheat-sheets/records";
+import { isTempSheet, type CheatSheetClass } from "./cheat-sheet-types";
+
+type CheatSheetListProps = {
+  cheatSheets: CheatSheet[];
+  classes: CheatSheetClass[];
+  selectedId: string | null;
+  collapsedGroups: Set<string>;
+  isPending: boolean;
+  disabled: boolean;
+  onToggleGroup: (groupId: string) => void;
+  onSelect: (sheet: CheatSheet) => void;
+  onCreate: (classId: string | null) => void;
+};
+
+function CheatSheetItem({
+  sheet,
+  isOpen,
+  compact,
+  classLabel,
+  classShortLabel,
+  onSelect,
+}: {
+  sheet: CheatSheet;
+  isOpen: boolean;
+  compact?: boolean;
+  classLabel: string | null;
+  classShortLabel: string | null;
+  onSelect: (sheet: CheatSheet) => void;
+}) {
+  const isTemp = isTempSheet(sheet.id);
+  return (
+    <button
+      type="button"
+      disabled={isTemp}
+      onClick={() => onSelect(sheet)}
+      className={cx(
+        "flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition",
+        isOpen
+          ? "bg-surface-elevated text-foreground"
+          : "text-muted-foreground hover:bg-surface hover:text-foreground",
+        isTemp && "animate-pulse opacity-60",
+      )}
+    >
+      <FileText className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+      <span className="min-w-0 flex-1 truncate font-medium">
+        {getRenderableTitle(sheet.title)}
+      </span>
+      {compact && classShortLabel ? (
+        <span
+          title={classLabel ?? undefined}
+          className="max-w-24 shrink-0 truncate text-[11px] text-muted-foreground"
+        >
+          {classShortLabel}
+        </span>
+      ) : (
+        <span className="shrink-0 text-[11px] text-muted-foreground">
+          {formatTimestamp(sheet.updatedAt)}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function CheatSheetList({
+  cheatSheets,
+  classes,
+  selectedId,
+  collapsedGroups,
+  isPending,
+  disabled,
+  onToggleGroup,
+  onSelect,
+  onCreate,
+}: CheatSheetListProps) {
+  const classesById = useMemo(
+    () => new Map(classes.map((item) => [item.id, item])),
+    [classes],
+  );
+  const recents = useMemo(
+    () => sortCheatSheets(cheatSheets).slice(0, 8),
+    [cheatSheets],
+  );
+  const groups = useMemo(
+    () => [
+      ...classes.map((item) => ({
+        id: item.id,
+        title: getClassLabel(item),
+        shortTitle: getClassShortLabel(item),
+        classId: item.id as string | null,
+        sheets: cheatSheets.filter((sheet) => sheet.classId === item.id),
+      })),
+      {
+        id: "unfiled",
+        title: "Unfiled",
+        shortTitle: "Unfiled",
+        classId: null as string | null,
+        sheets: cheatSheets.filter((sheet) => !sheet.classId),
+      },
+    ],
+    [classes, cheatSheets],
+  );
+
+  const labelFor = (classId: string | null) => {
+    const cls = classId ? (classesById.get(classId) ?? null) : null;
+    return {
+      full: cls ? getClassLabel(cls) : null,
+      short: cls ? getClassShortLabel(cls) : null,
+    };
+  };
+
+  return (
+    <aside className="flex h-full min-h-0 flex-col border-b border-border bg-surface-muted/70 lg:border-b-0 lg:border-r">
+      <div className="flex h-12 items-center gap-2 border-b border-border px-3">
+        <button
+          type="button"
+          onClick={() => onCreate(null)}
+          disabled={isPending || disabled}
+          className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-sm font-medium text-foreground hover:bg-surface disabled:opacity-60"
+        >
+          <Plus className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span className="truncate">New cheat sheet</span>
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 py-3">
+        {recents.length > 0 ? (
+          <section className="mb-5">
+            <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">
+              Recents
+            </div>
+            <div className="space-y-0.5">
+              {recents.map((sheet) => {
+                const labels = labelFor(sheet.classId);
+                return (
+                  <CheatSheetItem
+                    key={sheet.id}
+                    sheet={sheet}
+                    isOpen={sheet.id === selectedId}
+                    compact
+                    classLabel={labels.full}
+                    classShortLabel={labels.short}
+                    onSelect={onSelect}
+                  />
+                );
+              })}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="space-y-1">
+          <div className="px-2 pb-1 text-xs font-medium text-muted-foreground">
+            Cheat sheets
+          </div>
+          {groups.map((group) => {
+            const isCollapsed = collapsedGroups.has(group.id);
+            return (
+              <div key={group.id} className="rounded-lg">
+                <div className="group flex items-center gap-1 rounded-md text-muted-foreground hover:bg-surface hover:text-foreground">
+                  <button
+                    type="button"
+                    onClick={() => onToggleGroup(group.id)}
+                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+                    aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group.title}`}
+                  >
+                    {isCollapsed ? (
+                      <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+                    ) : (
+                      <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onToggleGroup(group.id)}
+                    className="flex min-w-0 flex-1 items-center gap-2 py-1.5 text-left text-sm font-medium"
+                  >
+                    <Folder
+                      className="h-4 w-4 shrink-0 opacity-70"
+                      aria-hidden="true"
+                    />
+                    <span className="truncate" title={group.title}>
+                      {group.shortTitle}
+                    </span>
+                    <span className="ml-auto pr-1 text-[11px] text-muted-foreground">
+                      {group.sheets.length}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onCreate(group.classId)}
+                    disabled={isPending || disabled}
+                    className="mr-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md opacity-0 hover:bg-surface-elevated group-hover:opacity-100 disabled:opacity-40"
+                    aria-label={`New cheat sheet in ${group.title}`}
+                  >
+                    <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+                  </button>
+                </div>
+
+                {!isCollapsed && group.sheets.length > 0 ? (
+                  <div className="ml-3 space-y-0.5 border-l border-border/70 pl-1">
+                    {group.sheets.map((sheet) => (
+                      <CheatSheetItem
+                        key={sheet.id}
+                        sheet={sheet}
+                        isOpen={sheet.id === selectedId}
+                        classLabel={null}
+                        classShortLabel={null}
+                        onSelect={onSelect}
+                      />
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/app/cheat-sheet/cheat-sheet-list.tsx
+++ b/app/cheat-sheet/cheat-sheet-list.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   FileText,
   Folder,
+  PanelLeftClose,
   Plus,
 } from "lucide-react";
 import { cx } from "@/lib/utils";
@@ -28,6 +29,7 @@ type CheatSheetListProps = {
   onToggleGroup: (groupId: string) => void;
   onSelect: (sheet: CheatSheet) => void;
   onCreate: (classId: string | null) => void;
+  onCollapse: () => void;
 };
 
 function CheatSheetItem({
@@ -89,6 +91,7 @@ export function CheatSheetList({
   onToggleGroup,
   onSelect,
   onCreate,
+  onCollapse,
 }: CheatSheetListProps) {
   const classesById = useMemo(
     () => new Map(classes.map((item) => [item.id, item])),
@@ -137,6 +140,15 @@ export function CheatSheetList({
         >
           <Plus className="h-4 w-4 shrink-0" aria-hidden="true" />
           <span className="truncate">New cheat sheet</span>
+        </button>
+        <button
+          type="button"
+          onClick={onCollapse}
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-surface hover:text-foreground"
+          aria-label="Collapse cheat sheet list"
+          title="Collapse cheat sheet list"
+        >
+          <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
         </button>
       </div>
 

--- a/app/cheat-sheet/cheat-sheet-types.ts
+++ b/app/cheat-sheet/cheat-sheet-types.ts
@@ -1,0 +1,26 @@
+import type { CheatSheet } from "@/lib/cheat-sheets/records";
+
+/** Minimal class info needed to file and label cheat sheets. */
+export type CheatSheetClass = {
+  id: string;
+  title: string;
+  courseCode: string | null;
+};
+
+export const isTempSheet = (id: string) => id.startsWith("temp-");
+
+export function createTempSheet(
+  classId: string | null,
+  overrides?: Partial<CheatSheet>,
+): CheatSheet {
+  const now = new Date().toISOString();
+  return {
+    id: `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    title: "Untitled",
+    classId,
+    createdAt: now,
+    updatedAt: now,
+    content: { markdown: "", document: { time: Date.now(), blocks: [] } },
+    ...overrides,
+  };
+}

--- a/app/cheat-sheet/cheat-sheet-workspace.tsx
+++ b/app/cheat-sheet/cheat-sheet-workspace.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 import { Copy, FileText, Trash2 } from "lucide-react";
 import { NoteSurface } from "@/components/note-editor/note-surface";
 import { Button } from "@/components/ui/button";
+import { CollapsedRail } from "@/components/ui/collapsed-rail";
+import { cx } from "@/lib/utils";
 import { formatTimestamp, getRenderableTitle } from "@/lib/notes/labels";
 import {
   rowToCheatSheet,
@@ -44,6 +46,7 @@ export function CheatSheetWorkspace({
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
     () => new Set(),
   );
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   const selectedSheet = useMemo(
@@ -247,20 +250,38 @@ export function CheatSheetWorkspace({
   }
 
   return (
-    <div className="grid h-full min-h-0 lg:grid-cols-[260px_minmax(0,1fr)]">
-      <CheatSheetList
-        cheatSheets={sheets}
-        classes={classes}
-        selectedId={selectedSheet?.id ?? null}
-        collapsedGroups={collapsedGroups}
-        isPending={isPending}
-        disabled={!storageReady}
-        onToggleGroup={toggleGroup}
-        onSelect={selectSheet}
-        onCreate={(classId) =>
-          startTransition(() => void handleCreate(classId))
-        }
-      />
+    <div
+      className={cx(
+        "grid h-full min-h-0",
+        sidebarCollapsed
+          ? "lg:grid-cols-[48px_minmax(0,1fr)]"
+          : "lg:grid-cols-[260px_minmax(0,1fr)]",
+      )}
+    >
+      {sidebarCollapsed ? (
+        <CollapsedRail
+          onExpand={() => setSidebarCollapsed(false)}
+          expandLabel="Expand cheat sheet list"
+          onNew={() => startTransition(() => void handleCreate(null))}
+          newLabel="New cheat sheet"
+          newDisabled={isPending || !storageReady}
+        />
+      ) : (
+        <CheatSheetList
+          cheatSheets={sheets}
+          classes={classes}
+          selectedId={selectedSheet?.id ?? null}
+          collapsedGroups={collapsedGroups}
+          isPending={isPending}
+          disabled={!storageReady}
+          onToggleGroup={toggleGroup}
+          onSelect={selectSheet}
+          onCreate={(classId) =>
+            startTransition(() => void handleCreate(classId))
+          }
+          onCollapse={() => setSidebarCollapsed(true)}
+        />
+      )}
 
       <section className="h-full min-h-0 bg-background">
         {selectedSheet ? (

--- a/app/cheat-sheet/cheat-sheet-workspace.tsx
+++ b/app/cheat-sheet/cheat-sheet-workspace.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Copy, FileText, Trash2 } from "lucide-react";
+import { NoteSurface } from "@/components/note-editor/note-surface";
+import { Button } from "@/components/ui/button";
+import { formatTimestamp, getRenderableTitle } from "@/lib/notes/labels";
+import {
+  rowToCheatSheet,
+  sortCheatSheets,
+  type CheatSheet,
+  type CheatSheetRecord,
+} from "@/lib/cheat-sheets/records";
+import type { NoteContent } from "@/lib/notes/types";
+import {
+  createTempSheet,
+  isTempSheet,
+  type CheatSheetClass,
+} from "./cheat-sheet-types";
+import { CheatSheetList } from "./cheat-sheet-list";
+
+type CheatSheetWorkspaceProps = {
+  initialCheatSheets: CheatSheet[];
+  classes: CheatSheetClass[];
+  storageReady: boolean;
+};
+
+export function CheatSheetWorkspace({
+  initialCheatSheets,
+  classes,
+  storageReady,
+}: CheatSheetWorkspaceProps) {
+  const [sheets, setSheets] = useState(() =>
+    sortCheatSheets(initialCheatSheets),
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(
+    () => initialCheatSheets[0]?.id ?? null,
+  );
+  const [titleDraftState, setTitleDraftState] = useState(() => ({
+    sheetId: initialCheatSheets[0]?.id ?? null,
+    value: initialCheatSheets[0]?.title ?? "Untitled",
+  }));
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const selectedSheet = useMemo(
+    () => sheets.find((sheet) => sheet.id === selectedId) ?? sheets[0] ?? null,
+    [sheets, selectedId],
+  );
+  const draftTitle =
+    selectedSheet && titleDraftState.sheetId === selectedSheet.id
+      ? titleDraftState.value
+      : (selectedSheet?.title ?? "Untitled");
+
+  async function readRecord(response: Response) {
+    const payload = (await response.json().catch(() => null)) as
+      | (CheatSheetRecord & { error?: string })
+      | { error?: string }
+      | null;
+    if (!response.ok) {
+      throw new Error(payload?.error || "The cheat sheet request failed.");
+    }
+    return rowToCheatSheet(payload as CheatSheetRecord);
+  }
+
+  function mergeSheet(next: CheatSheet) {
+    setSheets((current) =>
+      sortCheatSheets([next, ...current.filter((s) => s.id !== next.id)]),
+    );
+  }
+
+  function toggleGroup(groupId: string) {
+    setCollapsedGroups((current) => {
+      const next = new Set(current);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }
+
+  function selectSheet(sheet: CheatSheet) {
+    setSelectedId(sheet.id);
+    setTitleDraftState({ sheetId: sheet.id, value: sheet.title });
+  }
+
+  async function saveSheet(
+    sheetId: string,
+    patch: { title?: string; content?: NoteContent; classId?: string | null },
+  ) {
+    if (isTempSheet(sheetId)) return; // creation pending — skip
+
+    const response = await fetch(`/api/cheat-sheets/${sheetId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...(patch.title !== undefined ? { title: patch.title } : {}),
+        ...(patch.content ? { content: patch.content.document } : {}),
+        ...(patch.classId !== undefined ? { classId: patch.classId } : {}),
+      }),
+    });
+
+    const updated = await readRecord(response);
+    mergeSheet(updated);
+    setTitleDraftState((current) =>
+      current.sheetId === updated.id
+        ? { sheetId: updated.id, value: updated.title }
+        : current,
+    );
+  }
+
+  async function handleCreate(classId: string | null) {
+    if (!storageReady) {
+      toast.error("Cheat sheet storage is not ready", {
+        description: "Run the latest database migration before writing.",
+        duration: 5000,
+      });
+      return;
+    }
+
+    const temp = createTempSheet(classId);
+    setSheets((current) => sortCheatSheets([temp, ...current]));
+    setSelectedId(temp.id);
+    setTitleDraftState({ sheetId: temp.id, value: "Untitled" });
+    if (classId) {
+      setCollapsedGroups((current) => {
+        const next = new Set(current);
+        next.delete(classId);
+        return next;
+      });
+    }
+
+    try {
+      const response = await fetch("/api/cheat-sheets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Untitled",
+          classId,
+          content: temp.content.document,
+        }),
+      });
+      const created = await readRecord(response);
+      setSheets((current) =>
+        sortCheatSheets([created, ...current.filter((s) => s.id !== temp.id)]),
+      );
+      setSelectedId((prev) => (prev === temp.id ? created.id : prev));
+      setTitleDraftState((prev) =>
+        prev.sheetId === temp.id
+          ? { sheetId: created.id, value: created.title }
+          : prev,
+      );
+    } catch (err) {
+      setSheets((current) => current.filter((s) => s.id !== temp.id));
+      setSelectedId((prev) => (prev === temp.id ? null : prev));
+      toast.error("Could not create cheat sheet", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
+    }
+  }
+
+  async function handleDuplicate() {
+    if (!selectedSheet || isTempSheet(selectedSheet.id)) return;
+    const source = selectedSheet;
+    const temp = createTempSheet(source.classId, {
+      title: `${source.title} (copy)`,
+      content: source.content,
+    });
+
+    setSheets((current) => sortCheatSheets([temp, ...current]));
+    setSelectedId(temp.id);
+    setTitleDraftState({ sheetId: temp.id, value: temp.title });
+
+    try {
+      const response = await fetch("/api/cheat-sheets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: temp.title,
+          classId: temp.classId,
+          content: source.content.document,
+        }),
+      });
+      const created = await readRecord(response);
+      setSheets((current) =>
+        sortCheatSheets([created, ...current.filter((s) => s.id !== temp.id)]),
+      );
+      setSelectedId((prev) => (prev === temp.id ? created.id : prev));
+      setTitleDraftState((prev) =>
+        prev.sheetId === temp.id
+          ? { sheetId: created.id, value: created.title }
+          : prev,
+      );
+    } catch (err) {
+      setSheets((current) => current.filter((s) => s.id !== temp.id));
+      setSelectedId(source.id);
+      toast.error("Could not duplicate cheat sheet", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
+    }
+  }
+
+  async function handleDelete() {
+    if (!selectedSheet || isTempSheet(selectedSheet.id)) return;
+    const target = selectedSheet;
+    const nextSheet = sheets.find((s) => s.id !== target.id) ?? null;
+
+    setSheets((current) => current.filter((s) => s.id !== target.id));
+    setSelectedId(nextSheet?.id ?? null);
+
+    try {
+      const response = await fetch(`/api/cheat-sheets/${target.id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(payload?.error || "Could not delete the cheat sheet.");
+      }
+    } catch (err) {
+      setSheets((current) => sortCheatSheets([target, ...current]));
+      setSelectedId(target.id);
+      toast.error("Could not delete cheat sheet", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
+    }
+  }
+
+  async function handleTitleCommit() {
+    if (!selectedSheet || isTempSheet(selectedSheet.id)) return;
+    const nextTitle = draftTitle.trim() || "Untitled";
+    if (nextTitle === getRenderableTitle(selectedSheet.title)) return;
+    try {
+      await saveSheet(selectedSheet.id, { title: nextTitle });
+    } catch (err) {
+      toast.error("Could not save title", {
+        description: err instanceof Error ? err.message : undefined,
+        duration: 5000,
+      });
+    }
+  }
+
+  return (
+    <div className="grid h-full min-h-0 lg:grid-cols-[260px_minmax(0,1fr)]">
+      <CheatSheetList
+        cheatSheets={sheets}
+        classes={classes}
+        selectedId={selectedSheet?.id ?? null}
+        collapsedGroups={collapsedGroups}
+        isPending={isPending}
+        disabled={!storageReady}
+        onToggleGroup={toggleGroup}
+        onSelect={selectSheet}
+        onCreate={(classId) =>
+          startTransition(() => void handleCreate(classId))
+        }
+      />
+
+      <section className="h-full min-h-0 bg-background">
+        {selectedSheet ? (
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="flex min-h-12 items-center justify-between gap-3 border-b border-border px-4">
+              <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+                <FileText className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <span className="truncate text-foreground">
+                  {getRenderableTitle(draftTitle)}
+                </span>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleDuplicate()}
+                  disabled={isPending || isTempSheet(selectedSheet.id)}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-surface-muted hover:text-foreground disabled:opacity-60"
+                  aria-label="Duplicate cheat sheet"
+                  title="Duplicate cheat sheet"
+                >
+                  <Copy className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleDelete()}
+                  disabled={isPending || isTempSheet(selectedSheet.id)}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-danger-soft hover:text-danger disabled:opacity-60"
+                  aria-label="Delete cheat sheet"
+                  title="Delete cheat sheet"
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
+              <NoteSurface
+                initialDocument={selectedSheet.content.document}
+                keepEditingWhenEmpty
+                selectionPrelude={
+                  <div className="mx-auto w-full px-4 pt-7 md:px-10 md:pt-10">
+                    <input
+                      data-note-selection-region
+                      value={draftTitle}
+                      onChange={(event) => {
+                        const nextTitle = event.currentTarget.value;
+                        setTitleDraftState({
+                          sheetId: selectedSheet.id,
+                          value: nextTitle,
+                        });
+                        setSheets((current) =>
+                          current.map((s) =>
+                            s.id === selectedSheet.id
+                              ? { ...s, title: nextTitle }
+                              : s,
+                          ),
+                        );
+                      }}
+                      onBlur={() => void handleTitleCommit()}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") event.currentTarget.blur();
+                      }}
+                      className="w-full border-none bg-transparent p-0 text-4xl font-semibold tracking-tight text-foreground outline-none placeholder:text-muted-foreground/50"
+                      placeholder="Untitled"
+                    />
+                    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <span>{formatTimestamp(selectedSheet.updatedAt)}</span>
+                    </div>
+                  </div>
+                }
+                onSave={async (nextContent) => {
+                  try {
+                    await saveSheet(selectedSheet.id, {
+                      title: draftTitle.trim() || "Untitled",
+                      content: nextContent,
+                    });
+                  } catch (err) {
+                    toast.error("Could not save cheat sheet", {
+                      description:
+                        err instanceof Error ? err.message : undefined,
+                      duration: 5000,
+                    });
+                  }
+                }}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 p-6 text-center">
+            {storageReady ? (
+              <>
+                <p className="max-w-xs text-sm text-muted-foreground">
+                  Write a cheat sheet from scratch — condensing the material
+                  yourself is the point.
+                </p>
+                <Button
+                  type="button"
+                  onClick={() =>
+                    startTransition(() => void handleCreate(null))
+                  }
+                  disabled={isPending}
+                >
+                  New cheat sheet
+                </Button>
+              </>
+            ) : (
+              <p className="max-w-xs text-sm text-muted-foreground">
+                Cheat sheet storage is not ready yet. Run the latest database
+                migration to start writing.
+              </p>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,3 @@
-@import "katex/dist/katex.min.css";
-
 @import "tailwindcss";
 
 @custom-variant dark (&:where(.dark, .dark *));

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import "mathlive/fonts.css";
 import "mathlive/static.css";
 import { ThemeInitializer } from "@/components/ui/theme-initializer";
+import 'katex/dist/katex.min.css';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/app/notes/notes-workspace.tsx
+++ b/app/notes/notes-workspace.tsx
@@ -18,6 +18,7 @@ import {
   FileText,
   Folder,
   FolderInput,
+  PanelLeftClose,
   Plus,
   Sparkles,
   Square,
@@ -27,6 +28,7 @@ import {
 } from "lucide-react";
 import { NoteSurface } from "@/components/note-editor/note-surface";
 import { Button } from "@/components/ui/button";
+import { CollapsedRail } from "@/components/ui/collapsed-rail";
 import { cx } from "@/lib/utils";
 import {
   noteRecordToWorkspaceNote,
@@ -213,6 +215,9 @@ export function NotesWorkspace({
 
   // Upload modal
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+
+  // Sidebar collapse (gives the editor full width)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   const hasHandledCreateOnMountRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -1001,10 +1006,28 @@ export function NotesWorkspace({
         />
       ) : null}
 
-      <div className="grid h-full min-h-0 lg:grid-cols-[292px_minmax(0,1fr)]">
+      <div
+        className={cx(
+          "grid h-full min-h-0",
+          sidebarCollapsed
+            ? "lg:grid-cols-[48px_minmax(0,1fr)]"
+            : "lg:grid-cols-[292px_minmax(0,1fr)]",
+        )}
+      >
         {/* ---------------------------------------------------------------- */}
         {/* Sidebar                                                           */}
         {/* ---------------------------------------------------------------- */}
+        {sidebarCollapsed ? (
+          <CollapsedRail
+            onExpand={() => setSidebarCollapsed(false)}
+            expandLabel="Expand notes list"
+            onNew={() =>
+              startTransition(() => void handleCreateNote(fallbackClassId))
+            }
+            newLabel="New page"
+            newDisabled={isPending}
+          />
+        ) : (
         <aside className="flex h-full min-h-0 flex-col border-b border-border bg-surface-muted/70 lg:border-b-0 lg:border-r">
           {/* Toolbar */}
           <div className="flex h-12 items-center gap-2 border-b border-border px-3">
@@ -1019,16 +1042,15 @@ export function NotesWorkspace({
               <Plus className="h-4 w-4 shrink-0" aria-hidden="true" />
               <span className="truncate">New page</span>
             </button>
-            {/* <button
+            <button
               type="button"
-              onClick={() => setIsUploadModalOpen(true)}
-              disabled={isPending}
-              title="Import or generate notes"
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-surface hover:text-foreground disabled:opacity-60"
-              aria-label="Import or generate notes"
+              onClick={() => setSidebarCollapsed(true)}
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-surface hover:text-foreground"
+              aria-label="Collapse notes list"
+              title="Collapse notes list"
             >
-              <Upload className="h-4 w-4" aria-hidden="true" />
-            </button> */}
+              <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
+            </button>
           </div>
 
           {/* Note list */}
@@ -1280,6 +1302,7 @@ export function NotesWorkspace({
             </div>
           ) : null}
         </aside>
+        )}
 
         {/* ---------------------------------------------------------------- */}
         {/* Editor area                                                        */}

--- a/app/notes/notes-workspace.tsx
+++ b/app/notes/notes-workspace.tsx
@@ -36,6 +36,12 @@ import {
 } from "@/lib/notes/records";
 import { emptyNoteDocument, type NoteContent } from "@/lib/notes/types";
 import { parseMarkdownToNoteDocument } from "@/lib/notes/markdown";
+import {
+  formatTimestamp,
+  getClassLabel,
+  getClassShortLabel,
+  getRenderableTitle,
+} from "@/lib/notes/labels";
 
 type WorkspaceClass = {
   id: string;
@@ -52,53 +58,6 @@ type NotesWorkspaceProps = {
   shouldCreateOnMount: boolean;
   resetHref: string;
 };
-
-const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-});
-
-function formatTimestamp(value: string) {
-  return TIMESTAMP_FORMATTER.format(new Date(value));
-}
-
-function getRenderableTitle(value: string) {
-  return value.trim() || "Untitled";
-}
-
-/** Full label used in tooltips and accessible names */
-function getClassLabel(item: WorkspaceClass) {
-  return item.courseCode ? `${item.courseCode} ${item.title}` : item.title;
-}
-
-/**
- * Short label for compact sidebar contexts.
- * Uses the course code when available (e.g. "CS/CE 4337.006").
- * Falls back to an acronym when there is no code.
- */
-function getClassShortLabel(item: WorkspaceClass) {
-  if (item.courseCode) return item.courseCode;
-  const skip = new Set([
-    "a",
-    "an",
-    "the",
-    "of",
-    "in",
-    "to",
-    "for",
-    "and",
-    "or",
-    "at",
-    "by",
-  ]);
-  const words = item.title.split(/\s+/).filter(Boolean);
-  const acronym = words
-    .filter((w) => !skip.has(w.toLowerCase()))
-    .map((w) => w[0]?.toUpperCase() ?? "")
-    .join("");
-  if (acronym.length <= 1 || item.title.length <= 18) return item.title;
-  return acronym;
-}
 
 const isTempNote = (id: string) => id.startsWith("temp-");
 

--- a/components/mind-map/edge-layer.tsx
+++ b/components/mind-map/edge-layer.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Trash2 } from "lucide-react";
+import { cx } from "@/lib/utils";
+import type { MindMapEdge, MindMapNode } from "@/lib/mind-maps/types";
+
+type Point = { x: number; y: number };
+
+type EdgeLayerProps = {
+  edges: MindMapEdge[];
+  nodeById: Map<string, MindMapNode>;
+  draft: { source: Point; cursor: Point } | null;
+};
+
+/** SVG overlay that draws every association line plus the in-progress connect line. */
+export function EdgeLayer({ edges, nodeById, draft }: EdgeLayerProps) {
+  return (
+    <svg className="pointer-events-none absolute left-0 top-0 overflow-visible" width={1} height={1}>
+      {edges.map((edge) => {
+        const source = nodeById.get(edge.sourceNodeId);
+        const target = nodeById.get(edge.targetNodeId);
+        if (!source || !target) return null;
+
+        return (
+          <line
+            key={edge.id}
+            x1={source.positionX}
+            y1={source.positionY}
+            x2={target.positionX}
+            y2={target.positionY}
+            stroke={edge.isSuggested ? "var(--accent)" : "var(--border-strong)"}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeDasharray={edge.isSuggested ? "6 5" : undefined}
+            opacity={edge.isSuggested ? 0.75 : 1}
+          />
+        );
+      })}
+
+      {draft ? (
+        <line
+          x1={draft.source.x}
+          y1={draft.source.y}
+          x2={draft.cursor.x}
+          y2={draft.cursor.y}
+          stroke="var(--accent)"
+          strokeWidth={2}
+          strokeDasharray="6 6"
+          strokeLinecap="round"
+        />
+      ) : null}
+    </svg>
+  );
+}
+
+type EdgeLabelChipProps = {
+  edge: MindMapEdge;
+  midpoint: Point;
+  isEditing: boolean;
+  onStartEdit: () => void;
+  onCommit: (label: string) => void;
+  onCancelEdit: () => void;
+  onDelete: () => void;
+};
+
+/** HTML chip at the midpoint of an edge for viewing/editing the association's meaning. */
+export function EdgeLabelChip({
+  edge,
+  midpoint,
+  isEditing,
+  onStartEdit,
+  onCommit,
+  onCancelEdit,
+  onDelete,
+}: EdgeLabelChipProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cancelRef = useRef(false);
+
+  useEffect(() => {
+    if (isEditing) {
+      cancelRef.current = false;
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  return (
+    <div
+      className="group absolute z-10 flex -translate-x-1/2 -translate-y-1/2 items-center"
+      style={{ left: midpoint.x, top: midpoint.y }}
+      onPointerDown={(event) => event.stopPropagation()}
+    >
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          defaultValue={edge.label ?? ""}
+          maxLength={200}
+          placeholder="meaning…"
+          className="w-[140px] rounded-full border border-accent bg-surface px-3 py-1 text-xs text-foreground outline-none shadow-[var(--shadow-card)]"
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              inputRef.current?.blur();
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              cancelRef.current = true;
+              inputRef.current?.blur();
+            }
+          }}
+          onBlur={(event) => {
+            if (cancelRef.current) {
+              onCancelEdit();
+              return;
+            }
+            onCommit(event.target.value.trim());
+          }}
+        />
+      ) : (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onStartEdit}
+            title={edge.isSuggested ? "AI-suggested connection" : undefined}
+            className={cx(
+              "rounded-full border px-2.5 py-1 text-xs font-medium shadow-[var(--shadow-card)] transition",
+              edge.isSuggested
+                ? "border-accent/40 bg-accent-soft text-accent hover:border-accent"
+                : edge.label
+                  ? "border-border bg-surface text-foreground hover:border-accent/70"
+                  : "border-dashed border-border bg-surface/80 text-muted-foreground hover:border-accent/70 hover:text-foreground",
+            )}
+          >
+            {edge.label ? edge.label : "+ label"}
+          </button>
+          <button
+            type="button"
+            aria-label="Delete connection"
+            onClick={onDelete}
+            className="hidden rounded-full border border-border bg-surface p-1 text-muted-foreground shadow-[var(--shadow-card)] transition hover:bg-danger-soft hover:text-danger group-hover:inline-flex"
+          >
+            <Trash2 className="size-3" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/mind-map/mind-map-canvas.tsx
+++ b/components/mind-map/mind-map-canvas.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Plus } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import type { MindMapEdge, MindMapNode } from "@/lib/mind-maps/types";
+import { EdgeLabelChip, EdgeLayer } from "@/components/mind-map/edge-layer";
+import { NodeCard } from "@/components/mind-map/node-card";
+
+type MindMapCanvasProps = {
+  mapId: string;
+  initialNodes: MindMapNode[];
+  initialEdges: MindMapEdge[];
+};
+
+type Point = { x: number; y: number };
+
+type Gesture =
+  | { kind: "pan"; startClientX: number; startClientY: number; originPan: Point }
+  | {
+      kind: "drag";
+      nodeId: string;
+      startClientX: number;
+      startClientY: number;
+      nodeStartX: number;
+      nodeStartY: number;
+      moved: boolean;
+    }
+  | { kind: "connect"; sourceId: string; rectLeft: number; rectTop: number; pan: Point };
+
+async function mutate<T>(input: string, init: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+  const payload = (await response.json().catch(() => null)) as (T & { error?: string }) | null;
+  if (!response.ok) {
+    throw new Error(payload?.error || "Request failed");
+  }
+  return payload as T;
+}
+
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : undefined;
+}
+
+export function MindMapCanvas({ mapId, initialNodes, initialEdges }: MindMapCanvasProps) {
+  const [nodes, setNodes] = useState<MindMapNode[]>(initialNodes);
+  const [edges, setEdges] = useState<MindMapEdge[]>(initialEdges);
+  const [pan, setPan] = useState<Point>({ x: 0, y: 0 });
+  const [editingNodeId, setEditingNodeId] = useState<string | null>(null);
+  const [editingEdgeId, setEditingEdgeId] = useState<string | null>(null);
+  const [connectDraft, setConnectDraft] = useState<{ sourceId: string; cursor: Point } | null>(null);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const gestureRef = useRef<Gesture | null>(null);
+
+  const nodeById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+
+  const commitNodePosition = useCallback(
+    async (nodeId: string, position: Point, fallback: Point) => {
+      try {
+        await mutate(`/api/mind-maps/${mapId}/nodes/${nodeId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ positionX: position.x, positionY: position.y }),
+        });
+      } catch (error) {
+        setNodes((curr) =>
+          curr.map((node) =>
+            node.id === nodeId ? { ...node, positionX: fallback.x, positionY: fallback.y } : node,
+          ),
+        );
+        toast.error("Failed to move topic", { description: describeError(error) });
+      }
+    },
+    [mapId],
+  );
+
+  const createEdge = useCallback(
+    async (sourceId: string, targetId: string) => {
+      try {
+        const { edge } = await mutate<{ edge: MindMapEdge }>(`/api/mind-maps/${mapId}/edges`, {
+          method: "POST",
+          body: JSON.stringify({ sourceNodeId: sourceId, targetNodeId: targetId }),
+        });
+        setEdges((curr) =>
+          curr.some((existing) => existing.id === edge.id) ? curr : [...curr, edge],
+        );
+      } catch (error) {
+        toast.error("Failed to connect topics", { description: describeError(error) });
+      }
+    },
+    [mapId],
+  );
+
+  // Keep the latest async actions reachable from the (mount-stable) window listeners.
+  const actionsRef = useRef({ commitNodePosition, createEdge });
+  useEffect(() => {
+    actionsRef.current = { commitNodePosition, createEdge };
+  });
+
+  useEffect(() => {
+    function onPointerMove(event: PointerEvent) {
+      const gesture = gestureRef.current;
+      if (!gesture) return;
+
+      if (gesture.kind === "pan") {
+        setPan({
+          x: gesture.originPan.x + (event.clientX - gesture.startClientX),
+          y: gesture.originPan.y + (event.clientY - gesture.startClientY),
+        });
+      } else if (gesture.kind === "drag") {
+        const dx = event.clientX - gesture.startClientX;
+        const dy = event.clientY - gesture.startClientY;
+        if (Math.abs(dx) > 2 || Math.abs(dy) > 2) gesture.moved = true;
+        setNodes((curr) =>
+          curr.map((node) =>
+            node.id === gesture.nodeId
+              ? { ...node, positionX: gesture.nodeStartX + dx, positionY: gesture.nodeStartY + dy }
+              : node,
+          ),
+        );
+      } else if (gesture.kind === "connect") {
+        setConnectDraft({
+          sourceId: gesture.sourceId,
+          cursor: {
+            x: event.clientX - gesture.rectLeft - gesture.pan.x,
+            y: event.clientY - gesture.rectTop - gesture.pan.y,
+          },
+        });
+      }
+    }
+
+    function onPointerUp(event: PointerEvent) {
+      const gesture = gestureRef.current;
+      gestureRef.current = null;
+      if (!gesture) return;
+
+      if (gesture.kind === "drag" && gesture.moved) {
+        const finalPos = {
+          x: gesture.nodeStartX + (event.clientX - gesture.startClientX),
+          y: gesture.nodeStartY + (event.clientY - gesture.startClientY),
+        };
+        void actionsRef.current.commitNodePosition(gesture.nodeId, finalPos, {
+          x: gesture.nodeStartX,
+          y: gesture.nodeStartY,
+        });
+      } else if (gesture.kind === "connect") {
+        setConnectDraft(null);
+        const target = document
+          .elementFromPoint(event.clientX, event.clientY)
+          ?.closest("[data-node-id]");
+        const targetId = target?.getAttribute("data-node-id");
+        if (targetId && targetId !== gesture.sourceId) {
+          void actionsRef.current.createEdge(gesture.sourceId, targetId);
+        }
+      }
+    }
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+    };
+  }, []);
+
+  const handleBackgroundPointerDown = useCallback(
+    (event: ReactPointerEvent) => {
+      if (event.button !== 0) return;
+      setEditingNodeId(null);
+      setEditingEdgeId(null);
+      gestureRef.current = {
+        kind: "pan",
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        originPan: pan,
+      };
+    },
+    [pan],
+  );
+
+  const handleNodePointerDown = useCallback(
+    (node: MindMapNode) => (event: ReactPointerEvent) => {
+      if (event.button !== 0) return;
+      event.stopPropagation();
+      gestureRef.current = {
+        kind: "drag",
+        nodeId: node.id,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        nodeStartX: node.positionX,
+        nodeStartY: node.positionY,
+        moved: false,
+      };
+    },
+    [],
+  );
+
+  const handleStartConnect = useCallback(
+    (node: MindMapNode) => (event: ReactPointerEvent) => {
+      if (event.button !== 0) return;
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setConnectDraft({ sourceId: node.id, cursor: { x: node.positionX, y: node.positionY } });
+      gestureRef.current = {
+        kind: "connect",
+        sourceId: node.id,
+        rectLeft: rect.left,
+        rectTop: rect.top,
+        pan,
+      };
+    },
+    [pan],
+  );
+
+  const addTopic = useCallback(async () => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    const center = rect ? { x: rect.width / 2 - pan.x, y: rect.height / 2 - pan.y } : { x: 0, y: 0 };
+    const jitter = () => (Math.random() - 0.5) * 60;
+    try {
+      const { node } = await mutate<{ node: MindMapNode }>(`/api/mind-maps/${mapId}/nodes`, {
+        method: "POST",
+        body: JSON.stringify({
+          label: "New topic",
+          positionX: center.x + jitter(),
+          positionY: center.y + jitter(),
+        }),
+      });
+      setNodes((curr) => [...curr, node]);
+      setEditingNodeId(node.id);
+    } catch (error) {
+      toast.error("Failed to add topic", { description: describeError(error) });
+    }
+  }, [mapId, pan]);
+
+  const commitNodeLabel = useCallback(
+    async (nodeId: string, label: string) => {
+      let previous: string | undefined;
+      setEditingNodeId(null);
+      setNodes((curr) =>
+        curr.map((node) => {
+          if (node.id !== nodeId) return node;
+          previous = node.label;
+          return { ...node, label };
+        }),
+      );
+      try {
+        await mutate(`/api/mind-maps/${mapId}/nodes/${nodeId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ label }),
+        });
+      } catch (error) {
+        if (previous !== undefined) {
+          const restored = previous;
+          setNodes((curr) =>
+            curr.map((node) => (node.id === nodeId ? { ...node, label: restored } : node)),
+          );
+        }
+        toast.error("Failed to rename topic", { description: describeError(error) });
+      }
+    },
+    [mapId],
+  );
+
+  const deleteNode = useCallback(
+    async (nodeId: string) => {
+      let removedNode: MindMapNode | undefined;
+      let removedEdges: MindMapEdge[] = [];
+      setNodes((curr) => {
+        removedNode = curr.find((node) => node.id === nodeId);
+        return curr.filter((node) => node.id !== nodeId);
+      });
+      setEdges((curr) => {
+        removedEdges = curr.filter(
+          (edge) => edge.sourceNodeId === nodeId || edge.targetNodeId === nodeId,
+        );
+        return curr.filter((edge) => edge.sourceNodeId !== nodeId && edge.targetNodeId !== nodeId);
+      });
+      try {
+        await mutate(`/api/mind-maps/${mapId}/nodes/${nodeId}`, { method: "DELETE" });
+      } catch (error) {
+        if (removedNode) setNodes((curr) => [...curr, removedNode as MindMapNode]);
+        if (removedEdges.length > 0) setEdges((curr) => [...curr, ...removedEdges]);
+        toast.error("Failed to delete topic", { description: describeError(error) });
+      }
+    },
+    [mapId],
+  );
+
+  const commitEdgeLabel = useCallback(
+    async (edgeId: string, label: string) => {
+      const nextLabel = label.length > 0 ? label : null;
+      let previous: string | null = null;
+      setEditingEdgeId(null);
+      setEdges((curr) =>
+        curr.map((edge) => {
+          if (edge.id !== edgeId) return edge;
+          previous = edge.label;
+          return { ...edge, label: nextLabel };
+        }),
+      );
+      try {
+        await mutate(`/api/mind-maps/${mapId}/edges/${edgeId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ label: nextLabel }),
+        });
+      } catch (error) {
+        const restored = previous;
+        setEdges((curr) =>
+          curr.map((edge) => (edge.id === edgeId ? { ...edge, label: restored } : edge)),
+        );
+        toast.error("Failed to label connection", { description: describeError(error) });
+      }
+    },
+    [mapId],
+  );
+
+  const deleteEdge = useCallback(
+    async (edgeId: string) => {
+      let removed: MindMapEdge | undefined;
+      setEdges((curr) => {
+        removed = curr.find((edge) => edge.id === edgeId);
+        return curr.filter((edge) => edge.id !== edgeId);
+      });
+      try {
+        await mutate(`/api/mind-maps/${mapId}/edges/${edgeId}`, { method: "DELETE" });
+      } catch (error) {
+        if (removed) setEdges((curr) => [...curr, removed as MindMapEdge]);
+        toast.error("Failed to delete connection", { description: describeError(error) });
+      }
+    },
+    [mapId],
+  );
+
+  const draftPoints = useMemo(() => {
+    if (!connectDraft) return null;
+    const source = nodeById.get(connectDraft.sourceId);
+    if (!source) return null;
+    return {
+      source: { x: source.positionX, y: source.positionY },
+      cursor: connectDraft.cursor,
+    };
+  }, [connectDraft, nodeById]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative h-full w-full overflow-hidden rounded-[var(--radius-xl)] border border-border bg-surface-muted/40"
+      style={{ touchAction: "none", cursor: "grab" }}
+      onPointerDown={handleBackgroundPointerDown}
+    >
+      <div
+        className="absolute left-3 top-3 z-20 flex flex-wrap items-center gap-3"
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <Button type="button" size="sm" leadingIcon={<Plus className="size-4" />} onClick={addTopic}>
+          Add topic
+        </Button>
+        <span className="hidden text-xs text-muted-foreground sm:inline">
+          Double-click to rename · drag the blue dot onto another topic to connect · drag the canvas to pan
+        </span>
+      </div>
+
+      <div className="absolute inset-0" style={{ transform: `translate(${pan.x}px, ${pan.y}px)` }}>
+        <EdgeLayer edges={edges} nodeById={nodeById} draft={draftPoints} />
+
+        {edges.map((edge) => {
+          const source = nodeById.get(edge.sourceNodeId);
+          const target = nodeById.get(edge.targetNodeId);
+          if (!source || !target) return null;
+          const midpoint = {
+            x: (source.positionX + target.positionX) / 2,
+            y: (source.positionY + target.positionY) / 2,
+          };
+          return (
+            <EdgeLabelChip
+              key={edge.id}
+              edge={edge}
+              midpoint={midpoint}
+              isEditing={editingEdgeId === edge.id}
+              onStartEdit={() => setEditingEdgeId(edge.id)}
+              onCommit={(label) => commitEdgeLabel(edge.id, label)}
+              onCancelEdit={() => setEditingEdgeId(null)}
+              onDelete={() => deleteEdge(edge.id)}
+            />
+          );
+        })}
+
+        {nodes.map((node) => (
+          <NodeCard
+            key={node.id}
+            node={node}
+            isEditing={editingNodeId === node.id}
+            isConnectSource={connectDraft?.sourceId === node.id}
+            onPointerDownCard={handleNodePointerDown(node)}
+            onStartConnect={handleStartConnect(node)}
+            onStartEdit={() => setEditingNodeId(node.id)}
+            onCommitLabel={(label) => commitNodeLabel(node.id, label)}
+            onCancelEdit={() => setEditingNodeId(null)}
+            onDelete={() => deleteNode(node.id)}
+          />
+        ))}
+      </div>
+
+      {nodes.length === 0 ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <p className="max-w-xs text-center text-sm text-muted-foreground">
+            This canvas is empty. Add a topic to start mapping how your ideas connect.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/mind-map/node-card.tsx
+++ b/components/mind-map/node-card.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useEffect, useRef } from "react";
+import { Link2, Trash2 } from "lucide-react";
+import { cx } from "@/lib/utils";
+import type { MindMapNode } from "@/lib/mind-maps/types";
+
+type NodeCardProps = {
+  node: MindMapNode;
+  isEditing: boolean;
+  isConnectSource: boolean;
+  onPointerDownCard: (event: ReactPointerEvent) => void;
+  onStartConnect: (event: ReactPointerEvent) => void;
+  onStartEdit: () => void;
+  onCommitLabel: (label: string) => void;
+  onCancelEdit: () => void;
+  onDelete: () => void;
+};
+
+export function NodeCard({
+  node,
+  isEditing,
+  isConnectSource,
+  onPointerDownCard,
+  onStartConnect,
+  onStartEdit,
+  onCommitLabel,
+  onCancelEdit,
+  onDelete,
+}: NodeCardProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cancelRef = useRef(false);
+
+  useEffect(() => {
+    if (isEditing) {
+      cancelRef.current = false;
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  return (
+    <div
+      data-node-id={node.id}
+      className={cx(
+        "group absolute flex w-max max-w-[220px] cursor-grab items-center rounded-[var(--radius-xl)] border bg-surface px-4 py-2.5 text-sm font-medium text-foreground shadow-[var(--shadow-card)] transition select-none active:cursor-grabbing",
+        isConnectSource ? "border-accent ring-2 ring-accent/40" : "border-border-strong hover:border-accent/70",
+      )}
+      style={{ left: node.positionX, top: node.positionY, transform: "translate(-50%, -50%)" }}
+      onPointerDown={onPointerDownCard}
+      onDoubleClick={(event) => {
+        event.stopPropagation();
+        onStartEdit();
+      }}
+    >
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          defaultValue={node.label}
+          maxLength={200}
+          className="w-[160px] bg-transparent text-sm font-medium text-foreground outline-none"
+          onPointerDown={(event) => event.stopPropagation()}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              inputRef.current?.blur();
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              cancelRef.current = true;
+              inputRef.current?.blur();
+            }
+          }}
+          onBlur={(event) => {
+            if (cancelRef.current) {
+              onCancelEdit();
+              return;
+            }
+            const next = event.target.value.trim();
+            if (next && next !== node.label) {
+              onCommitLabel(next);
+            } else {
+              onCancelEdit();
+            }
+          }}
+        />
+      ) : (
+        <span className="truncate">{node.label}</span>
+      )}
+
+      {!isEditing ? (
+        <button
+          type="button"
+          aria-label="Delete topic"
+          className="ml-2 hidden shrink-0 rounded-md p-1 text-muted-foreground transition hover:bg-danger-soft hover:text-danger group-hover:inline-flex"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete();
+          }}
+        >
+          <Trash2 className="size-3.5" />
+        </button>
+      ) : null}
+
+      {/* Connect handle — drag from here to another topic to draw an association. */}
+      <button
+        type="button"
+        aria-label="Connect to another topic"
+        title="Drag to another topic to connect"
+        className="absolute -bottom-2.5 left-1/2 flex size-5 -translate-x-1/2 cursor-crosshair items-center justify-center rounded-full border border-accent bg-surface text-accent shadow-[var(--shadow-card)] transition hover:bg-accent hover:text-accent-foreground"
+        onPointerDown={(event) => {
+          event.stopPropagation();
+          onStartConnect(event);
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <Link2 className="size-3" />
+      </button>
+    </div>
+  );
+}

--- a/components/ui/collapsed-rail.tsx
+++ b/components/ui/collapsed-rail.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { PanelLeftOpen, Plus } from "lucide-react";
+
+type CollapsedRailProps = {
+  onExpand: () => void;
+  expandLabel: string;
+  onNew?: () => void;
+  newLabel?: string;
+  newDisabled?: boolean;
+};
+
+/**
+ * Slim vertical strip shown in place of a list sidebar when it is collapsed.
+ * Always renders an expand control (so the user is never stuck) plus an
+ * optional "new" shortcut. Shared by the Notes and Cheat Sheet workspaces.
+ */
+export function CollapsedRail({
+  onExpand,
+  expandLabel,
+  onNew,
+  newLabel,
+  newDisabled,
+}: CollapsedRailProps) {
+  return (
+    <aside className="flex h-full min-h-0 flex-row items-center gap-1 border-b border-border bg-surface-muted/70 px-1.5 py-2 lg:flex-col lg:border-b-0 lg:border-r lg:py-3">
+      <button
+        type="button"
+        onClick={onExpand}
+        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-surface hover:text-foreground"
+        aria-label={expandLabel}
+        title={expandLabel}
+      >
+        <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+      </button>
+      {onNew ? (
+        <button
+          type="button"
+          onClick={onNew}
+          disabled={newDisabled}
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-surface hover:text-foreground disabled:opacity-50"
+          aria-label={newLabel}
+          title={newLabel}
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+        </button>
+      ) : null}
+    </aside>
+  );
+}

--- a/drizzle/0012_warm_gravity.sql
+++ b/drizzle/0012_warm_gravity.sql
@@ -1,0 +1,40 @@
+CREATE TABLE "mind_map" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"title" text NOT NULL,
+	"source_text" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "mind_map_edge" (
+	"id" text PRIMARY KEY NOT NULL,
+	"map_id" text NOT NULL,
+	"source_node_id" text NOT NULL,
+	"target_node_id" text NOT NULL,
+	"label" text,
+	"is_suggested" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "mind_map_node" (
+	"id" text PRIMARY KEY NOT NULL,
+	"map_id" text NOT NULL,
+	"label" text NOT NULL,
+	"position_x" double precision DEFAULT 0 NOT NULL,
+	"position_y" double precision DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "mind_map" ADD CONSTRAINT "mind_map_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mind_map_edge" ADD CONSTRAINT "mind_map_edge_map_id_mind_map_id_fk" FOREIGN KEY ("map_id") REFERENCES "public"."mind_map"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mind_map_edge" ADD CONSTRAINT "mind_map_edge_source_node_id_mind_map_node_id_fk" FOREIGN KEY ("source_node_id") REFERENCES "public"."mind_map_node"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mind_map_edge" ADD CONSTRAINT "mind_map_edge_target_node_id_mind_map_node_id_fk" FOREIGN KEY ("target_node_id") REFERENCES "public"."mind_map_node"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mind_map_node" ADD CONSTRAINT "mind_map_node_map_id_mind_map_id_fk" FOREIGN KEY ("map_id") REFERENCES "public"."mind_map"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "mind_map_user_id_idx" ON "mind_map" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "mind_map_edge_map_id_idx" ON "mind_map_edge" USING btree ("map_id");--> statement-breakpoint
+CREATE INDEX "mind_map_edge_source_node_id_idx" ON "mind_map_edge" USING btree ("source_node_id");--> statement-breakpoint
+CREATE INDEX "mind_map_edge_target_node_id_idx" ON "mind_map_edge" USING btree ("target_node_id");--> statement-breakpoint
+CREATE INDEX "mind_map_node_map_id_idx" ON "mind_map_node" USING btree ("map_id");

--- a/drizzle/0013_dark_xorn.sql
+++ b/drizzle/0013_dark_xorn.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "cheat_sheet" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"title" text DEFAULT 'Untitled' NOT NULL,
+	"content" jsonb,
+	"markdown" text DEFAULT '' NOT NULL,
+	"class_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "cheat_sheet" ADD CONSTRAINT "cheat_sheet_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cheat_sheet" ADD CONSTRAINT "cheat_sheet_class_id_parse_test_course_id_fk" FOREIGN KEY ("class_id") REFERENCES "public"."parse_test_course"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "cheat_sheet_user_id_idx" ON "cheat_sheet" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "cheat_sheet_class_id_idx" ON "cheat_sheet" USING btree ("class_id");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2144 @@
+{
+  "id": "06d10f89-e668-4fca-a415-43fbd0c155aa",
+  "prevId": "f3aeb9b8-b888-4419-81c2-1847e1ab4a5f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flashcards": {
+      "name": "flashcards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_note_ids": {
+          "name": "source_note_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "cards": {
+          "name": "cards",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_count": {
+          "name": "card_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flashcards_user_id_idx": {
+          "name": "flashcards_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flashcards_created_at_idx": {
+          "name": "flashcards_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flashcards_user_id_user_id_fk": {
+          "name": "flashcards_user_id_user_id_fk",
+          "tableFrom": "flashcards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mind_map": {
+      "name": "mind_map",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mind_map_user_id_idx": {
+          "name": "mind_map_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mind_map_user_id_user_id_fk": {
+          "name": "mind_map_user_id_user_id_fk",
+          "tableFrom": "mind_map",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mind_map_edge": {
+      "name": "mind_map_edge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suggested": {
+          "name": "is_suggested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mind_map_edge_map_id_idx": {
+          "name": "mind_map_edge_map_id_idx",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mind_map_edge_source_node_id_idx": {
+          "name": "mind_map_edge_source_node_id_idx",
+          "columns": [
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mind_map_edge_target_node_id_idx": {
+          "name": "mind_map_edge_target_node_id_idx",
+          "columns": [
+            {
+              "expression": "target_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mind_map_edge_map_id_mind_map_id_fk": {
+          "name": "mind_map_edge_map_id_mind_map_id_fk",
+          "tableFrom": "mind_map_edge",
+          "tableTo": "mind_map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mind_map_edge_source_node_id_mind_map_node_id_fk": {
+          "name": "mind_map_edge_source_node_id_mind_map_node_id_fk",
+          "tableFrom": "mind_map_edge",
+          "tableTo": "mind_map_node",
+          "columnsFrom": [
+            "source_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mind_map_edge_target_node_id_mind_map_node_id_fk": {
+          "name": "mind_map_edge_target_node_id_mind_map_node_id_fk",
+          "tableFrom": "mind_map_edge",
+          "tableTo": "mind_map_node",
+          "columnsFrom": [
+            "target_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mind_map_node": {
+      "name": "mind_map_node",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mind_map_node_map_id_idx": {
+          "name": "mind_map_node_map_id_idx",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mind_map_node_map_id_mind_map_id_fk": {
+          "name": "mind_map_node_map_id_mind_map_id_fk",
+          "tableFrom": "mind_map_node",
+          "tableTo": "mind_map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note": {
+      "name": "note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "note_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_userId_idx": {
+          "name": "note_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_class_id_idx": {
+          "name": "note_class_id_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_createdAt_idx": {
+          "name": "note_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_user_id_user_id_fk": {
+          "name": "note_user_id_user_id_fk",
+          "tableFrom": "note",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_class_id_parse_test_course_id_fk": {
+          "name": "note_class_id_parse_test_course_id_fk",
+          "tableFrom": "note",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_assignments": {
+      "name": "parse_test_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_text": {
+          "name": "date_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_text": {
+          "name": "time_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_percent": {
+          "name": "weight_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_assignments_course_id_idx": {
+          "name": "parse_test_assignments_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_assignments_due_at_idx": {
+          "name": "parse_test_assignments_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_assignments_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_assignments_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_assignments",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_concepts": {
+      "name": "parse_test_concepts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_concepts_course_id_idx": {
+          "name": "parse_test_concepts_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_concepts_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_concepts_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_concepts",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_contacts": {
+      "name": "parse_test_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_hours": {
+          "name": "office_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_contacts_course_id_idx": {
+          "name": "parse_test_contacts_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_contacts_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_contacts_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_contacts",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_course": {
+      "name": "parse_test_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_section": {
+          "name": "course_section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructor_name": {
+          "name": "instructor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_days": {
+          "name": "meeting_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_time": {
+          "name": "meeting_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_location": {
+          "name": "meeting_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_materials": {
+          "name": "required_materials",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "homework_tools": {
+          "name": "homework_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "catalog_description": {
+          "name": "catalog_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_summary": {
+          "name": "student_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_course_run_id_idx": {
+          "name": "parse_test_course_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_course_run_id_parse_test_runs_id_fk": {
+          "name": "parse_test_course_run_id_parse_test_runs_id_fk",
+          "tableFrom": "parse_test_course",
+          "tableTo": "parse_test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parse_test_course_run_id_unique": {
+          "name": "parse_test_course_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_events": {
+      "name": "parse_test_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_text": {
+          "name": "date_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_text": {
+          "name": "time_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_events_course_id_idx": {
+          "name": "parse_test_events_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_events_due_at_idx": {
+          "name": "parse_test_events_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_events_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_events_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_events",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_grading_items": {
+      "name": "parse_test_grading_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_percent": {
+          "name": "weight_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_grading_items_course_id_idx": {
+          "name": "parse_test_grading_items_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_grading_items_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_grading_items_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_grading_items",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_runs": {
+      "name": "parse_test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parse_status": {
+          "name": "parse_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "parse_model": {
+          "name": "parse_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gemini_file_uri": {
+          "name": "gemini_file_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_runs_user_id_idx": {
+          "name": "parse_test_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_runs_content_hash_idx": {
+          "name": "parse_test_runs_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_runs_status_idx": {
+          "name": "parse_test_runs_status_idx",
+          "columns": [
+            {
+              "expression": "parse_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_runs_user_id_user_id_fk": {
+          "name": "parse_test_runs_user_id_user_id_fk",
+          "tableFrom": "parse_test_runs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_attempts": {
+      "name": "quiz_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_count": {
+          "name": "answered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_spent_seconds": {
+          "name": "time_spent_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quiz_attempts_quiz_id_idx": {
+          "name": "quiz_attempts_quiz_id_idx",
+          "columns": [
+            {
+              "expression": "quiz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quiz_attempts_user_id_idx": {
+          "name": "quiz_attempts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quiz_attempts_created_at_idx": {
+          "name": "quiz_attempts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_attempts_quiz_id_quizzes_id_fk": {
+          "name": "quiz_attempts_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_user_id_user_id_fk": {
+          "name": "quiz_attempts_user_id_user_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quizzes": {
+      "name": "quizzes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_note_ids": {
+          "name": "source_note_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "source_note_titles": {
+          "name": "source_note_titles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_types": {
+          "name": "question_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quizzes_user_id_idx": {
+          "name": "quizzes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quizzes_created_at_idx": {
+          "name": "quizzes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quizzes_user_id_user_id_fk": {
+          "name": "quizzes_user_id_user_id_fk",
+          "tableFrom": "quizzes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.note_source": {
+      "name": "note_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "upload"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,2267 @@
+{
+  "id": "79c7d10c-aad6-40ee-883f-bcbd0fa8b37a",
+  "prevId": "06d10f89-e668-4fca-a415-43fbd0c155aa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cheat_sheet": {
+      "name": "cheat_sheet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cheat_sheet_user_id_idx": {
+          "name": "cheat_sheet_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cheat_sheet_class_id_idx": {
+          "name": "cheat_sheet_class_id_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cheat_sheet_user_id_user_id_fk": {
+          "name": "cheat_sheet_user_id_user_id_fk",
+          "tableFrom": "cheat_sheet",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cheat_sheet_class_id_parse_test_course_id_fk": {
+          "name": "cheat_sheet_class_id_parse_test_course_id_fk",
+          "tableFrom": "cheat_sheet",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flashcards": {
+      "name": "flashcards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_note_ids": {
+          "name": "source_note_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "cards": {
+          "name": "cards",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_count": {
+          "name": "card_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flashcards_user_id_idx": {
+          "name": "flashcards_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flashcards_created_at_idx": {
+          "name": "flashcards_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flashcards_user_id_user_id_fk": {
+          "name": "flashcards_user_id_user_id_fk",
+          "tableFrom": "flashcards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mind_map": {
+      "name": "mind_map",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mind_map_user_id_idx": {
+          "name": "mind_map_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mind_map_user_id_user_id_fk": {
+          "name": "mind_map_user_id_user_id_fk",
+          "tableFrom": "mind_map",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mind_map_edge": {
+      "name": "mind_map_edge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suggested": {
+          "name": "is_suggested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mind_map_edge_map_id_idx": {
+          "name": "mind_map_edge_map_id_idx",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mind_map_edge_source_node_id_idx": {
+          "name": "mind_map_edge_source_node_id_idx",
+          "columns": [
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mind_map_edge_target_node_id_idx": {
+          "name": "mind_map_edge_target_node_id_idx",
+          "columns": [
+            {
+              "expression": "target_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mind_map_edge_map_id_mind_map_id_fk": {
+          "name": "mind_map_edge_map_id_mind_map_id_fk",
+          "tableFrom": "mind_map_edge",
+          "tableTo": "mind_map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mind_map_edge_source_node_id_mind_map_node_id_fk": {
+          "name": "mind_map_edge_source_node_id_mind_map_node_id_fk",
+          "tableFrom": "mind_map_edge",
+          "tableTo": "mind_map_node",
+          "columnsFrom": [
+            "source_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mind_map_edge_target_node_id_mind_map_node_id_fk": {
+          "name": "mind_map_edge_target_node_id_mind_map_node_id_fk",
+          "tableFrom": "mind_map_edge",
+          "tableTo": "mind_map_node",
+          "columnsFrom": [
+            "target_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mind_map_node": {
+      "name": "mind_map_node",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mind_map_node_map_id_idx": {
+          "name": "mind_map_node_map_id_idx",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mind_map_node_map_id_mind_map_id_fk": {
+          "name": "mind_map_node_map_id_mind_map_id_fk",
+          "tableFrom": "mind_map_node",
+          "tableTo": "mind_map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note": {
+      "name": "note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "note_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_userId_idx": {
+          "name": "note_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_class_id_idx": {
+          "name": "note_class_id_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_createdAt_idx": {
+          "name": "note_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_user_id_user_id_fk": {
+          "name": "note_user_id_user_id_fk",
+          "tableFrom": "note",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_class_id_parse_test_course_id_fk": {
+          "name": "note_class_id_parse_test_course_id_fk",
+          "tableFrom": "note",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_assignments": {
+      "name": "parse_test_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_text": {
+          "name": "date_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_text": {
+          "name": "time_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_percent": {
+          "name": "weight_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_assignments_course_id_idx": {
+          "name": "parse_test_assignments_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_assignments_due_at_idx": {
+          "name": "parse_test_assignments_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_assignments_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_assignments_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_assignments",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_concepts": {
+      "name": "parse_test_concepts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_concepts_course_id_idx": {
+          "name": "parse_test_concepts_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_concepts_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_concepts_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_concepts",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_contacts": {
+      "name": "parse_test_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_hours": {
+          "name": "office_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_contacts_course_id_idx": {
+          "name": "parse_test_contacts_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_contacts_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_contacts_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_contacts",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_course": {
+      "name": "parse_test_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_section": {
+          "name": "course_section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructor_name": {
+          "name": "instructor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_days": {
+          "name": "meeting_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_time": {
+          "name": "meeting_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_location": {
+          "name": "meeting_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_materials": {
+          "name": "required_materials",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "homework_tools": {
+          "name": "homework_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "catalog_description": {
+          "name": "catalog_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_summary": {
+          "name": "student_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_course_run_id_idx": {
+          "name": "parse_test_course_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_course_run_id_parse_test_runs_id_fk": {
+          "name": "parse_test_course_run_id_parse_test_runs_id_fk",
+          "tableFrom": "parse_test_course",
+          "tableTo": "parse_test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parse_test_course_run_id_unique": {
+          "name": "parse_test_course_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_events": {
+      "name": "parse_test_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_text": {
+          "name": "date_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_text": {
+          "name": "time_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_events_course_id_idx": {
+          "name": "parse_test_events_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_events_due_at_idx": {
+          "name": "parse_test_events_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_events_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_events_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_events",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_grading_items": {
+      "name": "parse_test_grading_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_percent": {
+          "name": "weight_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snippet": {
+          "name": "source_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_grading_items_course_id_idx": {
+          "name": "parse_test_grading_items_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_grading_items_course_id_parse_test_course_id_fk": {
+          "name": "parse_test_grading_items_course_id_parse_test_course_id_fk",
+          "tableFrom": "parse_test_grading_items",
+          "tableTo": "parse_test_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parse_test_runs": {
+      "name": "parse_test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parse_status": {
+          "name": "parse_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "parse_model": {
+          "name": "parse_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gemini_file_uri": {
+          "name": "gemini_file_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_test_runs_user_id_idx": {
+          "name": "parse_test_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_runs_content_hash_idx": {
+          "name": "parse_test_runs_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_test_runs_status_idx": {
+          "name": "parse_test_runs_status_idx",
+          "columns": [
+            {
+              "expression": "parse_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_test_runs_user_id_user_id_fk": {
+          "name": "parse_test_runs_user_id_user_id_fk",
+          "tableFrom": "parse_test_runs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_attempts": {
+      "name": "quiz_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_count": {
+          "name": "answered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_spent_seconds": {
+          "name": "time_spent_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quiz_attempts_quiz_id_idx": {
+          "name": "quiz_attempts_quiz_id_idx",
+          "columns": [
+            {
+              "expression": "quiz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quiz_attempts_user_id_idx": {
+          "name": "quiz_attempts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quiz_attempts_created_at_idx": {
+          "name": "quiz_attempts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_attempts_quiz_id_quizzes_id_fk": {
+          "name": "quiz_attempts_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_user_id_user_id_fk": {
+          "name": "quiz_attempts_user_id_user_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quizzes": {
+      "name": "quizzes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_note_ids": {
+          "name": "source_note_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "source_note_titles": {
+          "name": "source_note_titles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_types": {
+          "name": "question_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quizzes_user_id_idx": {
+          "name": "quizzes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quizzes_created_at_idx": {
+          "name": "quizzes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quizzes_user_id_user_id_fk": {
+          "name": "quizzes_user_id_user_id_fk",
+          "tableFrom": "quizzes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.note_source": {
+      "name": "note_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "upload"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1781389091821,
       "tag": "0012_warm_gravity",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1781456334031,
+      "tag": "0013_dark_xorn",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1779911691545,
       "tag": "0011_cynical_starbolt",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1781389091821,
+      "tag": "0012_warm_gravity",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/cheat-sheets/records.ts
+++ b/lib/cheat-sheets/records.ts
@@ -1,0 +1,54 @@
+import { createNoteContent } from "@/lib/notes/markdown";
+import { normalizeNoteDocument } from "@/lib/notes/records";
+import type { NoteContent } from "@/lib/notes/types";
+
+/** Raw DB row shape returned from the cheat_sheet table / API. */
+export type CheatSheetRecord = {
+  id: string;
+  title: string;
+  classId: string | null;
+  content: unknown;
+  markdown?: string | null;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+};
+
+/** Client-side shape used by the cheat-sheet workspace. */
+export type CheatSheet = {
+  id: string;
+  title: string;
+  classId: string | null;
+  content: NoteContent;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function normalizeDate(value: string | Date) {
+  return (value instanceof Date ? value : new Date(value)).toISOString();
+}
+
+export function rowToCheatSheet(record: CheatSheetRecord): CheatSheet {
+  const document = normalizeNoteDocument(record.content);
+  const content = createNoteContent(document);
+  const markdown =
+    typeof record.markdown === "string" ? record.markdown : content.markdown;
+
+  return {
+    id: record.id,
+    title: record.title,
+    classId: record.classId,
+    createdAt: normalizeDate(record.createdAt),
+    updatedAt: normalizeDate(record.updatedAt),
+    content: {
+      markdown,
+      document,
+    },
+  };
+}
+
+export function sortCheatSheets(sheets: CheatSheet[]) {
+  return [...sheets].sort(
+    (left, right) =>
+      new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
+  );
+}

--- a/lib/cheat-sheets/storage.ts
+++ b/lib/cheat-sheets/storage.ts
@@ -1,0 +1,38 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+type StorageProbeRow = {
+  sheet_exists: boolean;
+};
+
+function getRows(result: unknown): StorageProbeRow[] {
+  if (Array.isArray(result)) {
+    return result as StorageProbeRow[];
+  }
+
+  if (
+    result &&
+    typeof result === "object" &&
+    Array.isArray((result as { rows?: unknown }).rows)
+  ) {
+    return (result as { rows: StorageProbeRow[] }).rows;
+  }
+
+  return [];
+}
+
+export async function hasCheatSheetStorage() {
+  try {
+    const result = await db.execute(sql`
+      select to_regclass('public.cheat_sheet') is not null as "sheet_exists"
+    `);
+    const row = getRows(result)[0];
+
+    return Boolean(row?.sheet_exists);
+  } catch {
+    return false;
+  }
+}
+
+export const cheatSheetStorageUnavailableMessage =
+  "Cheat sheet storage is not ready yet. Run the latest database migration before saving cheat sheets.";

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -120,6 +120,36 @@ export const note = pgTable(
   ],
 );
 
+// Hand-written cheat sheets. Deliberately slimmer than `note`: no embedding,
+// source type, or file columns — cheat sheets are always authored manually and
+// never participate in AI/embedding features.
+export const cheatSheet = pgTable(
+  "cheat_sheet",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    title: text("title").notNull().default("Untitled"),
+    content: jsonb("content"),
+    markdown: text("markdown").notNull().default(""),
+    classId: text("class_id").references(() => parseTestCourse.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("cheat_sheet_user_id_idx").on(table.userId),
+    index("cheat_sheet_class_id_idx").on(table.classId),
+  ],
+);
+
 export const flashcards = pgTable(
   "flashcards",
   {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -4,15 +4,11 @@ import {
   doublePrecision,
   index,
   integer,
-  jsonb,
-  pgEnum,
   pgTable,
   text,
   timestamp,
   vector,
 } from "drizzle-orm/pg-core";
-
-export const noteSourceEnum = pgEnum("note_source", ["manual", "upload"]);
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),
@@ -409,6 +405,71 @@ export const parseTestConcept = pgTable(
   (table) => [index("parse_test_concepts_course_id_idx").on(table.courseId)],
 );
 
+export const mindMap = pgTable(
+  "mind_map",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    sourceText: text("source_text"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("mind_map_user_id_idx").on(table.userId)],
+);
+
+export const mindMapNode = pgTable(
+  "mind_map_node",
+  {
+    id: text("id").primaryKey(),
+    mapId: text("map_id")
+      .notNull()
+      .references(() => mindMap.id, { onDelete: "cascade" }),
+    label: text("label").notNull(),
+    positionX: doublePrecision("position_x").notNull().default(0),
+    positionY: doublePrecision("position_y").notNull().default(0),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("mind_map_node_map_id_idx").on(table.mapId)],
+);
+
+export const mindMapEdge = pgTable(
+  "mind_map_edge",
+  {
+    id: text("id").primaryKey(),
+    mapId: text("map_id")
+      .notNull()
+      .references(() => mindMap.id, { onDelete: "cascade" }),
+    sourceNodeId: text("source_node_id")
+      .notNull()
+      .references(() => mindMapNode.id, { onDelete: "cascade" }),
+    targetNodeId: text("target_node_id")
+      .notNull()
+      .references(() => mindMapNode.id, { onDelete: "cascade" }),
+    label: text("label"),
+    isSuggested: boolean("is_suggested").notNull().default(false),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("mind_map_edge_map_id_idx").on(table.mapId),
+    index("mind_map_edge_source_node_id_idx").on(table.sourceNodeId),
+    index("mind_map_edge_target_node_id_idx").on(table.targetNodeId),
+  ],
+);
+
 export const userRelations = relations(user, ({ many }) => ({
   sessions: many(session),
   accounts: many(account),
@@ -417,6 +478,7 @@ export const userRelations = relations(user, ({ many }) => ({
   quizzes: many(quizzes),
   quizAttempts: many(quizAttempts),
   parseTestRuns: many(parseTestRun),
+  mindMaps: many(mindMap),
 }));
 
 export const sessionRelations = relations(session, ({ one }) => ({
@@ -529,5 +591,38 @@ export const parseTestConceptRelations = relations(parseTestConcept, ({ one }) =
   course: one(parseTestCourse, {
     fields: [parseTestConcept.courseId],
     references: [parseTestCourse.id],
+  }),
+}));
+
+export const mindMapRelations = relations(mindMap, ({ one, many }) => ({
+  user: one(user, {
+    fields: [mindMap.userId],
+    references: [user.id],
+  }),
+  nodes: many(mindMapNode),
+  edges: many(mindMapEdge),
+}));
+
+export const mindMapNodeRelations = relations(mindMapNode, ({ one }) => ({
+  map: one(mindMap, {
+    fields: [mindMapNode.mapId],
+    references: [mindMap.id],
+  }),
+}));
+
+export const mindMapEdgeRelations = relations(mindMapEdge, ({ one }) => ({
+  map: one(mindMap, {
+    fields: [mindMapEdge.mapId],
+    references: [mindMap.id],
+  }),
+  sourceNode: one(mindMapNode, {
+    fields: [mindMapEdge.sourceNodeId],
+    references: [mindMapNode.id],
+    relationName: "sourceNode",
+  }),
+  targetNode: one(mindMapNode, {
+    fields: [mindMapEdge.targetNodeId],
+    references: [mindMapNode.id],
+    relationName: "targetNode",
   }),
 }));

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -4,11 +4,15 @@ import {
   doublePrecision,
   index,
   integer,
+  jsonb,
+  pgEnum,
   pgTable,
   text,
   timestamp,
   vector,
 } from "drizzle-orm/pg-core";
+
+export const noteSourceEnum = pgEnum("note_source", ["manual", "upload"]);
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),

--- a/lib/mind-maps/api.ts
+++ b/lib/mind-maps/api.ts
@@ -1,0 +1,41 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { mindMap } from "@/lib/db/schema";
+import { hasMindMapStorage, mindMapStorageUnavailableMessage } from "@/lib/mind-maps/storage";
+
+type GuardResult = { ok: false; response: NextResponse } | { ok: true; userId: string };
+
+/**
+ * Shared gate for every mind-map API handler: requires a session and that the
+ * mind_map tables have been migrated. Mirrors the auth + storage guard used by
+ * the quizzes routes.
+ */
+export async function guardMindMapRequest(): Promise<GuardResult> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return { ok: false, response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+
+  if (!(await hasMindMapStorage())) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: mindMapStorageUnavailableMessage }, { status: 503 }),
+    };
+  }
+
+  return { ok: true, userId: session.user.id };
+}
+
+/** Returns the map only if it exists and belongs to the user, else null. */
+export async function loadOwnedMap(mapId: string, userId: string) {
+  const [row] = await db
+    .select()
+    .from(mindMap)
+    .where(and(eq(mindMap.id, mapId), eq(mindMap.userId, userId)))
+    .limit(1);
+
+  return row ?? null;
+}

--- a/lib/mind-maps/context.ts
+++ b/lib/mind-maps/context.ts
@@ -1,0 +1,47 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { note } from "@/lib/db/schema";
+
+const MAX_MARKDOWN_CHARS_PER_NOTE = 18_000;
+const MAX_NOTES = 12;
+
+export type MindMapContextNote = {
+  id: string;
+  title: string;
+  markdown: string;
+  embedding: number[];
+};
+
+function normalizeEmbedding(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is number => typeof item === "number");
+}
+
+/**
+ * Loads the selected notes (scoped to the user) with their markdown + embedding so
+ * the association generator can read them. Mirrors getQuizContextNotes.
+ */
+export async function getMindMapContextNotes(params: {
+  userId: string;
+  noteIds: string[];
+}): Promise<MindMapContextNote[]> {
+  const uniqueNoteIds = Array.from(new Set(params.noteIds)).slice(0, MAX_NOTES);
+  if (uniqueNoteIds.length === 0) return [];
+
+  const rows = await db
+    .select({
+      id: note.id,
+      title: note.title,
+      markdown: note.markdown,
+      embedding: note.embedding,
+    })
+    .from(note)
+    .where(and(eq(note.userId, params.userId), inArray(note.id, uniqueNoteIds)));
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    markdown: row.markdown.trim().slice(0, MAX_MARKDOWN_CHARS_PER_NOTE),
+    embedding: normalizeEmbedding(row.embedding),
+  }));
+}

--- a/lib/mind-maps/gemini.ts
+++ b/lib/mind-maps/gemini.ts
@@ -1,0 +1,151 @@
+import { GoogleGenAI } from "@google/genai";
+import { z } from "zod";
+import type { MindMapContextNote } from "@/lib/mind-maps/context";
+
+export type GeneratedAssociationMap = {
+  topics: string[];
+  connections: Array<{ source: string; target: string; label: string | null }>;
+};
+
+const generatedSchema = z.object({
+  topics: z.array(z.object({ label: z.string().min(1) })).min(1),
+  connections: z
+    .array(
+      z.object({
+        source: z.string().min(1),
+        target: z.string().min(1),
+        relationship: z.string().optional(),
+      }),
+    )
+    .optional(),
+});
+
+function getRequiredEnv(name: string, fallbackName?: string) {
+  const value = process.env[name] || (fallbackName ? process.env[fallbackName] : undefined);
+  if (!value) {
+    throw new Error(`${name} is missing. Add it to your server environment.`);
+  }
+  return value;
+}
+
+function getGoogleAiClient() {
+  return new GoogleGenAI({ apiKey: getRequiredEnv("GOOGLE_GENERATIVE_AI_API_KEY") });
+}
+
+function parseJsonPayload(value: string) {
+  const trimmed = value.trim();
+  const fencedMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return JSON.parse(fencedMatch?.[1] ?? trimmed) as unknown;
+}
+
+function buildContextPrompt(notes: MindMapContextNote[]) {
+  return notes
+    .map((note, index) =>
+      [`NOTE ${index + 1}: ${note.title}`, note.markdown || "(No readable note body was stored.)"].join(
+        "\n",
+      ),
+    )
+    .join("\n\n---\n\n");
+}
+
+/**
+ * Reads the supplied notes and proposes an associations-style map: a set of key
+ * topics and the labelled relationships between them. Topics/connections are de-
+ * duplicated and connections are pruned to valid, distinct topic pairs.
+ */
+export async function generateAssociationMap(params: {
+  notes: MindMapContextNote[];
+}): Promise<GeneratedAssociationMap> {
+  const ai = getGoogleAiClient();
+
+  const response = await ai.models.generateContent({
+    model: getRequiredEnv("GEMINI_MINDMAP_MODEL", "GEMINI_PARSE_MODEL"),
+    contents: [
+      {
+        role: "user",
+        parts: [
+          {
+            text: [
+              "Build an associations-style study mind map from the supplied notes.",
+              "Identify between 6 and 12 of the most important concepts or topics worth remembering.",
+              "Then describe how those topics relate to each other using short relationship labels such as 'causes', 'example of', 'contrasts with', 'depends on', 'part of', or 'leads to'.",
+              "Only connect topics that have a meaningful relationship; aim for a connected map, not a fully connected one.",
+              "Each connection's source and target MUST exactly match one of the topic labels you returned.",
+              'Return JSON only with this shape: {"topics":[{"label":"..."}],"connections":[{"source":"...","target":"...","relationship":"..."}]}',
+              "Selected notes:",
+              buildContextPrompt(params.notes),
+            ].join("\n\n"),
+          },
+        ],
+      },
+    ],
+    config: {
+      temperature: 0.5,
+      responseMimeType: "application/json",
+      responseJsonSchema: {
+        type: "object",
+        properties: {
+          topics: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { label: { type: "string" } },
+              required: ["label"],
+            },
+          },
+          connections: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                source: { type: "string" },
+                target: { type: "string" },
+                relationship: { type: "string" },
+              },
+              required: ["source", "target"],
+            },
+          },
+        },
+        required: ["topics"],
+      },
+    },
+  });
+
+  if (!response.text) {
+    throw new Error("Gemini returned an empty mind-map generation response.");
+  }
+
+  const parsed = generatedSchema.parse(parseJsonPayload(response.text));
+
+  // De-duplicate topics case-insensitively, preserving the first-seen label.
+  const topicByKey = new Map<string, string>();
+  for (const topic of parsed.topics) {
+    const label = topic.label.trim();
+    const key = label.toLowerCase();
+    if (label && !topicByKey.has(key)) topicByKey.set(key, label);
+  }
+  const topics = Array.from(topicByKey.values());
+
+  // Keep only connections whose endpoints are real, distinct topics; drop dupes.
+  const seenPairs = new Set<string>();
+  const connections: GeneratedAssociationMap["connections"] = [];
+  for (const connection of parsed.connections ?? []) {
+    const sourceKey = connection.source.trim().toLowerCase();
+    const targetKey = connection.target.trim().toLowerCase();
+    if (sourceKey === targetKey) continue;
+    if (!topicByKey.has(sourceKey) || !topicByKey.has(targetKey)) continue;
+
+    const pairKey = [sourceKey, targetKey].sort().join("::");
+    if (seenPairs.has(pairKey)) continue;
+    seenPairs.add(pairKey);
+
+    const relationship = connection.relationship?.trim();
+    connections.push({
+      source: topicByKey.get(sourceKey) as string,
+      target: topicByKey.get(targetKey) as string,
+      label: relationship ? relationship : null,
+    });
+  }
+
+  return { topics, connections };
+}

--- a/lib/mind-maps/records.ts
+++ b/lib/mind-maps/records.ts
@@ -1,0 +1,74 @@
+import type { MindMapDetail, MindMapEdge, MindMapNode, MindMapSummary } from "@/lib/mind-maps/types";
+
+export function rowToMindMapNode(row: {
+  id: string;
+  mapId: string;
+  label: string;
+  positionX: number;
+  positionY: number;
+  createdAt: Date;
+  updatedAt: Date;
+}): MindMapNode {
+  return {
+    id: row.id,
+    mapId: row.mapId,
+    label: row.label,
+    positionX: row.positionX,
+    positionY: row.positionY,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export function rowToMindMapEdge(row: {
+  id: string;
+  mapId: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  label: string | null;
+  isSuggested: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}): MindMapEdge {
+  return {
+    id: row.id,
+    mapId: row.mapId,
+    sourceNodeId: row.sourceNodeId,
+    targetNodeId: row.targetNodeId,
+    label: row.label,
+    isSuggested: row.isSuggested,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export function rowToMindMapSummary(
+  row: { id: string; title: string; createdAt: Date; updatedAt: Date },
+  nodeCount: number,
+  edgeCount: number,
+): MindMapSummary {
+  return {
+    id: row.id,
+    title: row.title,
+    nodeCount,
+    edgeCount,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export function rowToMindMapDetail(
+  row: { id: string; title: string; sourceText: string | null; createdAt: Date; updatedAt: Date },
+  nodes: MindMapNode[],
+  edges: MindMapEdge[],
+): MindMapDetail {
+  return {
+    id: row.id,
+    title: row.title,
+    sourceText: row.sourceText,
+    nodes,
+    edges,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}

--- a/lib/mind-maps/storage.ts
+++ b/lib/mind-maps/storage.ts
@@ -1,0 +1,39 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+type StorageProbeRow = {
+  map_exists: boolean;
+  node_exists: boolean;
+  edge_exists: boolean;
+};
+
+function getRows(result: unknown): StorageProbeRow[] {
+  if (Array.isArray(result)) {
+    return result as StorageProbeRow[];
+  }
+
+  if (result && typeof result === "object" && Array.isArray((result as { rows?: unknown }).rows)) {
+    return (result as { rows: StorageProbeRow[] }).rows;
+  }
+
+  return [];
+}
+
+export async function hasMindMapStorage() {
+  try {
+    const result = await db.execute(sql`
+      select
+        to_regclass('public.mind_map') is not null as "map_exists",
+        to_regclass('public.mind_map_node') is not null as "node_exists",
+        to_regclass('public.mind_map_edge') is not null as "edge_exists"
+    `);
+    const row = getRows(result)[0];
+
+    return Boolean(row?.map_exists && row.node_exists && row.edge_exists);
+  } catch {
+    return false;
+  }
+}
+
+export const mindMapStorageUnavailableMessage =
+  "Association map storage is not ready yet. Run the latest database migration before saving maps.";

--- a/lib/mind-maps/types.ts
+++ b/lib/mind-maps/types.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+export type MindMapSummary = {
+  id: string;
+  title: string;
+  nodeCount: number;
+  edgeCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MindMapNode = {
+  id: string;
+  mapId: string;
+  label: string;
+  positionX: number;
+  positionY: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MindMapEdge = {
+  id: string;
+  mapId: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  label: string | null;
+  isSuggested: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MindMapDetail = {
+  id: string;
+  title: string;
+  sourceText: string | null;
+  nodes: MindMapNode[];
+  edges: MindMapEdge[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const createMapSchema = z.object({
+  title: z.string().trim().min(1).max(120),
+});
+
+export const updateMapSchema = z.object({
+  title: z.string().trim().min(1).max(120),
+});
+
+export const createNodeSchema = z.object({
+  label: z.string().trim().min(1).max(200),
+  positionX: z.number().finite(),
+  positionY: z.number().finite(),
+});
+
+export const updateNodeSchema = z
+  .object({
+    label: z.string().trim().min(1).max(200).optional(),
+    positionX: z.number().finite().optional(),
+    positionY: z.number().finite().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "No fields to update",
+  });
+
+export const createEdgeSchema = z
+  .object({
+    sourceNodeId: z.string().min(1),
+    targetNodeId: z.string().min(1),
+    label: z.string().trim().max(200).nullish(),
+  })
+  .refine((data) => data.sourceNodeId !== data.targetNodeId, {
+    message: "A topic cannot connect to itself",
+  });
+
+export const updateEdgeSchema = z.object({
+  label: z.string().trim().max(200).nullable(),
+});
+
+export const generateMapSchema = z.object({
+  noteIds: z.array(z.string().min(1)).min(1).max(12),
+});

--- a/lib/notes/labels.ts
+++ b/lib/notes/labels.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared title / class label formatting used by the Notes workspace and the
+ * Cheat Sheet workspace. Extracted so both panels render identical labels.
+ */
+
+export type ClassLabelInput = {
+  title: string;
+  courseCode: string | null;
+};
+
+const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+});
+
+export function formatTimestamp(value: string) {
+  return TIMESTAMP_FORMATTER.format(new Date(value));
+}
+
+export function getRenderableTitle(value: string) {
+  return value.trim() || "Untitled";
+}
+
+/** Full label used in tooltips and accessible names. */
+export function getClassLabel(item: ClassLabelInput) {
+  return item.courseCode ? `${item.courseCode} ${item.title}` : item.title;
+}
+
+/**
+ * Short label for compact sidebar contexts.
+ * Uses the course code when available (e.g. "CS/CE 4337.006").
+ * Falls back to an acronym when there is no code.
+ */
+export function getClassShortLabel(item: ClassLabelInput) {
+  if (item.courseCode) return item.courseCode;
+  const skip = new Set([
+    "a",
+    "an",
+    "the",
+    "of",
+    "in",
+    "to",
+    "for",
+    "and",
+    "or",
+    "at",
+    "by",
+  ]);
+  const words = item.title.split(/\s+/).filter(Boolean);
+  const acronym = words
+    .filter((w) => !skip.has(w.toLowerCase()))
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+  if (acronym.length <= 1 || item.title.length <= 18) return item.title;
+  return acronym;
+}


### PR DESCRIPTION
Closes #27

SUMMARY
Implements the Cheat Sheet writing study method at /study/cheat-sheet. It's a split view: your existing Notes workspace on the left (reused as-is, fully editable) sits beside a new hand-written cheat-sheet library on the right — "two notes pages together."
Cheat-sheet writing is the study technique where you condense the material yourself, so there is deliberately no AI anywhere in this feature (no generation, no file-upload parsing). The right-hand editor has the same abilities as the notes editor (headings, lists, code, math, images) because it reuses the same NoteSurface editor.

WHAT'S INCLUDED
• New cheat_sheet table — a slim clone of note (no embedding / sourceType / file columns), so cheat sheets never appear in the Notes list or any AI/embedding filter. Migration drizzle/0013_dark_xorn.sql.
• API /api/cheat-sheets (GET/POST) and /api/cheat-sheets/[id] (PATCH/DELETE), mirroring the Notes routes — auth + ownership + class-ownership checks, { error } responses, 503 storage guard.
• Library UX — create / rename / duplicate / delete multiple named cheat sheets, optionally filed under a class, with optimistic updates and toasts.
• Collapsible list rails — each side's list can collapse to a slim strip so the editor gets nearly the full panel width; the two rails collapse independently.
• Marked the study card Live.

ARCHITECTURE AND REUSE
Follows the existing Associations / mind-map precedent for a persisted study feature (own table + hasCheatSheetStorage() probe + records module + page hydrates a client). Reuses NoteSurface, the lib/notes document/markdown helpers, and normalizeNoteWriteContent. Shared label/timestamp helpers were extracted to lib/notes/labels.ts (behavior-preserving) so both workspaces share one copy.

REVIEWER SETUP — RUN THE MIGRATION
This adds a table. After checkout, run:
    pnpm db:migrate
Without it, the page degrades gracefully to a "storage not ready" message (the hasCheatSheetStorage() probe) rather than crashing.

NOTE ON THE SHARED NOTES COMPONENT
The left panel reuses the real NotesWorkspace, so the new collapse toggle also appears on the standalone /notes page. It's purely additive (off by default) — an enhancement there, not a regression. Can be gated behind a prop if we'd prefer it scoped to the split view only.

TESTING
• pnpm build (full typecheck) and pnpm lint are clean.
• Migration generated and applied locally.
• Manually tested in the browser.

BASE BRANCH
Targets mind-map (this branch was cut from it and reuses its study/notes patterns). Retarget to develop once mind-map merges.

OUT OF SCOPE (v1)
• Drag-and-drop reorder / multi-select on the cheat-sheet list (Notes keeps them).
• Resizable divider between panels (fixed 50/50 for now).